### PR TITLE
office-addin-node-debugger: fix bootstrapper code

### DIFF
--- a/packages/office-addin-node-debugger/src/debuggerWorker.ts
+++ b/packages/office-addin-node-debugger/src/debuggerWorker.ts
@@ -52,9 +52,9 @@ process.on('message', message => {
       }
 
       // load platform bundles
-      if (__platformBundles != undefined) {
-        const platformBundles = __platformBundles.concat();
-        __platformBundles = null;
+      if ((global as any).__platformBundles != undefined) {
+        const platformBundles = (global as any).__platformBundles.concat();
+        delete (global as any).__platformBundles;   
         for (const [index, pb] of platformBundles.entries()) {
           //console.log(`PB start ${index + 1}/${platformBundles.length}`);
           eval(pb);


### PR DESCRIPTION
Once the platform bundles are loaded, the __platformBundles global needs to be deleted rather than set to null to ensure that it is undefined.

This prevents bootstrapper code in the user bundle from also trying to load the platform bundles a second time.