### PR TITLE
workaround lerna bootstrap issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "lerna run build",
     "dist-tags": "lerna exec --concurrency 1 --no-sort --stream npm dist-tag ls",
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna exec --concurrency 1 --stream npm install && lerna bootstrap",
     "publish:next": "lerna publish --dist-tag next",
     "test": "lerna run test",
     "update-latest-dist-tags": "lerna exec --concurrency 1 --no-sort --stream  for /f \"usebackq\" %a in (`npm view . name`) do @for /f \"usebackq\" %b in (`npm view . dist-tags.next`) do @npm dist-tag add %a@%b",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "lerna run build",
     "dist-tags": "lerna exec --concurrency 1 --no-sort --stream npm dist-tag ls",
-    "postinstall": "lerna exec --concurrency 1 --stream npm install && lerna bootstrap",
+    "postinstall": "lerna exec --concurrency 1 --stream npm install & lerna bootstrap",
     "publish:next": "lerna publish --dist-tag next",
     "test": "lerna run test",
     "update-latest-dist-tags": "lerna exec --concurrency 1 --no-sort --stream  for /f \"usebackq\" %a in (`npm view . name`) do @for /f \"usebackq\" %b in (`npm view . dist-tags.next`) do @npm dist-tag add %a@%b",


### PR DESCRIPTION
For a clean git repository, running "lerna bootstrap" is failing to link
packages in this repository. Running "npm ls" in "packages\office-addin-manifest" will
have UNMET dependencies for office-addin-cli and office-addin-usage-data.

I can consistently reproduce this, and even going back to older versions of lerna do not resolve it.

The only reliable fix I have found, is to run "npm install" for each of the packages after the "npm install" in the root, and then afterward run "lerna bootstrap".

This updates the "postinstall" command to do that.