### PR TITLE
shared prettier config

### DIFF
--- a/packages/office-addin-prettier-config/package-lock.json
+++ b/packages/office-addin-prettier-config/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "office-addin-prettier-config",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/packages/office-addin-prettier-config/package.json
+++ b/packages/office-addin-prettier-config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "office-addin-prettier-config",
+  "version": "1.0.0",
+  "description": "Prettier config for Office-Addins",
+  "main": "prettier.config.js",
+  "scripts": {
+    "test": "echo \"No tests\" "
+  },
+  "author": "OfficeDev",
+  "license": "MIT"
+}

--- a/packages/office-addin-prettier-config/prettier.config.js
+++ b/packages/office-addin-prettier-config/prettier.config.js
@@ -1,7 +1,3 @@
 module.exports = {
-    bracketSpacing: true,
-    printWidth: 100,
-    semi: false,
-    singleQuote: true,
-    trailingComma: 'all',
-  }
+  printWidth: 120
+}

--- a/packages/office-addin-prettier-config/prettier.config.js
+++ b/packages/office-addin-prettier-config/prettier.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    bracketSpacing: true,
+    printWidth: 100,
+    semi: false,
+    singleQuote: true,
+    trailingComma: 'all',
+  }


### PR DESCRIPTION
This creates a shared prettier config for Office-Addins. Packages that want to use it can add the following to package.json : "prettier": "office-addin-prettier-config"