### PR TITLE
Change tests to use a less common port than 8080

### DIFF
--- a/packages/office-addin-test-helpers/test/test.ts
+++ b/packages/office-addin-test-helpers/test/test.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import * as mocha from "mocha";
 import * as testHelper from "../src/testHelpers";
 import { TestServer } from "../../office-addin-test-server";
-const port: number = 8080;
+const port: number = 4201;
 const testServer = new TestServer(port);
 const promiseStartTestServer = testServer.startTestServer(true /* mochaTest */);
 const testKey: string = "TestString";

--- a/packages/office-addin-test-server/test/test.ts
+++ b/packages/office-addin-test-server/test/test.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import * as mocha from "mocha";
 import * as testHelper from "../../office-addin-test-helpers"
 import { TestServer } from "../src/testServer";
-const port: number = 8080;
+const port: number = 4201;
 const testServer = new TestServer(port);
 const platformName = testServer.getPlatformName();
 const promiseStartTestServer = testServer.startTestServer(true /* mochaTest */);


### PR DESCRIPTION
- It's possible 8080 may already be in use by IIS, for example, and we don't want tests to fail because the port for the test server is already in use