### PR TITLE
office-addin-dev-certs: fix install

### DIFF
--- a/packages/office-addin-dev-certs/src/install.ts
+++ b/packages/office-addin-dev-certs/src/install.ts
@@ -12,7 +12,7 @@ function getInstallCommand(caCertificatePath: string, machine: boolean = false):
    switch (process.platform) {
       case "win32":
          const script = path.resolve(__dirname, "..\\scripts\\install.ps1");
-         return `powershell -ExecutionPolicy Bypass & "${script}" ${machine ? "LocalMachine" : "CurrentUser"} "${caCertificatePath}"`;
+         return `powershell -ExecutionPolicy Bypass "${script}" ${machine ? "LocalMachine" : "CurrentUser"} "${caCertificatePath}"`;
       case "darwin": // macOS
          return `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain '${caCertificatePath}'`;
       default:

--- a/packages/office-addin-dev-certs/test/test.ts
+++ b/packages/office-addin-dev-certs/test/test.ts
@@ -144,7 +144,7 @@ describe("office-addin-dev-certs", function() {
                 sandbox.stub(verify, "isCaCertificateInstalled").returns(false);
                 await install.installCaCertificate(testCaCertificatePath, machine);
                 assert.strictEqual(execSync.callCount, 1);
-                assert.strictEqual(execSync.calledWith(`powershell -ExecutionPolicy Bypass & "${script}" ${machine ? "LocalMachine" : "CurrentUser"} "${testCaCertificatePath}"`), true);
+                assert.strictEqual(execSync.calledWith(`powershell -ExecutionPolicy Bypass "${script}" ${machine ? "LocalMachine" : "CurrentUser"} "${testCaCertificatePath}"`), true);
             });
             it("without --machine option", async function() {
                 const execSync = sandbox.fake();
@@ -153,7 +153,7 @@ describe("office-addin-dev-certs", function() {
                 sandbox.stub(verify, "isCaCertificateInstalled").returns(false);
                 await install.installCaCertificate(testCaCertificatePath, machine);
                 assert.strictEqual(execSync.callCount, 1);
-                assert.strictEqual(execSync.calledWith(`powershell -ExecutionPolicy Bypass & "${script}" ${machine ? "LocalMachine" : "CurrentUser"} "${testCaCertificatePath}"`), true);
+                assert.strictEqual(execSync.calledWith(`powershell -ExecutionPolicy Bypass "${script}" ${machine ? "LocalMachine" : "CurrentUser"} "${testCaCertificatePath}"`), true);
             });
         }
     });


### PR DESCRIPTION
The ampersand should not be in the command. It causes it to execute as two separate commands
 and opens the script file rather than executing it.