### PR TITLE
custom-functions-metadata-plugin: emit CustomFunctions.associate() more than once

### DIFF
--- a/packages/custom-functions-metadata-plugin/src/customfunctionsplugin.ts
+++ b/packages/custom-functions-metadata-plugin/src/customfunctionsplugin.ts
@@ -51,20 +51,16 @@ class CustomFunctionsMetadataPlugin {
             }
         });
 
-        let functionsUpdated: boolean = false;
         compiler.hooks.compilation.tap(pluginName, (compilation, params) => {
             compilation.moduleTemplates.javascript.hooks.render.tap(pluginName, (source, module) => {
-                if (!functionsUpdated && module._source && module._source._name.endsWith(inputFilePath)) {
+                if (module._source && module._source._name.endsWith(inputFilePath)) {
                     associate.forEach((item) => {
                         module._source._value += `\nCustomFunctions.associate("${item.id}", ${item.functionName});`;
-                      });
-                    functionsUpdated = true;
+                    });
                 }
             });
         });
-
     }
-
 }
 
 module.exports = CustomFunctionsMetadataPlugin;


### PR DESCRIPTION
Allows the calls be written when watching files and changes are saved. 

Fixes #113.