### PR TITLE
Linux support

### DIFF
--- a/packages/office-addin-dev-certs/src/install.ts
+++ b/packages/office-addin-dev-certs/src/install.ts
@@ -17,7 +17,7 @@ function getInstallCommand(caCertificatePath: string, machine: boolean = false):
       case "darwin": // macOS
          return `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain '${caCertificatePath}'`;
       case "linux":
-         return `sudo mv ${caCertificatePath} /usr/local/share/ca-certificates && sudo /usr/sbin/update-ca-certificates`;
+         return `sudo cp ${caCertificatePath} /usr/local/share/ca-certificates && sudo /usr/sbin/update-ca-certificates`;
       default:
          throw new Error(`Platform not supported: ${process.platform}`);
    }

--- a/packages/office-addin-dev-certs/src/install.ts
+++ b/packages/office-addin-dev-certs/src/install.ts
@@ -16,6 +16,8 @@ function getInstallCommand(caCertificatePath: string, machine: boolean = false):
          return `powershell -ExecutionPolicy Bypass -File "${script}" ${machine ? "LocalMachine" : "CurrentUser"} "${caCertificatePath}"`;
       case "darwin": // macOS
          return `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain '${caCertificatePath}'`;
+      case "linux":
+         return `sudo mv ${caCertificatePath} /usr/local/share/ca-certificates && sudo /usr/sbin/update-ca-certificates`;
       default:
          throw new Error(`Platform not supported: ${process.platform}`);
    }

--- a/packages/office-addin-dev-certs/src/uninstall.ts
+++ b/packages/office-addin-dev-certs/src/uninstall.ts
@@ -15,6 +15,8 @@ function getUninstallCommand(machine: boolean = false): string {
          return `powershell -ExecutionPolicy Bypass -File "${script}" ${machine ? "LocalMachine" : "CurrentUser"} "${defaults.certificateName}"`;
       case "darwin": // macOS
          return `sudo security delete-certificate -c '${defaults.certificateName}'`;
+      case "linux":
+         return `sudo rm /usr/local/share/ca-certificates/${defaults.certificateName} && sudo /usr/sbin/update-ca-certificates`
       default:
          throw new Error(`Platform not supported: ${process.platform}`);
    }

--- a/packages/office-addin-dev-certs/src/uninstall.ts
+++ b/packages/office-addin-dev-certs/src/uninstall.ts
@@ -16,7 +16,7 @@ function getUninstallCommand(machine: boolean = false): string {
       case "darwin": // macOS
          return `sudo security delete-certificate -c '${defaults.certificateName}'`;
       case "linux":
-         return `sudo rm /usr/local/share/ca-certificates/${defaults.certificateName} && sudo /usr/sbin/update-ca-certificates`
+         return `sudo rm /usr/local/share/ca-certificates/${defaults.caCertificateFileName} && sudo /usr/sbin/update-ca-certificates --fresh`
       default:
          throw new Error(`Platform not supported: ${process.platform}`);
    }

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -16,7 +16,7 @@ function getVerifyCommand(): string {
        case "darwin": // macOS
           return `security find-certificate -c '${defaults.certificateName}' -p | openssl x509 -checkend 86400 -noout`;
         case "linux":
-          return `[ -f /usr/local/share/ca-certificates/${defaults.caCertificateFileName} ]`;
+          return `[ -f /usr/local/share/ca-certificates/${defaults.caCertificateFileName} ] && openssl x509 -in /usr/local/share/ca-certificates/${defaults.caCertificateFileName} -checkend 86400 -noout`;
        default:
           throw new Error(`Platform not supported: ${process.platform}`);
     }

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -16,7 +16,7 @@ function getVerifyCommand(): string {
        case "darwin": // macOS
           return `security find-certificate -c '${defaults.certificateName}' -p | openssl x509 -checkend 86400 -noout`;
         case "linux":
-          return `[ -f /usr/local/share/ca-certificates/${defaults.certificateName} ]`;
+          return `[ -f /usr/local/share/ca-certificates/${defaults.caCertificateFileName} ]`;
        default:
           throw new Error(`Platform not supported: ${process.platform}`);
     }

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -15,6 +15,8 @@ function getVerifyCommand(): string {
           return `powershell -ExecutionPolicy Bypass -File "${script}" "${defaults.certificateName}"`;
        case "darwin": // macOS
           return `security find-certificate -c '${defaults.certificateName}' -p | openssl x509 -checkend 86400 -noout`;
+        case "linux":
+          return `[ -f /usr/local/share/ca-certificates/${defaults.certificateName} ]`;
        default:
           throw new Error(`Platform not supported: ${process.platform}`);
     }


### PR DESCRIPTION
This provides a 'linux' case for installing, uninstalling, and verifying a cert in `office-addin-dev-certs`. Before adding changes, tests fail on my machine (Ubuntu 18.04). After adding, tests pass. That said, it's a fairly naive implementation.