### PR TITLE
add lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,6 @@
+{
+  "packages": [
+    "packages/*"
+  ],
+  "version": "independent"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "root",
+  "private": true,
+  "devDependencies": {
+    "lerna": "^3.6.0"
+  }
+}


### PR DESCRIPTION
Instead of installing lerna globally, after run "npm install" in root folder the first time, run "npx lerna" to execute lerna commands.

Lerna will help make it easier to use semantic versioning for the packages and publish them. I have configured it for "independent" mode where each package uses an independent version number.