### PR TITLE
office-addin-dev-settings: appcontainer --yes option to avoid prompts

### DIFF
--- a/packages/office-addin-dev-settings/.vscode/launch.json
+++ b/packages/office-addin-dev-settings/.vscode/launch.json
@@ -8,42 +8,42 @@
       "name": "Command Line: appcontainer",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["appcontainer", "${workspaceFolder}\\test\\manifest.xml"]
     },
     {
       "name": "Command Line: appcontainer --loopback",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
-      "args": ["appcontainer", "${workspaceFolder}\\test\\manifest.xml", "--loopback"]
+      "program": "${workspaceFolder}/lib/cli.js",
+      "args": ["appcontainer", "EdgeWebView", "--loopback", "-y"]
     },
     {
       "name": "Command Line: appcontainer --prevent-loopback",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["appcontainer", "${workspaceFolder}\\test\\manifest.xml", "--prevent-loopback"]
     },
     {
       "name": "Command Line: clear",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["clear", "${workspaceFolder}\\test\\manifest.xml"]
     },
     {
       "name": "Command Line: debugging",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["debugging", "${workspaceFolder}\\test\\manifest.xml"]
     },
     {
       "name": "Command Line: debugging --disable",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": [
         "debugging",
         "${workspaceFolder}\\test\\manifest.xml",
@@ -54,7 +54,7 @@
       "name": "Command Line: debugging --enable",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": [
         "debugging",
         "${workspaceFolder}\\test\\manifest.xml",
@@ -65,14 +65,14 @@
       "name": "Command Line: live-reload",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["live-reload", "${workspaceFolder}\\test\\manifest.xml"]
     },
     {
       "name": "Command Line: live-reload --disable",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": [
         "live-reload",
         "${workspaceFolder}\\test\\manifest.xml",
@@ -83,7 +83,7 @@
       "name": "Command Line: live-reload --enable",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": [
         "live-reload",
         "${workspaceFolder}\\test\\manifest.xml",
@@ -94,35 +94,35 @@
       "name": "Command Line: runtime-log",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["runtime-log"]
     },
     {
       "name": "Command Line: runtime-log --disable",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["runtime-log", "--disable"]
     },
     {
       "name": "Command Line: runtime-log --enable",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["runtime-log", "--enable"]
     },
     {
       "name": "Command Line: source-bundle-url",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": ["source-bundle-url", "${workspaceFolder}\\test\\manifest.xml"]
     },
     {
       "name": "Command Line: source-bundle-url (set)",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": [
         "source-bundle-url",
         "${workspaceFolder}\\test\\manifest.xml",
@@ -134,7 +134,7 @@
       "name": "Command Line: source-bundle-url (set to defaults)",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": [
         "source-bundle-url",
         "${workspaceFolder}\\test\\manifest.xml",
@@ -148,7 +148,7 @@
       "name": "Command Line: source-bundle-url (some params)",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/lib/dev-settings.js",
+      "program": "${workspaceFolder}/lib/cli.js",
       "args": [
         "source-bundle-url",
         "${workspaceFolder}\\test\\manifest.xml",

--- a/packages/office-addin-dev-settings/src/appcontainer.ts
+++ b/packages/office-addin-dev-settings/src/appcontainer.ts
@@ -102,12 +102,12 @@ export async function getAppcontainerNameFromManifestPath(manifestPath: string):
   }
 }
 
-export async function ensureLoopbackIsEnabled(manifestPath: string): Promise<boolean> {
+export async function ensureLoopbackIsEnabled(manifestPath: string, askForConfirmation: boolean = true): Promise<boolean> {
   const name = await getAppcontainerNameFromManifestPath(manifestPath);
   let isEnabled = await isLoopbackExemptionForAppcontainer(name);
 
   if (!isEnabled) {
-    if (await getUserConfirmation(manifestPath)) {
+    if (!askForConfirmation || await getUserConfirmation(manifestPath)) {
       await addLoopbackExemptionForAppcontainer(name);
       isEnabled = true;
     }

--- a/packages/office-addin-dev-settings/src/cli.ts
+++ b/packages/office-addin-dev-settings/src/cli.ts
@@ -11,6 +11,7 @@ commander
 .description("Display or configure the appcontainer used to run the Office Add-in.")
 .option("--loopback", `Allow access to loopback addresses such as "localhost".`)
 .option("--prevent-loopback", `Prevent access to loopback addresses such as "localhost".`)
+.option("-y,--yes", "Provide approval without any prompts.")
 .action(commands.appcontainer);
 
 commander

--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -19,8 +19,9 @@ export async function appcontainer(manifestPath: string, command: commander.Comm
     try {
       if (command.loopback) {
         try {
-          await ensureLoopbackIsEnabled(manifestPath);
-          console.log(`Loopback is allowed.`);
+          const askForConfirmation: boolean = (command.yes !== true);
+          const allowed = await ensureLoopbackIsEnabled(manifestPath, askForConfirmation);
+          console.log(allowed ? "Loopback is allowed." : "Loopback is not allowed.");
         } catch (err) {
           throw new Error(`Unable to allow loopback for the appcontainer. \n${err}`);
         }


### PR DESCRIPTION
Provide an option so the appcontainer command can be used to enable loopback without prompting.

`npx office-addin-dev-settings appcontainer --loopback --yes`

I also fixed a bug so that if the user says No to the prompt, the command will print "Loopback is not enabled" because it uses the boolean value returned.