### PR TITLE
add script to update latest dist-tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "lerna run build",
-    "dist-tags": "lerna exec npm dist-tag ls --stream",
+    "dist-tags": "lerna exec --concurrency 1 --no-sort --stream npm dist-tag ls",
     "postinstall": "lerna bootstrap",
     "publish:next": "lerna publish --dist-tag next",
     "test": "lerna run test",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "scripts": {
     "build": "lerna run build",
-    "npm-dist-tags": "lerna exec npm dist-tag ls --stream",
+    "dist-tags": "lerna exec npm dist-tag ls --stream",
     "postinstall": "lerna bootstrap",
     "publish:next": "lerna publish --dist-tag next",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "update-latest-dist-tags": "lerna exec --concurrency 1 --no-sort --stream  for /f \"usebackq\" %a in (`npm view . name`) do @for /f \"usebackq\" %b in (`npm view . dist-tags.next`) do @npm dist-tag add %a@%b"
   },
   "devDependencies": {
     "lerna": "^3.16.4"


### PR DESCRIPTION
Add a script which can update the latest dist-tag for the packages to the value of the next dist-tag.

To publish updated packages, the process becomes:

1. Use `npm run publish:next` to publish the packages to NPM using the "next" dist-tag.
2. Validate the packages published to the next dist-tag.
3. Use `npm run update-latest-dist-tags` to update the "latest" dist-tag to the value of the "next" dist-tag.