### PR TITLE
Implement sideloading for bundled manifest

### DIFF
--- a/packages/office-addin-debugging/README.md
+++ b/packages/office-addin-debugging/README.md
@@ -59,12 +59,11 @@ Host name of the packager. Default: `localhost`.
 
 ` --packager-port <port>`
 
-
 Port number of the packager. Default: `8081`.
 
 ` --prod`
 
-Specifies that debugging session is for production mode. Default is dev mode.
+Specifies that debugging session is for production mode. Default is development mode.
 
 ` --sideload <command>`
 
@@ -105,7 +104,7 @@ Options:
 
 ` --prod`
 
-Specifies that debugging session is for production mode. Default is dev mode.
+Specifies that debugging session is for production mode. Default is development mode.
 
 #
 

--- a/packages/office-addin-debugging/README.md
+++ b/packages/office-addin-debugging/README.md
@@ -59,6 +59,10 @@ Host name of the packager. Default: `localhost`.
 
 ` --packager-port <port>`
 
+Specifies that debugging session is for production mode. Default is dev mode.
+
+` --prod`
+
 Port number of the packager. Default: `8081`.
 
 ` --sideload <command>`
@@ -98,9 +102,9 @@ Syntax:
 
 Options:
 
-`--unload <command>`
+Specifies if in production mode. Default is dev mode.
 
-Unregister the Office Add-in using the specified command. For example: `office-toolbox remove -m <manifest> -a <app>`.
- 
+` --prod`
+
 #
 

--- a/packages/office-addin-debugging/README.md
+++ b/packages/office-addin-debugging/README.md
@@ -59,11 +59,12 @@ Host name of the packager. Default: `localhost`.
 
 ` --packager-port <port>`
 
-Specifies that debugging session is for production mode. Default is dev mode.
+
+Port number of the packager. Default: `8081`.
 
 ` --prod`
 
-Port number of the packager. Default: `8081`.
+Specifies that debugging session is for production mode. Default is dev mode.
 
 ` --sideload <command>`
 
@@ -102,9 +103,9 @@ Syntax:
 
 Options:
 
-Specifies if in production mode. Default is dev mode.
-
 ` --prod`
+
+Specifies that debugging session is for production mode. Default is dev mode.
 
 #
 

--- a/packages/office-addin-debugging/src/cli.ts
+++ b/packages/office-addin-debugging/src/cli.ts
@@ -11,7 +11,7 @@ commander.name("office-addin-debugging");
 commander.version(process.env.npm_package_version || "(version not available)");
 
 commander
-    .command("start <manifest-path> [app-type]")
+    .command("start <manifest-path> [platform]")
     .option("--app <app>", "Specify which Office app to use.")
     .option("--debug-method <method>", "The debug method to use.")
     .option("--dev-server <command>", "Run the dev server.")
@@ -21,6 +21,7 @@ commander
     .option("--packager <command>", "Run the packager.")
     .option("--packager-host <host>")
     .option("--packager-port <port>")
+    .option("--prod", "Specifies production mode.")
     .option("--sideload <command>")
     .option("--source-bundle-url-host <host>")
     .option("--source-bundle-url-port <port>")
@@ -29,8 +30,8 @@ commander
     .action(commands.start);
 
 commander
-    .command("stop <manifest-path>")
-    .option("--unload <command>")
+    .command("stop <manifest-path> [platform]")
+    .option("--prod", "Specifies production mode.")
     .action(commands.stop);
 
 // if the command is not known, display an error

--- a/packages/office-addin-debugging/src/cli.ts
+++ b/packages/office-addin-debugging/src/cli.ts
@@ -21,7 +21,7 @@ commander
     .option("--packager <command>", "Run the packager.")
     .option("--packager-host <host>")
     .option("--packager-port <port>")
-    .option("--prod", "Specifies production mode.")
+    .option("--prod", "Specifies that debugging session is for production mode. Default is dev mode.")
     .option("--sideload <command>")
     .option("--source-bundle-url-host <host>")
     .option("--source-bundle-url-port <port>")

--- a/packages/office-addin-debugging/src/commands.ts
+++ b/packages/office-addin-debugging/src/commands.ts
@@ -11,17 +11,15 @@ import { stopDebugging } from "./stop";
 
 function determineManifestPath(platform: Platform, dev: boolean): string {
     let manifestPath = process.env.npm_package_config_manifest_location || "";
+    manifestPath = manifestPath.replace("${flavor}", dev ? "dev" : "prod").replace("${platform}", platform);
 
-    manifestPath.replace("${flavor}", dev ? "dev" : "prod").replace("${platform}", platform);
-    
     if (!manifestPath) {
       throw new Error(`The manifest path was not provided.`);
     }
-    
     if (!fs.existsSync(manifestPath)) {
       throw new Error(`The manifest path does not exist: ${manifestPath}.`);
     }
-    
+
     return manifestPath;
 }
 

--- a/packages/office-addin-debugging/src/commands.ts
+++ b/packages/office-addin-debugging/src/commands.ts
@@ -5,7 +5,7 @@ import * as commander from "commander";
 import { logErrorMessage, parseNumber } from "office-addin-cli";
 import * as devSettings from "office-addin-dev-settings";
 import { OfficeApp, parseOfficeApp } from "office-addin-manifest";
-import { AppType, parseAppType, parseDebuggingMethod, startDebugging } from "./start";
+import { AppType, parseAppType, parseDebuggingMethod, startDebugging, parseAppPlatform, AppPlaform } from "./start";
 import { stopDebugging } from "./stop";
 
 function parseDevServerPort(optionValue: any): number | undefined {
@@ -23,8 +23,9 @@ function parseDevServerPort(optionValue: any): number | undefined {
     return devServerPort;
 }
 
-export async function start(manifestPath: string, appType: string | undefined, command: commander.Command) {
+export async function start(manifestPath: string, appType: string | undefined, appPlatform: string | undefined, command: commander.Command) {
     try {
+        const appPlatformToDebug: AppPlaform | undefined = parseAppPlatform(appPlatform || process.env.npm_package_config_app_plaform_to_debug || "win32");
         const appTypeToDebug: AppType | undefined = parseAppType(appType || process.env.npm_package_config_app_type_to_debug || "desktop");
         const appToDebug: string | undefined = command.app || process.env.npm_package_config_app_to_debug;
         const app: OfficeApp | undefined = appToDebug ? parseOfficeApp(appToDebug) : undefined;

--- a/packages/office-addin-debugging/src/commands.ts
+++ b/packages/office-addin-debugging/src/commands.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import { logErrorMessage, parseNumber } from "office-addin-cli";
 import * as devSettings from "office-addin-dev-settings";
 import { OfficeApp, parseOfficeApp } from "office-addin-manifest";
-import { AppType, parseAppType, parsePlatform, parseDebuggingMethod, Platform, startDebugging } from "./start";
+import { AppType, parseAppType, parseDebuggingMethod, parsePlatform, Platform, startDebugging } from "./start";
 import { stopDebugging } from "./stop";
 
 function determineManifestPath(platform: Platform, dev: boolean): string {
@@ -42,7 +42,7 @@ function parseDevServerPort(optionValue: any): number | undefined {
 
 export async function start(manifestPath: string, platform: string | undefined, command: commander.Command) {
     try {
-        const appPlatformToDebug: Platform | undefined = parsePlatform(platform || process.env.npm_package_config_app_platform_to_debug || AppPlatform.Win32);
+        const appPlatformToDebug: Platform | undefined = parsePlatform(platform || process.env.npm_package_config_app_platform_to_debug || Platform.Win32);
         const appTypeToDebug: AppType | undefined = parseAppType(appPlatformToDebug || process.env.npm_package_config_app_type_to_debug || AppType.Desktop);
         const appToDebug: string | undefined = command.app || process.env.npm_package_config_app_to_debug;
         const app: OfficeApp | undefined = appToDebug ? parseOfficeApp(appToDebug) : undefined;
@@ -84,14 +84,10 @@ export async function start(manifestPath: string, platform: string | undefined, 
 
 export async function stop(manifestPath: string, platform: string | undefined, command: commander.Command) {
     try {
-        const appPlatformToDebug: Platform | undefined = parsePlatform(platform || process.env.npm_package_config_app_plaform_to_debug || AppPlatform.Win32);
+        const appPlatformToDebug: Platform | undefined = parsePlatform(platform || process.env.npm_package_config_app_plaform_to_debug || Platform.Win32);
         const devBuild: boolean = command.prod ? false : true;
 
-        if (appPlatformToDebug === undefined) {
-            throw new Error("Please specify the application platform to debug.");
-        }
-
-        if (manifestPath === "") {
+        if (manifestPath === "" && appPlatformToDebug !== undefined) {
             manifestPath = determineManifestPath(appPlatformToDebug, devBuild);
         }
         await stopDebugging(manifestPath);

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -11,9 +11,13 @@ import * as debugInfo from "./debugInfo";
 import { getProcessIdsForPort } from "./port";
 import { startDetachedProcess  } from "./process";
 
-export enum AppPlaform {
-    iOS = "iOS",
-    Win32 = "win32"
+export enum AppPlatform {
+    Android = "android",
+    Desktop = "desktop",
+    iOS = "ios",
+    MacOS = "macos",
+    Win32 = "win32",
+    Web = "web",
 }
 
 export enum AppType {
@@ -57,20 +61,32 @@ export async function isPackagerRunning(statusUrl: string): Promise<boolean> {
 export function parseAppType(text: string): AppType | undefined {
     switch (text) {
         case "desktop":
+        case "macos":
+        case "win32":
             return AppType.Desktop;
         case "web":
             return AppType.Web;
+        case "ios":
+        case "android":
+            throw new Error(`Platform type ${text} not currently supported for debugging`);
         default:
             return undefined;
     }
 }
 
-export function parseAppPlatform(text: string): AppPlaform | undefined {
+export function parseAppPlatform(text: string): AppPlatform | undefined {
     switch (text) {
+        case "desktop":
+            return process.platform === "win32" ? AppPlatform.Win32 : AppPlatform.MacOS;
+        case "macos":
+            return AppPlatform.MacOS;
+        case "web":
+            return AppPlatform.Web;
         case "win32":
-            return AppPlaform.Win32;
-        case "iOS":
-            return AppPlaform.iOS;
+            return AppPlatform.Win32;
+        case "ios":
+        case "android":
+            throw new Error(`Platform type ${text} not currently supported for debugging`);
         default:
             return undefined;
     }

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -11,6 +11,11 @@ import * as debugInfo from "./debugInfo";
 import { getProcessIdsForPort } from "./port";
 import { startDetachedProcess  } from "./process";
 
+export enum AppPlaform {
+    iOS = "iOS",
+    Win32 = "win32"
+}
+
 export enum AppType {
     Desktop = "desktop",
     Web = "web",
@@ -55,6 +60,17 @@ export function parseAppType(text: string): AppType | undefined {
             return AppType.Desktop;
         case "web":
             return AppType.Web;
+        default:
+            return undefined;
+    }
+}
+
+export function parseAppPlatform(text: string): AppPlaform | undefined {
+    switch (text) {
+        case "win32":
+            return AppPlaform.Win32;
+        case "iOS":
+            return AppPlaform.iOS;
         default:
             return undefined;
     }

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -11,17 +11,17 @@ import * as debugInfo from "./debugInfo";
 import { getProcessIdsForPort } from "./port";
 import { startDetachedProcess  } from "./process";
 
-export enum AppPlatform {
+export enum AppType {
+    Desktop = "desktop",
+    Web = "web",
+}
+
+export enum Platform {
     Android = "android",
     Desktop = "desktop",
     iOS = "ios",
     MacOS = "macos",
     Win32 = "win32",
-    Web = "web",
-}
-
-export enum AppType {
-    Desktop = "desktop",
     Web = "web",
 }
 
@@ -63,30 +63,11 @@ export function parseAppType(text: string): AppType | undefined {
         case "desktop":
         case "macos":
         case "win32":
+        case "ios":
+        case "android":
             return AppType.Desktop;
         case "web":
             return AppType.Web;
-        case "ios":
-        case "android":
-            throw new Error(`Platform type ${text} not currently supported for debugging`);
-        default:
-            return undefined;
-    }
-}
-
-export function parseAppPlatform(text: string): AppPlatform | undefined {
-    switch (text) {
-        case "desktop":
-            return process.platform === "win32" ? AppPlatform.Win32 : AppPlatform.MacOS;
-        case "macos":
-            return AppPlatform.MacOS;
-        case "web":
-            return AppPlatform.Web;
-        case "win32":
-            return AppPlatform.Win32;
-        case "ios":
-        case "android":
-            throw new Error(`Platform type ${text} not currently supported for debugging`);
         default:
             return undefined;
     }
@@ -100,6 +81,29 @@ export function parseDebuggingMethod(text: string): DebuggingMethod | undefined 
             return DebuggingMethod.Proxy;
         default:
             return undefined;
+    }
+}
+
+export function parsePlatform(text: string): Platform | undefined {
+    if (text === AppType.Desktop) {
+        text = process.platform;
+    }
+    
+    switch (text) {
+        case "android":
+            return Platform.Android;
+        case "darwin":
+            return Platform.MacOS;
+        case "ios":
+            return Platform.iOS;
+        case "macos":
+            return Platform.MacOS;
+        case "web":
+            return Platform.Web;
+        case "win32":
+            return Platform.Win32;
+        default:
+            throw new Error(`The current platform is not supported: ${process.platform}`);
     }
 }
 


### PR DESCRIPTION
- Replace app-type with platform param
- If manifestPath is an empty string, determine the manifest path via the platform and new --prod option. This allows for the creation the correct manifest for SDX's where the manifest is copied to the dist folder as part of build
- Remove the --unload option for stop, which as far as I can tell is no longer used
- Tested this to ensure backwards compat and to ensure it can construct the manifest path correctly when the manifest is in the dist folder
