### PR TITLE
office-addin-manifest command fixes

### DIFF
--- a/packages/office-addin-manifest/package.json
+++ b/packages/office-addin-manifest/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^10.5.7",
     "@types/node-fetch": "^2.1.2",
     "@types/uuid": "^3.4.4",
+    "@types/validator": "^9.4.2",
     "@types/xml2js": "^0.4.3",
     "concurrently": "^3.6.1",
     "copy-dir": "^0.4.0",

--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -4,6 +4,13 @@
 import * as commnder from "commander";
 import * as manifestInfo from "./manifestInfo";
 
+function getCommandOptionString(option: string | boolean, defaultValue?: string): string | undefined {
+  // For a command option defined with an optional value, e.g. "--option [value]",
+  // when the option is provided with a value, it will be of type "string", return the specified value;
+  // when the option is provided without a value, it will be of type "boolean", return undefined.
+  return (typeof(option) === "boolean") ? defaultValue : option;
+}
+
 export async function info(manifestPath: string) {
   try {
     const manifest = await manifestInfo.readManifestFile(manifestPath);
@@ -30,12 +37,9 @@ function logManifestInfo(manifestPath: string, manifest: manifestInfo.ManifestIn
 
 export async function modify(manifestPath: string, command: commnder.Command) {
   try {
-    const guid: string | undefined = (command.guid) ? command.guid : undefined;
-    const displayName: string | undefined = (command.displayName) ? command.displayName : undefined;
-
-    if (guid === undefined && displayName === undefined) {
-      throw new Error("You need to specify something to change in the manifest.");
-    }
+    // if the --guid command option is provided without a value, use "" to specify to change to a random guid value.
+    const guid: string | undefined = getCommandOptionString(command.guid, "");
+    const displayName: string | undefined = getCommandOptionString(command.displayName);
 
     const manifest = await manifestInfo.modifyManifestFile(manifestPath, guid, displayName);
     logManifestInfo(manifestPath, manifest);

--- a/packages/office-addin-manifest/src/manifest.ts
+++ b/packages/office-addin-manifest/src/manifest.ts
@@ -13,8 +13,8 @@ if (process.argv[1].endsWith("\\manifest.js")) {
 
   commander
     .command("modify <manifest-path>")
-    .option("-g,--guid [guid]", "Change the guid. Specify \"random\" for a random guid.")
-    .option("-d, --displayName [name]", "Display name for the add-in.")
+    .option("-g,--guid [guid]", "Change the guid. A random guid is used if one is not provided.")
+    .option("-d, --displayName <name>", "Change the display name.")
     .action(commands.modify);
 
   commander.parse(process.argv);

--- a/packages/office-addin-manifest/src/manifestInfo.ts
+++ b/packages/office-addin-manifest/src/manifestInfo.ts
@@ -35,7 +35,7 @@ function parseManifest(xml: Xml): ManifestInfo {
 export async function modifyManifestFile(manifestPath: string, guid?: string, displayName?: string): Promise<ManifestInfo> {
   let manifestData: ManifestInfo = {};
   if (manifestPath) {
-    if (!guid && !displayName) {
+    if (guid === undefined && displayName === undefined) {
       throw new Error("You need to specify something to change in the manifest.");
     } else {
       manifestData = await modifyManifestXml(manifestPath, guid, displayName);
@@ -85,15 +85,15 @@ async function readXmlFromManifestFile(manifestPath: string): Promise<Xml> {
   return xml;
 }
 
-function setModifiedXmlData(xml: any, guid: string | undefined, displayName: string | undefined) {
-  if (guid) {
-    if (guid === "random") {
+function setModifiedXmlData(xml: any, guid: string | undefined, displayName: string | undefined): void {
+  if (typeof(guid) !== "undefined") {
+    if (!guid || guid === "random") {
       guid = uuid();
     }
     xmlMethods.setXmlElementValue(xml, "Id", guid);
   }
 
-  if (displayName) {
+  if (typeof(displayName) !== "undefined") {
     xmlMethods.setXmlElementAttributeValue(xml, "DisplayName", displayName);
   }
 }

--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -1,9 +1,9 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import * as mocha from "mocha";
+import * as uuid from "uuid";
+import { isUUID } from "validator";
 import * as manifestInfo from "../src/manifestInfo";
-const uuid = require('uuid');
-const validator = require("validator");
 const manifestOriginalFolder = process.cwd() + "/test/manifests";
 const manifestTestFolder = process.cwd() + "\\testExecution\\testManifests";
 const testManifest = manifestTestFolder + "\\manifest.xml";
@@ -70,9 +70,9 @@ describe("Manifest", function() {
       const updatedInfo = await manifestInfo.modifyManifestFile(testManifest, "random", undefined);
 
       // verify guid updated, that it"s a valid guid and that the displayName is not updated
-      assert.notStrictEqual(originalInfo.id, updatedInfo.id);
-      assert.equal(true, validator.isUUID(updatedInfo.id));
-      assert.strictEqual(originalInfo.displayName, updatedInfo.displayName);
+      assert.notStrictEqual(updatedInfo.id, originalInfo.id);
+      assert.strictEqual(updatedInfo.id && isUUID(updatedInfo.id), true);
+      assert.strictEqual(updatedInfo.displayName, originalInfo.displayName);
     });
     it("should handle specifying displayName only", async function() {
       // get original manifest info and create copy of manifest that we can overwrite in this test
@@ -83,18 +83,18 @@ describe("Manifest", function() {
       const updatedInfo = await manifestInfo.modifyManifestFile(testManifest, undefined, testDisplayName);
 
       // verify displayName updated and guid not updated
-      assert.notStrictEqual(originalInfo.displayName, updatedInfo.displayName);
+      assert.notStrictEqual(updatedInfo.displayName, originalInfo.displayName);
       assert.strictEqual(updatedInfo.displayName, testDisplayName);
-      assert.strictEqual(originalInfo.id, updatedInfo.id);
+      assert.strictEqual( updatedInfo.id, originalInfo.id);
     });
     it("should handle not specifying either a guid or displayName", async function() {
       let result;
       try {
-        await manifestInfo.modifyManifestFile(testManifest, undefined, undefined);
+        await manifestInfo.modifyManifestFile(testManifest);
       } catch (err) {
-        result = err;
+        result = err.message;
       }
-      assert.equal(result, "Error: You need to specify something to change in the manifest.");
+      assert.strictEqual(result, `You need to specify something to change in the manifest.`);
     });
     it("should handle an invalid manifest file path", async function() {
       // call  modify, specifying an invalid manifest path with a valid guid and displayName
@@ -108,7 +108,7 @@ describe("Manifest", function() {
         result = err.message;
       }
 
-      assert.equal(result, `Unable to modify xml data for manifest file: ${invalidManifest}. \nError: ENOENT: no such file or directory, open '${invalidManifest}'`);
+      assert.strictEqual(result, `Unable to modify xml data for manifest file: ${invalidManifest}. \nError: ENOENT: no such file or directory, open '${invalidManifest}'`);
     });
   });
 });


### PR DESCRIPTION
I noticed some bugs when testing the "office-addin-manifest modify" command.

1. "Error: " duplicated when command has an error.
c:\dev>office-addin-manifest modify manifest.xml
**Error: Error:** You need to specify something to change in the manifest.

2. "modify -g" with no value would change guid to "true".
c:\dev>office-addin-manifest modify manifest.xml -g
Manifest: manifest.xml
  **Id: true**
  Name: My Office Add-in
  Provider: [Provider name]
  Type: TaskPaneApp
  Version: 1.0.0.0
  Default Locale: en-US
  Description: [Document Add-in description]

3. modify -d with empty string would give incorrect error message. It now allows an empty string to be set.
c:\dev>office-addin-manifest modify manifest.xml -d ""
Error: Error: You need to specify something to change in the manifest.

4. modify -g with empty string would give incorrect error message. It now sets the guid to a random value.
c:\dev>office-addin-manifest modify manifest.xml -g ""
Error: Error: You need to specify something to change in the manifest.

5. Changed <path> to <manifest-path> so it is more informative that the path specifies a manifest file.
c:\dev>office-addin-manifest modify -g ""
  error: missing required argument `path'

I also fixed the code to use import instead of require, and updated test asserts to specify actual value first, then expected value.

I made each fix as a separate commit, so it may be simpler to review each commit.



