### PR TITLE
office-addin-dev-settings: fix sideload command

### DIFF
--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -146,7 +146,6 @@ export async function runPackager(commandLine: string, host: string = "localhost
  * @param packagerCommandLine If provided, starts the packager.
  * @param packagerHost Specifies the host name of the packager.
  * @param packagerPort Specifies the port of the packager.
- * @param sideloadCommandLine If provided, launches the add-in.
  * @param enableDebugging If false, start without debugging.
  */
 export async function startDebugging(manifestPath: string, appType: AppType, app: OfficeApp | undefined,
@@ -245,7 +244,7 @@ export async function startDebugging(manifestPath: string, appType: AppType, app
     if (isDesktopAppType) {
         try {
             console.log(`Sideloading the Office Add-in...`);
-            await sideloadAddIn(manifestPath, app);
+            await sideloadAddIn(manifestPath, app, true);
         } catch (err) {
             throw new Error(`Unable to sideload the Office Add-in. \n${err}`);
         }

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -199,18 +199,25 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
 
   const appsInManifest = getOfficeAppsForManifestHosts(manifest.hosts);
 
-  if (appsInManifest.length === 1) {
-    if (!app) {
-      app = appsInManifest[0];
-    } else if (app !== appsInManifest[0]) {
-      throw new Error(`The Office Add-in does not support ${getOfficeAppName(app)}.`);
+  if (app) {
+    if (appsInManifest.indexOf(app) < 0) {
+      throw new Error(`The Office Add-in manifest does not support ${getOfficeAppName(app)}.`);
     }
-  } else if (appsInManifest.length === 0) {
-    throw new Error("The manifest does not support any Office apps.");
-  } else if (canPrompt) {
-    app = await chooseOfficeApp(appsInManifest);
   } else {
-    throw new Error("Please specify the Office app.");
+    switch (appsInManifest.length) {
+      case 0:
+        throw new Error("The manifest does not support any Office apps.");
+      case 1:
+        app = appsInManifest[0];
+        break;
+      default:
+        if (canPrompt) {
+          app = await chooseOfficeApp(appsInManifest);
+        } else {
+          throw new Error("Please specify the Office app.");
+        }
+        break;
+    }
   }
 
   await registerAddIn(manifestPath);


### PR DESCRIPTION
Need better logic for the case where the is an app specified and the manifest contains multiple hosts.