### PR TITLE
load platform bundles after fetch

### DIFF
--- a/packages/office-addin-node-debugger/src/debuggerWorker.ts
+++ b/packages/office-addin-node-debugger/src/debuggerWorker.ts
@@ -51,21 +51,26 @@ process.on('message', message => {
         }
       }
 
-      // load platform bundles
-      if ((global as any).__platformBundles != undefined) {
-        const platformBundles = (global as any).__platformBundles.concat();
-        delete (global as any).__platformBundles;   
-        for (const [index, pb] of platformBundles.entries()) {
-          //console.log(`PB start ${index + 1}/${platformBundles.length}`);
-          eval(pb);
-          //console.log(`PB done  ${index + 1}/${platformBundles.length}`);
+      function loadPlatformBundles(): void {
+        // load platform bundles
+        if ((global as any).__platformBundles != undefined) {
+          const platformBundles = (global as any).__platformBundles.concat();
+          delete (global as any).__platformBundles;   
+          for (const [index, pb] of platformBundles.entries()) {
+            //console.log(`PB start ${index + 1}/${platformBundles.length}`);
+            eval(pb);
+            //console.log(`PB done  ${index + 1}/${platformBundles.length}`);
+          }
         }
       }
       
       fetch
         .default(message.url)
         .then(resp => resp.text())
-        .then(evalJS);
+        .then((js) => {
+          loadPlatformBundles();
+          evalJS(js);
+        })
     }
   };
 


### PR DESCRIPTION
We need to fetch the user bundle before loading the platform bundles.
It used to be OK to do this, but now there is some code in the platform bundles
which cause an issue for fetch if the platform bundles are loaded first.