### PR TITLE
Move test server listener code to separate function

### DIFF
--- a/packages/office-addin-test-server/src/testServer.ts
+++ b/packages/office-addin-test-server/src/testServer.ts
@@ -25,7 +25,7 @@ export class TestServer {
         this.m_testServerStarted = false;
     }
 
-    public async startTestServer(mochaTest: boolean = false): Promise<any> {
+    public async startTestServer(mochaTest: boolean = false): Promise<boolean> {
         try {
             if (mochaTest) {
                 process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
@@ -59,8 +59,8 @@ export class TestServer {
         }
     }
 
-    private async startListening(): Promise<any> {
-        return new Promise<any>(async (resolve, reject) => {
+    private async startListening(): Promise<boolean> {
+        return new Promise<boolean>(async (resolve, reject) => {
             try {
                 // set server to listen on specified port
                 this.m_server.listen(this.m_port, () => {

--- a/packages/office-addin-test-server/src/testServer.ts
+++ b/packages/office-addin-test-server/src/testServer.ts
@@ -40,7 +40,7 @@ export class TestServer {
             return await this.startListening();
 
         } catch (err) {
-            throw new Error(`Test server failed with error.\n${err}`);
+            throw new Error(`Unable to start test server.\n${err}`);
         }
     }
 
@@ -57,7 +57,6 @@ export class TestServer {
                 const platformName = this.getPlatformName();
                 this.m_app.get("/ping", function (req: any, res: any, next: any) {
                     res.send(platformName);
-                    resolve(true);
                 });
 
                 // listen for posting of test results
@@ -70,7 +69,7 @@ export class TestServer {
                 });
 
             } catch (err) {
-                reject(new Error(`Test server failed with error.\n${err}`));
+                reject(new Error(`Unable to start test server.\n${err}`));
             }
         });
     }

--- a/packages/office-addin-test-server/src/testServer.ts
+++ b/packages/office-addin-test-server/src/testServer.ts
@@ -24,46 +24,58 @@ export class TestServer {
         this.m_resultsPromise = undefined;
         this.m_testServerStarted = false;
     }
-    
-    public async startTestServer(mochaTest: boolean = false): Promise<any>{
-        return new Promise<boolean>(async (resolve, reject) => {
+
+    public async startTestServer(mochaTest: boolean = false): Promise<any> {
+        try {
             if (mochaTest) {
                 process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
             }
 
+            // create express server instance
             const options = await devCerts.getHttpsServerOptions();
-            const platformName = this.getPlatformName();
-
-            // listen for 'ping'
             this.m_app.use(cors());
-            this.m_app.get("/ping", function (req: any, res: any, next: any) {                
-                res.send(platformName);
-            });
-
-            // listen for posting of test results
-            this.m_resultsPromise = new Promise<JSON>(async (resolveResults) => {
-                this.m_app.post("/results", async (req: any, res: any) => {
-                    res.send("200");
-                    this.m_jsonData = JSON.parse(req.query.data);
-                    resolveResults(this.m_jsonData);
-                });
-            });
-    
             this.m_server = https.createServer(options, this.m_app);
-    
+
             // start listening on specified port
+            return await this.startListening();
+
+        } catch (err) {
+            throw new Error(`Test server failed with error.\n${err}`);
+        }
+    }
+
+    private async startListening(): Promise<any> {
+        return new Promise<any>(async (resolve, reject) => {
             try {
+                // set server to listen on specified port
                 this.m_server.listen(this.m_port, () => {
                     this.m_testServerStarted = true;
                     resolve(true);
                 });
+
+                // listen for 'ping'
+                const platformName = this.getPlatformName();
+                this.m_app.get("/ping", function (req: any, res: any, next: any) {
+                    res.send(platformName);
+                    resolve(true);
+                });
+
+                // listen for posting of test results
+                this.m_resultsPromise = new Promise<JSON>(async (resolveResults) => {
+                    this.m_app.post("/results", async (req: any, res: any) => {
+                        res.send("200");
+                        this.m_jsonData = JSON.parse(req.query.data);
+                        resolveResults(this.m_jsonData);
+                    });
+                });
+
             } catch (err) {
-                reject(new Error(`Unable to start test server.\n${err}`));
+                reject(new Error(`Test server failed with error.\n${err}`));
             }
         });
     }
-    
-    public async stopTestServer(): Promise <boolean> {
+
+    public async stopTestServer(): Promise<boolean> {
         return new Promise<boolean>(async (resolve, reject) => {
             if (this.m_testServerStarted) {
                 try {
@@ -79,15 +91,15 @@ export class TestServer {
             }
         });
     }
-   
+
     public async getTestResults(): Promise<JSON> {
         return this.m_resultsPromise;
     }
-    
+
     public getTestServerState(): boolean {
         return this.m_testServerStarted;
     }
-    
+
     public getTestServerPort(): number {
         return this.m_port;
     }

--- a/packages/office-addin-test-server/src/testServer.ts
+++ b/packages/office-addin-test-server/src/testServer.ts
@@ -36,6 +36,21 @@ export class TestServer {
             this.m_app.use(cors());
             this.m_server = https.createServer(options, this.m_app);
 
+            // listen for 'ping'
+            const platformName = this.getPlatformName();
+            this.m_app.get("/ping", function (req: any, res: any, next: any) {
+                res.send(platformName);
+            });
+
+            // listen for posting of test results
+            this.m_resultsPromise = new Promise<JSON>(async (resolveResults) => {
+                this.m_app.post("/results", async (req: any, res: any) => {
+                    res.send("200");
+                    this.m_jsonData = JSON.parse(req.query.data);
+                    resolveResults(this.m_jsonData);
+                });
+            });
+
             // start listening on specified port
             return await this.startListening();
 
@@ -51,21 +66,6 @@ export class TestServer {
                 this.m_server.listen(this.m_port, () => {
                     this.m_testServerStarted = true;
                     resolve(true);
-                });
-
-                // listen for 'ping'
-                const platformName = this.getPlatformName();
-                this.m_app.get("/ping", function (req: any, res: any, next: any) {
-                    res.send(platformName);
-                });
-
-                // listen for posting of test results
-                this.m_resultsPromise = new Promise<JSON>(async (resolveResults) => {
-                    this.m_app.post("/results", async (req: any, res: any) => {
-                        res.send("200");
-                        this.m_jsonData = JSON.parse(req.query.data);
-                        resolveResults(this.m_jsonData);
-                    });
                 });
 
             } catch (err) {


### PR DESCRIPTION
- Per suggestion of AKrantz: "There is no try/catch around the await to call reject on the Promise which is returned. Await on a rejected promise throws from that point. I highly suggest not mixing async/await code with callbacks that resolve/reject a Promise in the same function. Its too easy to miss things"
- Validated tests pass
- Also linked changes to Office-Addin-Taskpane and validated UI tests pass