### PR TITLE
update test server version

### DIFF
--- a/packages/custom-functions-metadata-plugin/package-lock.json
+++ b/packages/custom-functions-metadata-plugin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-functions-metadata-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -988,14 +988,14 @@
       }
     },
     "custom-functions-metadata": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.0.2.tgz",
-      "integrity": "sha512-shnWp5sqIk5dm+UwxylM8CiGoL7nOMyZOPm7zw2zzqeIymYv1lex29lrJDn5ZFCQ46xrlOBJ2SB4H3qouvDCoQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.0.3.tgz",
+      "integrity": "sha512-7W2JHHAlVXgvph2aH2Z84a9E704/mEBioplxoCWB4wyENZ4YN+R6yqDkbAW8GqUH9ojrecv++NkAsutInTJ0WQ==",
       "requires": {
         "assert": "^1.4.1",
         "commander": "^2.19.0",
         "nconf": "^0.10.0",
-        "office-addin-cli": "^0.2.6",
+        "office-addin-cli": "^0.2.7",
         "optimist": "^0.6.1",
         "xregexp": "^4.2.4"
       },
@@ -2786,9 +2786,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.6.tgz",
-      "integrity": "sha512-2QoV3pdcP5cM1BwjbwWDpvUxe8bX1T3CE3Js9nOzPGwjOOa4d27OmmyIBNvjj7eBcpyfckM+NcALUjrl2F94pQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.7.tgz",
+      "integrity": "sha512-alJGyd8rDDkNMD65DwTjp/YcDO2uMv0pSVVoX9byBZ3Ibhe9ChKvmEyw97VVZlpR4ZFz5W4MpL1B1ns1jowsZg==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.3.0"

--- a/packages/custom-functions-metadata/package-lock.json
+++ b/packages/custom-functions-metadata/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-functions-metadata",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/office-addin-cli/package-lock.json
+++ b/packages/office-addin-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-cli",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/office-addin-debugging/package-lock.json
+++ b/packages/office-addin-debugging/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-debugging",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -651,13 +651,6 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
-        }
       }
     },
     "ip-regex": {
@@ -740,8 +733,7 @@
     "lodash": {
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -918,57 +910,57 @@
       }
     },
     "office-addin-cli": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.6.tgz",
-      "integrity": "sha512-2QoV3pdcP5cM1BwjbwWDpvUxe8bX1T3CE3Js9nOzPGwjOOa4d27OmmyIBNvjj7eBcpyfckM+NcALUjrl2F94pQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.7.tgz",
+      "integrity": "sha512-alJGyd8rDDkNMD65DwTjp/YcDO2uMv0pSVVoX9byBZ3Ibhe9ChKvmEyw97VVZlpR4ZFz5W4MpL1B1ns1jowsZg==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.3.0"
       }
     },
     "office-addin-dev-certs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.3.0.tgz",
-      "integrity": "sha512-qo83TFzmTzPPIUQi1T9Jp9pA1tzib270s6ZDVcQiWiHJpvAxkmPua6JtuvRnU+BPElNzaLLU/DxyX1nGB5ktXw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.3.1.tgz",
+      "integrity": "sha512-LIvePFZTMUB3HjdUa9Auf2n4G7l21NTU/k/6MOAxsIAVyMyXDk1d/RHjPBDOo+2HrrIh8gRMfhPCqhwYgNrSfg==",
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^2.19.0",
         "fs-extra": "^7.0.1",
         "mkcert": "^1.2.0",
-        "office-addin-cli": "^0.2.6"
+        "office-addin-cli": "^0.2.7"
       }
     },
     "office-addin-dev-settings": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.6.6.tgz",
-      "integrity": "sha512-j7tC+/1oZ2//EEEjweps+nsu5YnC0L34llWv6xzghdd+AAkk9xI04MbqyNmghf+Y98CwhA1HuDyoAwm3CQc+yw==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.6.7.tgz",
+      "integrity": "sha512-Qocp6/GRFKdtHnZUWgn1JiePDHTi7CgsSf5ZqAG9Gm+fiyjXHkHEKE6zoxZoNI8VUN/yDa+DPKBW83A2rECDnQ==",
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^2.18.0",
         "inquirer": "^6.2.2",
-        "office-addin-cli": "^0.2.6",
-        "office-addin-manifest": "^1.3.6",
+        "office-addin-cli": "^0.2.7",
+        "office-addin-manifest": "^1.3.7",
         "whatwg-url": "^7.0.0",
         "winreg": "^1.2.4"
       }
     },
     "office-addin-manifest": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.3.6.tgz",
-      "integrity": "sha512-jJDJcIxNhuu3yezJLw+BxwvTpoCbBOVo9/fn6p/vQQH8lgU4vC6jepvNkNR2UAG3z+0/KSDNhA9QzlwriCJhwQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.3.7.tgz",
+      "integrity": "sha512-Wgk5YX7qyQGVNzGr3tq5JyKS8LtlAl5fpQrGseKWWL3iKDlQKy/rY3f7eAWc5aGq8pxSBmArS2ysa0p3kP831w==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.2.0",
-        "office-addin-cli": "^0.2.6",
+        "office-addin-cli": "^0.2.7",
         "path": "^0.12.7",
         "uuid": "^3.3.2",
         "xml2js": "^0.4.19"
       }
     },
     "office-addin-node-debugger": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.4.6.tgz",
-      "integrity": "sha512-4/zEYJBG8Z32ZJOPaQrCnJEgOGq562/1ZdsNviNPv/sAgumSk1TKIgzNjYtjUEFn/zqyftj0HVj5lnoyOFgwQw==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.4.7.tgz",
+      "integrity": "sha512-lTv8VVkSH2kQ2ysRrsTiAAf90su6VfVcqQyIAzjc6sDGQUDXNfNWoFgs7vaNhv9EjtrHyfn9gjd6n+c3IPzq7Q==",
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^2.19.0",

--- a/packages/office-addin-dev-certs/package-lock.json
+++ b/packages/office-addin-dev-certs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-dev-certs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -626,9 +626,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.6.tgz",
-      "integrity": "sha512-2QoV3pdcP5cM1BwjbwWDpvUxe8bX1T3CE3Js9nOzPGwjOOa4d27OmmyIBNvjj7eBcpyfckM+NcALUjrl2F94pQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.7.tgz",
+      "integrity": "sha512-alJGyd8rDDkNMD65DwTjp/YcDO2uMv0pSVVoX9byBZ3Ibhe9ChKvmEyw97VVZlpR4ZFz5W4MpL1B1ns1jowsZg==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.3.0"

--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-dev-settings",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -758,22 +758,22 @@
       }
     },
     "office-addin-cli": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.6.tgz",
-      "integrity": "sha512-2QoV3pdcP5cM1BwjbwWDpvUxe8bX1T3CE3Js9nOzPGwjOOa4d27OmmyIBNvjj7eBcpyfckM+NcALUjrl2F94pQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.7.tgz",
+      "integrity": "sha512-alJGyd8rDDkNMD65DwTjp/YcDO2uMv0pSVVoX9byBZ3Ibhe9ChKvmEyw97VVZlpR4ZFz5W4MpL1B1ns1jowsZg==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.3.0"
       }
     },
     "office-addin-manifest": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.3.6.tgz",
-      "integrity": "sha512-jJDJcIxNhuu3yezJLw+BxwvTpoCbBOVo9/fn6p/vQQH8lgU4vC6jepvNkNR2UAG3z+0/KSDNhA9QzlwriCJhwQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.3.7.tgz",
+      "integrity": "sha512-Wgk5YX7qyQGVNzGr3tq5JyKS8LtlAl5fpQrGseKWWL3iKDlQKy/rY3f7eAWc5aGq8pxSBmArS2ysa0p3kP831w==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.2.0",
-        "office-addin-cli": "^0.2.6",
+        "office-addin-cli": "^0.2.7",
         "path": "^0.12.7",
         "uuid": "^3.3.2",
         "xml2js": "^0.4.19"

--- a/packages/office-addin-manifest/package-lock.json
+++ b/packages/office-addin-manifest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-manifest",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -539,9 +539,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.6.tgz",
-      "integrity": "sha512-2QoV3pdcP5cM1BwjbwWDpvUxe8bX1T3CE3Js9nOzPGwjOOa4d27OmmyIBNvjj7eBcpyfckM+NcALUjrl2F94pQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.7.tgz",
+      "integrity": "sha512-alJGyd8rDDkNMD65DwTjp/YcDO2uMv0pSVVoX9byBZ3Ibhe9ChKvmEyw97VVZlpR4ZFz5W4MpL1B1ns1jowsZg==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.3.0"

--- a/packages/office-addin-node-debugger/package-lock.json
+++ b/packages/office-addin-node-debugger/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-node-debugger",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/office-addin-test-helpers/package-lock.json
+++ b/packages/office-addin-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "office-addin-test-helpers",
-    "version": "0.3.2",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/office-addin-test-server/package-lock.json
+++ b/packages/office-addin-test-server/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "office-addin-test-server",
-    "version": "0.4.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -887,24 +887,24 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "office-addin-cli": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.6.tgz",
-            "integrity": "sha512-2QoV3pdcP5cM1BwjbwWDpvUxe8bX1T3CE3Js9nOzPGwjOOa4d27OmmyIBNvjj7eBcpyfckM+NcALUjrl2F94pQ==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.7.tgz",
+            "integrity": "sha512-alJGyd8rDDkNMD65DwTjp/YcDO2uMv0pSVVoX9byBZ3Ibhe9ChKvmEyw97VVZlpR4ZFz5W4MpL1B1ns1jowsZg==",
             "requires": {
                 "commander": "^2.19.0",
                 "node-fetch": "^2.3.0"
             }
         },
         "office-addin-dev-certs": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.3.0.tgz",
-            "integrity": "sha512-qo83TFzmTzPPIUQi1T9Jp9pA1tzib270s6ZDVcQiWiHJpvAxkmPua6JtuvRnU+BPElNzaLLU/DxyX1nGB5ktXw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.3.1.tgz",
+            "integrity": "sha512-LIvePFZTMUB3HjdUa9Auf2n4G7l21NTU/k/6MOAxsIAVyMyXDk1d/RHjPBDOo+2HrrIh8gRMfhPCqhwYgNrSfg==",
             "requires": {
                 "child_process": "^1.0.2",
                 "commander": "^2.19.0",
                 "fs-extra": "^7.0.1",
                 "mkcert": "^1.2.0",
-                "office-addin-cli": "^0.2.6"
+                "office-addin-cli": "^0.2.7"
             }
         },
         "on-finished": {

--- a/packages/office-addin-test-server/package.json
+++ b/packages/office-addin-test-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "office-addin-test-server",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Creates a local web server for testing Office Add-ins and receiving test results.",
     "main": "./lib/main.js",
     "scripts": {


### PR DESCRIPTION
Verison 1.0.0 had already been published -- not sure why -- so need to bump version to 1.0.1.

This caused all of the package-lock.json files to be updated.