### PR TITLE
Enable dev-server to start an http port as well as https

### DIFF
--- a/packages/office-addin-test-helpers/package-lock.json
+++ b/packages/office-addin-test-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "office-addin-test-helpers",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -309,14 +309,6 @@
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
-        "encoding": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-            "requires": {
-                "iconv-lite": "~0.4.13"
-            }
-        },
         "end-of-stream": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -441,14 +433,6 @@
             "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
             "dev": true
         },
-        "iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            }
-        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -486,22 +470,14 @@
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
-        },
-        "isomorphic-fetch": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-            "requires": {
-                "node-fetch": "^1.0.1",
-                "whatwg-fetch": ">=0.10.0"
-            }
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -647,15 +623,6 @@
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
-        },
-        "node-fetch": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-            "requires": {
-                "encoding": "^0.1.11",
-                "is-stream": "^1.0.1"
-            }
         },
         "normalize-package-data": {
             "version": "2.5.0",
@@ -861,11 +828,6 @@
             "requires": {
                 "tslib": "^1.9.0"
             }
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
             "version": "5.6.0",
@@ -1080,11 +1042,6 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
-        },
-        "whatwg-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-            "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
         },
         "which": {
             "version": "1.3.1",

--- a/packages/office-addin-test-helpers/package.json
+++ b/packages/office-addin-test-helpers/package.json
@@ -15,8 +15,7 @@
         "Office Add-in"
     ],
     "dependencies": {
-        "es6-promise": "^4.2.6",
-        "isomorphic-fetch": "^2.2.1"
+        "es6-promise": "^4.2.6"
     },
     "devDependencies": {
         "@types/es6-collections": "^0.5.31",

--- a/packages/office-addin-test-helpers/src/defaults.ts
+++ b/packages/office-addin-test-helpers/src/defaults.ts
@@ -1,0 +1,2 @@
+export const httpPort: number = 4200;
+export const httpsPort: number = 4201;

--- a/packages/office-addin-test-helpers/src/testHelpers.ts
+++ b/packages/office-addin-test-helpers/src/testHelpers.ts
@@ -1,13 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+import * as defaults from "./defaults";
 import * as fetch from "isomorphic-fetch";
-export const defaultPort: number = 4201;
 
-export async function pingTestServer(port: number = defaultPort): Promise<object> {
+/**
+ * Ping the test server
+ * @param port Specifies port to ping
+ * @param useHttps Specifies protocol to use when pinging port (https or http)
+ */
+export async function pingTestServer(port: number = defaults.httpsPort, useHttps: boolean = true): Promise<object> {
     return new Promise<object>(async (resolve, reject) => {
         const serverResponse: any = {};
         try {
-            const pingUrl: string = `https://localhost:${port}/ping`;
+            const protocol = useHttps ? "https" : "http";
+            const pingUrl: string = `${protocol}://localhost:${port}/ping`
             const response = await fetch(pingUrl);
             serverResponse["status"] = response.status;
             const text = await response.text();
@@ -20,7 +26,12 @@ export async function pingTestServer(port: number = defaultPort): Promise<object
     });
 }
 
-export async function sendTestResults(data: object, port: number = defaultPort): Promise<boolean> {
+/**
+ * Ping the test server
+ * @param data Specifies data object containing test results
+ * @param port Specifies port to send data to
+ */
+export async function sendTestResults(data: object, port: number = defaults.httpsPort): Promise<boolean> {
     return new Promise<boolean>(async (resolve, reject) => {
         const json = JSON.stringify(data);
         const url: string = `https://localhost:${port}/results/`;
@@ -38,4 +49,3 @@ export async function sendTestResults(data: object, port: number = defaultPort):
         }
     });
 }
-

--- a/packages/office-addin-test-helpers/src/testHelpers.ts
+++ b/packages/office-addin-test-helpers/src/testHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 import * as defaults from "./defaults";
-import * as fetch from "isomorphic-fetch";
+import * as fetch from "node-fetch";
 
 /**
  * Ping the test server
@@ -13,7 +13,7 @@ export async function pingTestServer(port: number = defaults.httpsPort, useHttps
         const serverResponse: any = {};
         try {
             const protocol = useHttps ? "https" : "http";
-            const pingUrl: string = `${protocol}://localhost:${port}/ping`
+            const pingUrl: string = `${protocol}://localhost:${port}/ping`;
             const response = await fetch(pingUrl);
             serverResponse["status"] = response.status;
             const text = await response.text();

--- a/packages/office-addin-test-helpers/test/test.ts
+++ b/packages/office-addin-test-helpers/test/test.ts
@@ -3,25 +3,38 @@
 
 import * as assert from "assert";
 import * as mocha from "mocha";
+import * as defaults from "./../src/defaults";
 import * as testHelper from "../src/testHelpers";
 import { TestServer } from "../../office-addin-test-server";
 const port: number = 4201;
 const testServer = new TestServer(port);
-const promiseStartTestServer = testServer.startTestServer(true /* mochaTest */);
+const promiseStartTestServer = testServer.startTestServer();
 const testKey: string = "TestString";
 const testValue: string = "Office-Addin-Test-Infrastructure";
 const testValues: any = [];
 
 describe("Start test server, validate pingTestServer and sendTestResults methods and stop test server", function () {
+    this.beforeAll(async function () {
+        _setTLSRejectUnauthorized(false);
+    });
+
+    this.afterAll(async function () {
+        _setTLSRejectUnauthorized(false);
+    });
     describe("Setup test server", function () {
         it("Test server should have started", async function () {
             const startTestServer = await promiseStartTestServer;
             assert.equal(startTestServer, true);
         });
         it("Test server should have responded to ping", async function () {
-            const testServerResponse: object = await testHelper.pingTestServer(port);
-            assert.equal(testServerResponse["status"], 200);
-            assert.equal(testServerResponse["platform"], testServer.getPlatformName());
+            // ping test server on https port
+            const httpsTestServerResponse: object = await testHelper.pingTestServer(defaults.httpsPort);
+            assert.equal(httpsTestServerResponse["status"], 200);
+            assert.equal(httpsTestServerResponse["platform"], testServer.getPlatformName());
+            // ping test server on http port
+            const httpTestServerResponse: object = await testHelper.pingTestServer(defaults.httpPort, false /* useHttps */);
+            assert.equal(httpTestServerResponse["status"], 200);
+            assert.equal(httpTestServerResponse["platform"], testServer.getPlatformName());
         });
         it("Send data should have succeeded", async function () {
             const sendData: boolean = await _sendTestData();
@@ -43,5 +56,9 @@ async function _sendTestData(): Promise<boolean> {
     testData[valueKey] = testValue;
     testValues.push(testData);
 
-    return testHelper.sendTestResults(testValues, port);
+    return testHelper.sendTestResults(testValues, defaults.httpsPort);
+}
+
+function _setTLSRejectUnauthorized(on: boolean) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = on ? " 1" : "0";
 }

--- a/packages/office-addin-test-server/src/cli.ts
+++ b/packages/office-addin-test-server/src/cli.ts
@@ -4,18 +4,19 @@
 import * as commander from "commander";
 import { logErrorMessage } from "office-addin-cli";
 import * as commands from "./commands";
-import { defaultPort } from "./testServer";
+import * as defaults from "./defaults";
 
 commander.name("office-addin-test-server");
 commander.version(process.env.npm_package_version || "(version not available)");
 
 commander
     .command("start")
-    .option(`-p --port [port number]", "Port number must be between 0 - 65535. Default: ${defaultPort}`)
+    .option(`--https [port number]", "Port number must be between 0 - 65535. Default: ${defaults.httpsPort}`)
+    .option(`--http [port number]", "Port number must be between 0 - 65535. Default: ${defaults.httpPort}`)
     .action(commands.start);
 
 // if the command is not known, display an error
-commander.on("command:*", function() {
+commander.on("command:*", function () {
     logErrorMessage(`The command syntax is not valid.\n`);
     process.exitCode = 1;
     commander.help();

--- a/packages/office-addin-test-server/src/commands.ts
+++ b/packages/office-addin-test-server/src/commands.ts
@@ -3,15 +3,17 @@
 
 import * as commnder from "commander";
 import { parseNumber } from "office-addin-cli";
-import { defaultPort, TestServer } from "./testServer";
+import * as defaults from "./defaults";
+import { TestServer } from "./testServer";
 
 export async function start(command: commnder.Command) {
-    const testServerPort: number = (command.port !== undefined) ? parseTestServerPort(command.port) : defaultPort;
-    const testServer = new TestServer(testServerPort);
+    const httpPort: number = (command.http !== undefined) ? parseTestServerPort(command.http) : defaults.httpPort;
+    const httpsPort: number = (command.https !== undefined) ? parseTestServerPort(command.https) : defaults.httpsPort;
+    const testServer = new TestServer(httpsPort, httpPort);
     const serverStarted: boolean = await testServer.startTestServer();
 
     if (serverStarted) {
-        console.log(`Server started successfully on port ${testServerPort}`);
+        console.log(`Server started successfully on port ${httpsPort} and ${httpPort}`);
     } else {
         console.log("Server failed to start");
     }

--- a/packages/office-addin-test-server/src/defaults.ts
+++ b/packages/office-addin-test-server/src/defaults.ts
@@ -1,0 +1,2 @@
+export const httpPort: number = 4200;
+export const httpsPort: number = 4201;


### PR DESCRIPTION
- This allows for jest/mocha test to ping the http port to ensure the server is running while at the same time allowing foran https port to run that can be used for taskpane apps to communicate with
- Update tests as neccessary