### PR TITLE
Fixes Issue 518

### DIFF
--- a/packages/office-addin-sso/src/commands.ts
+++ b/packages/office-addin-sso/src/commands.ts
@@ -60,7 +60,8 @@ export async function configureSSO(manifestPath: string) {
                 console.log('Granting admin consent');
                 await configure.grantAdminContent(applicationJson);
                 // Check to set if SharePoint reply urls are set for tenant. If not, set them
-                const setSharePointReplyUrls: boolean = await configure.setSharePointTenantReplyUrls();
+                const tenantName: string = applicationJson['publisherDomain'].substr(0, applicationJson['publisherDomain'].indexOf('.'));
+                const setSharePointReplyUrls: boolean = await configure.setSharePointTenantReplyUrls(tenantName);
                 if (setSharePointReplyUrls) {
                     console.log('Set SharePoint reply urls for tenant');
                 }

--- a/packages/office-addin-sso/src/configure.ts
+++ b/packages/office-addin-sso/src/configure.ts
@@ -205,7 +205,7 @@ export async function setSignInAudience(applicationJson: Object):Promise<void> {
     }
 }
 
-export async function setSharePointTenantReplyUrls(): Promise<boolean> {
+export async function setSharePointTenantReplyUrls(tenantName: string): Promise<boolean> {
     try {
         let servicePrinicipaObjectlId = "";
         let setReplyUrls: boolean = true;
@@ -213,8 +213,6 @@ export async function setSharePointTenantReplyUrls(): Promise<boolean> {
 
         // Get tenant name and construct SharePoint SSO reply urls with tenant name
         let azRestCommand: string = fs.readFileSync(defaults.azRestGetOrganizationDetailsCommandPath, 'utf8');
-        const tenantDetails: any = await promiseExecuteCommand(azRestCommand);
-        const tenantName: string = tenantDetails.value[0].displayName
         const oneDriveReplyUrl: string = `https://${tenantName}-my.sharepoint.com/_forms/singlesignon.aspx`;
         const sharePointReplyUrl: string = `https://${tenantName}.sharepoint.com/_forms/singlesignon.aspx`;
 


### PR DESCRIPTION
- setSharePointTenantReplyUrls was failing because it was using the tenant displayName, which can have spaces in it, rather than the actual tenant name
- the fix is to extract the tenant name from the application publisherDomain property and pass it to setSharePointTenantReplyUrls