### PR TITLE
npm run script to show dist-tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "build": "lerna run build",
+    "npm-dist-tags": "lerna exec npm dist-tag ls --stream",
     "postinstall": "lerna bootstrap",
     "test": "lerna run test"
   },


### PR DESCRIPTION
`npm run npm-dist-tags` shows dist-tags for the packages.

![image](https://user-images.githubusercontent.com/741153/58370266-69c3cd00-7eb9-11e9-8be0-dbc730d9156f.png)
