### PR TITLE
office-addin-dev-settings: register command should write full path

### DIFF
--- a/packages/office-addin-dev-settings/src/dev-settings.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings.ts
@@ -190,7 +190,8 @@ export async function registerAddIn(manifestPath: string): Promise<void> {
   switch (process.platform) {
     case "win32":
       const manifest = await readManifestFile(manifestPath);
-      return devSettingsWindows.registerAddIn(manifest.id || "", manifestPath);
+      const realManifestPath = fs.realpathSync(manifestPath);
+      return devSettingsWindows.registerAddIn(manifest.id || "", realManifestPath);
     case "darwin":
       return devSettingsMac.registerAddIn(manifestPath);
     default:
@@ -213,7 +214,8 @@ export async function unregisterAddIn(manifestPath: string): Promise<void> {
       return devSettingsMac.unregisterAddIn(manifestPath);
     case "win32":
       const manifest = await readManifestFile(manifestPath);
-      return devSettingsWindows.unregisterAddIn(manifest.id || "", manifestPath);
+      const realManifestPath = fs.realpathSync(manifestPath);
+      return devSettingsWindows.unregisterAddIn(manifest.id || "", realManifestPath);
     default:
       throw new Error(`Platform not supported: ${process.platform}.`);
   }


### PR DESCRIPTION
On Windows, if the register command is called with a relative path or just a file name,
the full path should be written into the registry.