### PR TITLE
Fix for sideloading race condition

### DIFF
--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-dev-settings",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -770,22 +770,22 @@
       }
     },
     "office-addin-cli": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.15.tgz",
-      "integrity": "sha512-Qq4u7HLXiOsUKS9Yt3RhCqEwEURR3DqiNtkee9lAvyu0I0nvbbpAt3PAUA4fhBNBP+LGBhHJsjt1+nFKDQE7VA==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.16.tgz",
+      "integrity": "sha512-TB1uWZjyso6TSSszCWeHwbOsGgGepYGpSBRKW4iIC/c+GTUZtG9fTYFwMqkCbzkAZQR0RDqa+aaShxe0qkT9Qw==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.3.0"
       }
     },
     "office-addin-manifest": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.4.5.tgz",
-      "integrity": "sha512-Vpurx3E6DSflSo77xVyJIQHtGUenYWpLyS+Vp49FoCnR4RpC4OIp/aIKvxwlmInKv3/pYK/NMGZNnmtWUnUQ9w==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.4.6.tgz",
+      "integrity": "sha512-9A0+SYFJk2eC7qApyV4Q4U8M1M/DEpclHPpNUYsF2eSUN3ROVdV5FNR+tWf4Rmy5xa0XvYM3SFR+k32i3h+lFA==",
       "requires": {
         "commander": "^2.19.0",
         "node-fetch": "^2.6.0",
-        "office-addin-cli": "^0.2.15",
+        "office-addin-cli": "^0.2.16",
         "path": "^0.12.7",
         "uuid": "^3.3.2",
         "xml2js": "^0.4.19"

--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -25,6 +25,7 @@
     "inquirer": "^6.2.2",
     "jszip": "^3.2.2",
     "junk": "^3.1.0",
+    "node-fetch": "^2.6.0",
     "office-addin-cli": "^0.2.16",
     "office-addin-manifest": "^1.4.6",
     "open": "^6.4.0",

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -226,13 +226,10 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
   if (app) {
     const sideloadFile = await generateSideloadFile(app, manifest);
 
-    const devBuildComplete: boolean = await waitUntilDevBuildIsComplete(manifestPath);
+    // give the dev server time to build before sideloading
+    await waitUntilDevBuildIsComplete(manifestPath);
 
-    if (devBuildComplete) {
-      await open(sideloadFile, { wait: false });
-    } else {
-      throw new Error(`The dev build did not complete in time.`);
-    }
+    await open(sideloadFile, { wait: false });
   }
 }
 

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -239,10 +239,7 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
 export async function isDevBuildComplete(manifestPath: string): Promise<boolean> {
   try {
     const manifestInfo: any = await readManifestFile(manifestPath);
-
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
     const response = await fetch.default(manifestInfo.defaultSettings.sourceLocation);
-
     return response.status === 200;
   } catch {
     return false;


### PR DESCRIPTION
We have had an issue recently where UI tests fail in the CI loops because sideloading is occurring too soon before the dev build is done and thus the task pane fails to load.  These changes a check to see if the dev build is complete by doing a fetch call to the default SourceLocation and waiting for a successful response before sideloading.  I built and linked these changes on a CI VM and they look to address the failure we were seeing

NOTE: I initially thought the error was related to enabling EdgeWebView on the VMs, but turns out that's not the problem, as we already set this up as part of VM deployment