### PR TITLE
custom-functions-metadata: ensure Promise return type works for TypeScript and JavaScript

### DIFF
--- a/packages/custom-functions-metadata/src/generate.ts
+++ b/packages/custom-functions-metadata/src/generate.ts
@@ -550,8 +550,20 @@ function getResults(func: ts.FunctionDeclaration, isStreamingFunction: boolean, 
             const errorString = `Type {${ts.SyntaxKind[func.type.kind]}:${ts.SyntaxKind[returnTypeFromJSDoc.kind]}} doesn't match for return type : ${name}`;
             extra.errors.push(logError(errorString, returnPosition));
         }
-        resultType = getParamType(returnTypeFromJSDoc, extra, enumList);
-        resultDim = getParamDim(returnTypeFromJSDoc);
+        if (returnTypeFromJSDoc.kind === ts.SyntaxKind.TypeReference &&
+            (returnTypeFromJSDoc as ts.TypeReferenceNode).typeName.getText() === "Promise" &&
+            (returnTypeFromJSDoc as ts.TypeReferenceNode).typeArguments &&
+            // @ts-ignore
+            (returnTypeFromJSDoc as ts.TypeReferenceNode).typeArguments.length === 1
+        ) {
+            // @ts-ignore
+            resultType = getParamType((returnTypeFromJSDoc as ts.TypeReferenceNode).typeArguments[0], extra, enumList);
+            // @ts-ignore
+            resultDim = getParamDim((returnTypeFromJSDoc as ts.TypeReferenceNode).typeArguments[0]);
+        } else {
+            resultType = getParamType(returnTypeFromJSDoc, extra, enumList);
+            resultDim = getParamDim(returnTypeFromJSDoc);
+        }
     }
 
     const resultItem: IFunctionResult = {

--- a/packages/custom-functions-metadata/test/cases/return-type-explicit/expected.json
+++ b/packages/custom-functions-metadata/test/cases/return-type-explicit/expected.json
@@ -56,6 +56,63 @@
                 "dimensionality": "matrix",
                 "type": "string"
             }
+        },
+        {
+            "id": "RETURNSBOOLEANPROMISE",
+            "name": "RETURNSBOOLEANPROMISE",
+            "parameters": [],
+            "result": {
+                "type": "boolean"
+            }
+        },
+        {
+            "id": "RETURNSNUMBERPROMISE",
+            "name": "RETURNSNUMBERPROMISE",
+            "parameters": [],
+            "result": {
+                "type": "number"
+            }
+        },
+        {
+            "id": "RETURNSSTRINGPROMISE",
+            "name": "RETURNSSTRINGPROMISE",
+            "parameters": [],
+            "result": {
+                "type": "string"
+            }
+        },
+        {
+            "id": "RETURNSOBJECTPROMISE",
+            "name": "RETURNSOBJECTPROMISE",
+            "parameters": [],
+            "result": {}
+        },
+        {
+            "id": "RETURNSMATRIXBOOLEANPROMISE",
+            "name": "RETURNSMATRIXBOOLEANPROMISE",
+            "parameters": [],
+            "result": {
+                "dimensionality": "matrix",
+                "type": "boolean"
+            }
+        },
+        {
+            "id": "RETURNSMATRIXNUMBERPROMISE",
+            "name": "RETURNSMATRIXNUMBERPROMISE",
+            "parameters": [],
+            "result": {
+                "dimensionality": "matrix",
+                "type": "number"
+            }
+        },
+        {
+            "id": "RETURNSMATRIXSTRINGPROMISE",
+            "name": "RETURNSMATRIXSTRINGPROMISE",
+            "parameters": [],
+            "result": {
+                "dimensionality": "matrix",
+                "type": "string"
+            }
         }
     ]
 }

--- a/packages/custom-functions-metadata/test/cases/return-type-explicit/functions.js
+++ b/packages/custom-functions-metadata/test/cases/return-type-explicit/functions.js
@@ -1,58 +1,114 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-    /**
-     * @customfunction
-     * @returns {boolean}
-     */
-    function returnsBoolean() {
-        return true;
-      }
+/**
+ * @customfunction
+ * @returns {boolean}
+ */
+function returnsBoolean() {
+  return true;
+}
 
-     /**
-     * @customfunction
-     * @returns {number}
-     */
-    function returnsNumber() {
-       return 5;
-      }
+/**
+ * @customfunction
+ * @returns {number}
+ */
+function returnsNumber() {
+  return 5;
+}
 
-     /**
-     * @customfunction
-     * @returns {string}
-     */
-    function returnsString() {
-        return "abc";
-      }
+/**
+ * @customfunction
+ * @returns {string}
+ */
+function returnsString() {
+  return "abc";
+}
 
-     /**
-     * @customfunction
-     * @returns {object}
-     */
-    function returnsObject() {
-       return {};
-      }
+/**
+ * @customfunction
+ * @returns {object}
+ */
+function returnsObject() {
+  return {};
+}
 
-     /**
-     * @customfunction
-     * @returns {boolean[][]}
-     */
-    function returnsMatrixBoolean() {
-        return [[true]];
-      }
+/**
+ * @customfunction
+ * @returns {boolean[][]}
+ */
+function returnsMatrixBoolean() {
+  return [[true]];
+}
 
-     /**
-     * @customfunction
-     * @returns {number[][]}
-     */
-    function returnsMatrixNumber() {
-        return [[5]];
-      }
+/**
+ * @customfunction
+ * @returns {number[][]}
+ */
+function returnsMatrixNumber() {
+  return [[5]];
+}
 
-     /**
-     * @customfunction
-     * @returns {string[][]}
-     */
-    function returnsMatrixString() {
-        return [["abc"]];
-      }
+/**
+ * @customfunction
+ * @returns {string[][]}
+ */
+function returnsMatrixString() {
+  return [["abc"]];
+}
+
+/**
+ * @customfunction
+ * @returns {Promise<boolean>}
+ */
+function returnsBooleanPromise() {
+  return Promise.resolve(true);
+}
+
+/**
+ * @customfunction
+ * @returns {Promise<number>}
+ */
+function returnsNumberPromise() {
+  return Promise.resolve(5);
+}
+
+/**
+ * @customfunction
+ * @returns {Promise<string>}
+ */
+function returnsStringPromise() {
+  return Promise.resolve("abc");
+}
+
+/**
+ * @customfunction
+ * @returns {Promise<object>}
+ */
+function returnsObjectPromise() {
+  return Promise.resolve({});
+}
+
+/**
+ * @customfunction
+ * @returns {Promise<boolean[][]>}
+ */
+function returnsMatrixBooleanPromise() {
+  return Promise.resolve([[true]]);
+}
+
+/**
+ * @customfunction
+ * @returns {Promise<number[][]>}
+ */
+function returnsMatrixNumberPromise() {
+  return Promise.resolve([[5]]);
+}
+
+/**
+ * @customfunction
+ * @returns {Promise<string[][]>}
+ */
+function returnsMatrixStringPromise() {
+  return Promise.resolve([["abc"]]);
+}

--- a/packages/custom-functions-metadata/test/cases/return-type-explicit/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/return-type-explicit/functions.ts
@@ -1,51 +1,100 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-    
-    /**
-     * @customfunction
-     */
-    function returnsBoolean(): boolean {
-        return true;
-      }
 
-    /**
-     * @customfunction
-     */
-    function returnsNumber(): number {
-       return 5;
-      }
+/**
+ * @customfunction
+ */
+function returnsBoolean(): boolean {
+  return true;
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsString(): string {
-        return "abc";
-      }
+/**
+ * @customfunction
+ */
+function returnsNumber(): number {
+  return 5;
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsObject(): object {
-        return {};
-      }
+/**
+ * @customfunction
+ */
+function returnsString(): string {
+  return "abc";
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsMatrixBoolean(): boolean[][] {
-        return [[true]];
-      }
+/**
+ * @customfunction
+ */
+function returnsObject(): object {
+  return {};
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsMatrixNumber(): number[][] {
-        return [[5]];
-      }
+/**
+ * @customfunction
+ */
+function returnsMatrixBoolean(): boolean[][] {
+  return [[true]];
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsMatrixString(): string[][] {
-        return [["abc"]];
-      }
+/**
+ * @customfunction
+ */
+function returnsMatrixNumber(): number[][] {
+  return [[5]];
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixString(): string[][] {
+  return [["abc"]];
+}
+
+/**
+ * @customfunction
+ */
+function returnsBooleanPromise(): Promise<boolean> {
+  return Promise.resolve(true);
+}
+
+/**
+ * @customfunction
+ */
+function returnsNumberPromise(): Promise<number> {
+  return Promise.resolve(5);
+}
+
+/**
+ * @customfunction
+ */
+function returnsStringPromise(): Promise<string> {
+  return Promise.resolve("abc");
+}
+
+/**
+ * @customfunction
+ */
+function returnsObjectPromise(): Promise<object> {
+  return Promise.resolve({});
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixBooleanPromise(): Promise<boolean[][]> {
+  return Promise.resolve([[true]]);
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixNumberPromise(): Promise<number[][]> {
+  return Promise.resolve([[5]]);
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixStringPromise(): Promise<string[][]> {
+  return Promise.resolve([["abc"]]);
+}

--- a/packages/custom-functions-metadata/test/cases/return-type-implicit/expected.json
+++ b/packages/custom-functions-metadata/test/cases/return-type-implicit/expected.json
@@ -41,6 +41,48 @@
             "name": "RETURNSMATRIXSTRING",
             "parameters": [],
             "result": {}
+        },
+        {
+            "id": "RETURNSBOOLEANPROMISE",
+            "name": "RETURNSBOOLEANPROMISE",
+            "parameters": [],
+            "result": {}
+        },
+        {
+            "id": "RETURNSNUMBERPROMISE",
+            "name": "RETURNSNUMBERPROMISE",
+            "parameters": [],
+            "result": {}
+        },
+        {
+            "id": "RETURNSSTRINGPROMISE",
+            "name": "RETURNSSTRINGPROMISE",
+            "parameters": [],
+            "result": {}
+        },
+        {
+            "id": "RETURNSOBJECTPROMISE",
+            "name": "RETURNSOBJECTPROMISE",
+            "parameters": [],
+            "result": {}
+        },
+        {
+            "id": "RETURNSMATRIXBOOLEANPROMISE",
+            "name": "RETURNSMATRIXBOOLEANPROMISE",
+            "parameters": [],
+            "result": {}
+        },
+        {
+            "id": "RETURNSMATRIXNUMBERPROMISE",
+            "name": "RETURNSMATRIXNUMBERPROMISE",
+            "parameters": [],
+            "result": {}
+        },
+        {
+            "id": "RETURNSMATRIXSTRINGPROMISE",
+            "name": "RETURNSMATRIXSTRINGPROMISE",
+            "parameters": [],
+            "result": {}
         }
     ]
 }

--- a/packages/custom-functions-metadata/test/cases/return-type-implicit/functions.js
+++ b/packages/custom-functions-metadata/test/cases/return-type-implicit/functions.js
@@ -1,51 +1,100 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-    
-    /**
-     * @customfunction
-     */
-    function returnsBoolean() {
-        return true;
-      }
 
-     /**
-     * @customfunction
-     */
-    function returnsNumber() {
-       return 5;
-      }
+/**
+ * @customfunction
+ */
+function returnsBoolean() {
+  return true;
+}
 
-     /**
-     * @customfunction
-     */
-    function returnsString() {
-        return "abc";
-      }
+/**
+ * @customfunction
+ */
+function returnsNumber() {
+  return 5;
+}
 
-     /**
-     * @customfunction
-     */
-    function returnsObject() {
-       return {};
-      }
+/**
+ * @customfunction
+ */
+function returnsString() {
+  return "abc";
+}
 
-     /**
-     * @customfunction
-     */
-    function returnsMatrixBoolean() {
-        return [[true]];
-      }
+/**
+ * @customfunction
+ */
+function returnsObject() {
+  return {};
+}
 
-     /**
-     * @customfunction
-     */
-    function returnsMatrixNumber() {
-        return [[5]];
-      }
+/**
+ * @customfunction
+ */
+function returnsMatrixBoolean() {
+  return [[true]];
+}
 
-     /**
-     * @customfunction
-     */
-    function returnsMatrixString() {
-        return [["abc"]];
-      }
+/**
+ * @customfunction
+ */
+function returnsMatrixNumber() {
+  return [[5]];
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixString() {
+  return [["abc"]];
+}
+
+/**
+ * @customfunction
+ */
+function returnsBooleanPromise() {
+  return Promise.resolve(true);
+}
+
+/**
+ * @customfunction
+ */
+function returnsNumberPromise() {
+  return Promise.resolve(5);
+}
+
+/**
+ * @customfunction
+ */
+function returnsStringPromise() {
+  return Promise.resolve("abc");
+}
+
+/**
+ * @customfunction
+ */
+function returnsObjectPromise() {
+  return Promise.resolve({});
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixBooleanPromise() {
+  return Promise.resolve([[true]]);
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixNumberPromise() {
+  return Promise.resolve([[5]]);
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixStringPromise() {
+  return Promise.resolve([["abc"]]);
+}

--- a/packages/custom-functions-metadata/test/cases/return-type-implicit/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/return-type-implicit/functions.ts
@@ -1,51 +1,100 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-    
-    /**
-     * @customfunction
-     */
-    function returnsBoolean() {
-        return true;
-      }
 
-    /**
-     * @customfunction
-     */
-    function returnsNumber() {
-       return 5;
-      }
+/**
+ * @customfunction
+ */
+function returnsBoolean() {
+  return true;
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsString() {
-        return "abc";
-      }
+/**
+ * @customfunction
+ */
+function returnsNumber() {
+  return 5;
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsObject() {
-        return {};
-      }
+/**
+ * @customfunction
+ */
+function returnsString() {
+  return "abc";
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsMatrixBoolean() {
-        return [[true]];
-      }
+/**
+ * @customfunction
+ */
+function returnsObject() {
+  return {};
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsMatrixNumber() {
-        return [[5]];
-      }
+/**
+ * @customfunction
+ */
+function returnsMatrixBoolean() {
+  return [[true]];
+}
 
-    /**
-     * @customfunction
-     */
-    function returnsMatrixString() {
-        return [["abc"]];
-      }
+/**
+ * @customfunction
+ */
+function returnsMatrixNumber() {
+  return [[5]];
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixString() {
+  return [["abc"]];
+}
+
+/**
+ * @customfunction
+ */
+function returnsBooleanPromise() {
+  return Promise.resolve(true);
+}
+
+/**
+ * @customfunction
+ */
+function returnsNumberPromise() {
+  return Promise.resolve(5);
+}
+
+/**
+ * @customfunction
+ */
+function returnsStringPromise() {
+  return Promise.resolve("abc");
+}
+
+/**
+ * @customfunction
+ */
+function returnsObjectPromise() {
+  return Promise.resolve({});
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixBooleanPromise() {
+  return Promise.resolve([[true]]);
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixNumberPromise() {
+  return Promise.resolve([[5]]);
+}
+
+/**
+ * @customfunction
+ */
+function returnsMatrixStringPromise() {
+  return Promise.resolve([["abc"]]);
+}


### PR DESCRIPTION
Fixes https://github.com/OfficeDev/Office-Addin-Scripts/issues/172

* Add test cases for Promise return types.
* Fix code to handle Promise return types in the @returns JSDoc tag.