### PR TITLE
Enable live-reload as part of startDebugging

### DIFF
--- a/packages/office-addin-debugging/src/commands.ts
+++ b/packages/office-addin-debugging/src/commands.ts
@@ -13,7 +13,7 @@ export async function start(manifestPath: string, command: commander.Command) {
         startDebugging(manifestPath, debuggingMethod, sourceBundleUrlComponents,
             command.devServer, command.devServerUrl,
             command.packager, command.packagerHost, command.PackagerPort,
-            command.sideload, command.debug);
+            command.sideload, command.debug, command.liveReload);
     } catch (err) {
         console.log(`Unable to start debugging.\n${err}`);
     }

--- a/packages/office-addin-debugging/src/debugging.ts
+++ b/packages/office-addin-debugging/src/debugging.ts
@@ -24,6 +24,7 @@ if (process.argv[1].endsWith("\\debugging.js")) {
         .option("--source-bundle-url-port <port>")
         .option("--source-bundle-url-path <path>")
         .option("--source-bundle-url-extension <extension>")
+        .option("--live-reload")
         .action(commands.start);
 
     commander

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -124,7 +124,7 @@ export async function startDebugging(manifestPath: string,
     sourceBundleUrlComponents?: devSettings.SourceBundleUrlComponents,
     devServerCommandLine?: string, devServerUrl?: string,
     packagerCommandLine?: string, packagerHost?: string, packagerPort?: string,
-    sideloadCommandLine?: string, enableDebugging: boolean = true) {
+    sideloadCommandLine?: string, enableDebugging: boolean = true, enableLiveReload: boolean = true) {
 
     let packagerPromise: Promise<void> | undefined;
     let devServerPromise: Promise<void> | undefined;
@@ -151,6 +151,12 @@ export async function startDebugging(manifestPath: string,
     await devSettings.enableDebugging(manifestInfo.id, enableDebugging, debuggingMethod);
     if (enableDebugging) {
         console.log(`Enabled debugging for add-in ${manifestInfo.id}. Debug method: ${debuggingMethod.toString()}`);
+    }
+
+    // enable live reload
+    await devSettings.enableLiveReload(manifestInfo.id, enableLiveReload);
+    if (enableLiveReload) {
+        console.log(`Enabled live-reload for add-in ${manifestInfo.id}.`);
     }
 
     // set source bundle url


### PR DESCRIPTION
- I tested to ensure that live-reload gets set in the registry as part of hitting F5 in the Excel Custom Functions project and that live reload works out-of-the-box with my local live-reload changes