### PR TITLE
empty error log on each generate call

### DIFF
--- a/packages/custom-functions-metadata/src/custom-functions-metadata.ts
+++ b/packages/custom-functions-metadata/src/custom-functions-metadata.ts
@@ -97,6 +97,7 @@ export function isErrorFound(): boolean {
 export async function generate(inputFile: string, outputFileName: string, noConsole?: boolean): Promise<void> {
     // @ts-ignore
     let rootObject: ICustomFunctionsMetadata = null;
+    errorLogFile = [];
     if (fs.existsSync(inputFile)) {
 
     const sourceCode = fs.readFileSync(inputFile, "utf-8");


### PR DESCRIPTION
This fixes the issue of the watcher not auto generating the metadata after hitting an error.