### PR TITLE
office-addin-manifest: fix exports

### DIFF
--- a/packages/office-addin-manifest/src/manifest.ts
+++ b/packages/office-addin-manifest/src/manifest.ts
@@ -6,6 +6,8 @@
 import * as commander from "commander";
 import * as commands from "./commands";
 
+export * from "./manifestInfo";
+
 if (process.argv[1].endsWith("\\manifest.js")) {
   commander
     .command("info <manifest-path>")


### PR DESCRIPTION
The exports such as readManifestFile are not available for other packages.