### PR TITLE
Update docs URLs

### DIFF
--- a/packages/custom-functions-metadata/src/testfunctions.ts
+++ b/packages/custom-functions-metadata/src/testfunctions.ts
@@ -3,7 +3,7 @@
  * @param {number} first - the first number
  * @param {number} [second]
  * @param {number} [optional] - an optional number
- * @helpUrl https://dev.office.com
+ * @helpUrl https://docs.microsoft.com/office/dev/add-ins
  * @CustomFunction
  * @notfound test123
  * @volatile

--- a/packages/custom-functions-metadata/test/src/test.ts
+++ b/packages/custom-functions-metadata/test/src/test.ts
@@ -29,7 +29,7 @@ describe("verify json created in file by typescript", function() {
             assert.strictEqual(j.functions[0].id, "ADD", "id not created properly");
             assert.strictEqual(j.functions[0].name, "ADD", "name not created properly");
             assert.strictEqual(j.functions[0].description, "Test comments", "description not created properly");
-            assert.strictEqual(j.functions[0].helpUrl, "https://dev.office.com", "helpUrl not created properly");
+            assert.strictEqual(j.functions[0].helpUrl, "https://docs.microsoft.com/office/dev/add-ins", "helpUrl not created properly");
             assert.strictEqual(j.functions[0].parameters[0].name, "first", "parameter name not created properly");
             assert.strictEqual(j.functions[0].parameters[0].description, "the first number", "description not created properly");
             assert.strictEqual(j.functions[0].parameters[0].type, "number", "type not created properly");

--- a/packages/custom-functions-metadata/test/typescript/testfunctions.ts
+++ b/packages/custom-functions-metadata/test/typescript/testfunctions.ts
@@ -5,7 +5,7 @@
  * Test comments
  * @param {number} first - the first number
  * @param {number} second 
- * @helpUrl https://dev.office.com
+ * @helpUrl https://docs.microsoft.com/office/dev/add-ins
  * @customfunction
  * @notfound test123
  * @volatile

--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -104,7 +104,7 @@ function logManifestValidationSupportedProducts(products: ManifestValidationProd
       for (const productTitle of productTitles) {
         console.log(`  - ${productTitle}`);
       }
-      console.log(`Important: This analysis is based on the requirements specified in your manifest and does not account for any runtime JavaScript calls within your add-in. For information about which API sets and features are supported on each platform, see Office Add-in host and platform availability. (https://dev.office.com/add-in-availability).\n`);
+      console.log(`Important: This analysis is based on the requirements specified in your manifest and does not account for any runtime JavaScript calls within your add-in. For information about which API sets and features are supported on each platform, see Office Add-in host and platform availability. (https://docs.microsoft.com/office/dev/add-ins/overview/office-add-in-availability).\n`);
       console.log(`*This does not include mobile apps. You can opt-in to support mobile apps when you submit your add-in.`);
     }
   }

--- a/packages/office-addin-manifest/test/manifests/ScriptLab-v1.3.2.0.manifest.xml
+++ b/packages/office-addin-manifest/test/manifests/ScriptLab-v1.3.2.0.manifest.xml
@@ -35,7 +35,7 @@
   <AppDomains>
     <AppDomain>https://github.com</AppDomain>
     <AppDomain>https://stackoverflow.com</AppDomain>
-    <AppDomain>https://dev.office.com</AppDomain>
+    <AppDomain>https://docs.microsoft.com</AppDomain>
     <AppDomain>https://localhost:3000</AppDomain>
     <AppDomain>https://localhost:3200</AppDomain>
     <AppDomain>https://script-lab.azureedge.net</AppDomain>


### PR DESCRIPTION
The `dev.office.com` site was deprecated a while back; Office Add-ins docs now reside on the `docs.microsoft.com` site. This PR updates URLs accordingly.