### PR TITLE
fix test cleanup if cannot restore runtime log settings

### DIFF
--- a/packages/office-addin-dev-settings/test/test.ts
+++ b/packages/office-addin-dev-settings/test/test.ts
@@ -194,7 +194,12 @@ describe("RuntimeLogging", async function() {
 
     this.afterAll(async function() {
       if (pathBeforeTests) {
-        await devSettings.enableRuntimeLogging(pathBeforeTests);
+        try {
+          await devSettings.enableRuntimeLogging(pathBeforeTests);
+        } catch (err) {
+          console.log("Unable to restore original runtime logging settings. Runtime logging will be disabled.");
+          await devSettings.disableRuntimeLogging();
+        }
       } else {
         await devSettings.disableRuntimeLogging();
       }


### PR DESCRIPTION
The build agent has runtime log settings to a directory which is not writable when running the tests. Therefore it cannot restore the original settings when test cleanup runs.

To resolve this, if an error occurs restoring the settings, then the runtime log settings will be disabled.