### PR TITLE
Create install script that install dependencies for each package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "lerna run build",
     "dist-tags": "lerna exec --concurrency 1 --no-sort --stream npm dist-tag ls",
+    "install": "lerna exec --concurrency 1 --stream -- npm install --no-fund --no-optional",
     "postinstall": "lerna bootstrap",
     "publish:next": "lerna publish --dist-tag next",
     "test": "lerna run test",


### PR DESCRIPTION
There is an apparent bug in lerna that causes the sub-packages to not have their dependencies fully installed when running "npm install" at root of Office-Addin-Scripts and is causing our CI loop jobs to fail. The proposed fix is to create a new npm intall script that will independently do an npm install for each sub-package