### PR TITLE
Address recent drop in usage data because usagelevel set to off

### DIFF
--- a/packages/office-addin-usage-data/src/defaults.ts
+++ b/packages/office-addin-usage-data/src/defaults.ts
@@ -7,3 +7,12 @@ import * as path from "path";
 export const usageDataJsonFilePath: string = path.join(os.homedir(), "/office-addin-usage-data.json");
 export const groupName = "office-addin-usage-data";
 export const instrumentationKeyForOfficeAddinCLITools = "de0d9e7c-1f46-4552-bc21-4e43e489a015";
+// Office-Addin-Scripts packages currently sending usage data
+export const officeAddinScriptsPackages: string[] = [
+    "office-addin-debugging",
+    "office-addin-dev-certs",
+    "office-addin-lint",
+    "office-addin-manifest",
+    "office-addin-sso",
+    "office-addin-usage-data"
+]

--- a/packages/office-addin-usage-data/src/defaults.ts
+++ b/packages/office-addin-usage-data/src/defaults.ts
@@ -5,14 +5,6 @@ import * as os from "os";
 import * as path from "path";
 
 export const usageDataJsonFilePath: string = path.join(os.homedir(), "/office-addin-usage-data.json");
-export const groupName = "office-addin-usage-data";
-export const instrumentationKeyForOfficeAddinCLITools = "de0d9e7c-1f46-4552-bc21-4e43e489a015";
-// Office-Addin-Scripts packages currently sending usage data
-export const officeAddinScriptsPackages: string[] = [
-    "office-addin-debugging",
-    "office-addin-dev-certs",
-    "office-addin-lint",
-    "office-addin-manifest",
-    "office-addin-sso",
-    "office-addin-usage-data"
-]
+export const groupName: string = "office-addin-usage-data";
+export const instrumentationKeyForOfficeAddinCLITools: string = "de0d9e7c-1f46-4552-bc21-4e43e489a015";
+export const generatorOffice: string = "generator-office";

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -70,7 +70,7 @@ export class OfficeAddinUsageData {
         isForTesting: false,
         ...usageDataOptions
       };
-      
+
       if (this.options.instrumentationKey === undefined) {
         throw new Error("Instrumentation Key not defined - cannot create usage data object");
       }
@@ -85,13 +85,13 @@ export class OfficeAddinUsageData {
 
       if (!this.options.isForTesting && this.options.raisePrompt && jsonData.needToPromptForUsageData(this.options.groupName)) {
         this.usageDataOptIn();
-      } else {
-        // Don't write out office-addin-usage-data file for Office-Addin-Scripts packages
-        const isOfficeAddinScriptsPackage = defaults.officeAddinScriptsPackages.includes(this.options.projectName)
-          && this.options.instrumentationKey === defaults.instrumentationKeyForOfficeAddinCLITools
-        if (!isOfficeAddinScriptsPackage){
-          jsonData.writeUsageDataJsonData(this.options.groupName, this.options.usageDataLevel);
-        }
+      }
+
+      // Generator-office will not raise a prompt because the yeoman generator creates the prompt.  If the projectName
+      // is defaults.generatorOffice and a office-addin-usage-data file hasn't been written yet, write one out.
+      if (this.options.projectName === defaults.generatorOffice && jsonData.needToPromptForUsageData(this.options.groupName)
+        && this.options.instrumentationKey === defaults.instrumentationKeyForOfficeAddinCLITools) {
+        jsonData.writeUsageDataJsonData(this.options.groupName, this.options.usageDataLevel);
       }
 
       appInsights.setup(this.options.instrumentationKey)

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -86,7 +86,12 @@ export class OfficeAddinUsageData {
       if (!this.options.isForTesting && this.options.raisePrompt && jsonData.needToPromptForUsageData(this.options.groupName)) {
         this.usageDataOptIn();
       } else {
-        jsonData.writeUsageDataJsonData(this.options.groupName, this.options.usageDataLevel);
+        // Don't write out office-addin-usage-data file for Office-Addin-Scripts packages
+        const isOfficeAddinScriptsPackage = defaults.officeAddinScriptsPackages.includes(this.options.projectName)
+          && this.options.instrumentationKey === defaults.instrumentationKeyForOfficeAddinCLITools
+        if (!isOfficeAddinScriptsPackage){
+          jsonData.writeUsageDataJsonData(this.options.groupName, this.options.usageDataLevel);
+        }
       }
 
       appInsights.setup(this.options.instrumentationKey)
@@ -121,10 +126,10 @@ export class OfficeAddinUsageData {
       usageDataEvent.name = this.options.isForTesting ? `${eventName}-test` : eventName;
       try {
         for (const [key, [value, elapsedTime]] of Object.entries(data)) {
-          usageDataEvent.properties[key] = value; 
+          usageDataEvent.properties[key] = value;
           usageDataEvent.measurements[key + " durationElapsed"] = elapsedTime;
         }
-        
+
         this.usageDataClient.trackEvent(usageDataEvent);
         this.eventsSent++;
       } catch (err) {
@@ -271,8 +276,8 @@ export class OfficeAddinUsageData {
    */
   public sendUsageDataSuccessEvent(method: string, data: object = {}) {
     this.sendUsageDataEvent({
-      Succeeded: true, 
-      Method: method, 
+      Succeeded: true,
+      Method: method,
       ...data
     });
   }
@@ -285,10 +290,10 @@ export class OfficeAddinUsageData {
   public sendUsageDataEvent(data: object = {}) {
     if (this.getUsageDataLevel() === UsageDataLevel.on) {
       try {
-        let eventTelemetryObj= new appInsights.Contracts.EventData();
+        let eventTelemetryObj = new appInsights.Contracts.EventData();
         eventTelemetryObj.name = this.options.isForTesting ? `${this.options.projectName}-test` : this.options.projectName;
         eventTelemetryObj.properties = {
-          ...this.defaultData, 
+          ...this.defaultData,
           ...data
         };
         this.usageDataClient.trackEvent(eventTelemetryObj);
@@ -315,9 +320,9 @@ export class OfficeAddinUsageData {
           properties: {}
         };
         Object.entries({
-          Succeeded: false, 
-          Method: method, 
-          ...this.defaultData, 
+          Succeeded: false,
+          Method: method,
+          ...this.defaultData,
           ...data
         }).forEach((entry) => {
           exceptionTelemetryObj.properties[entry[0]] = JSON.stringify(entry[1]);

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -83,15 +83,15 @@ export class OfficeAddinUsageData {
         this.options.usageDataLevel = jsonData.readUsageDataLevel(this.options.groupName);
       }
 
-      if (!this.options.isForTesting && this.options.raisePrompt && jsonData.needToPromptForUsageData(this.options.groupName)) {
-        this.usageDataOptIn();
-      }
-
       // Generator-office will not raise a prompt because the yeoman generator creates the prompt.  If the projectName
       // is defaults.generatorOffice and a office-addin-usage-data file hasn't been written yet, write one out.
-      if (this.options.projectName === defaults.generatorOffice && jsonData.needToPromptForUsageData(this.options.groupName)
-        && this.options.instrumentationKey === defaults.instrumentationKeyForOfficeAddinCLITools) {
+      if (this.options.projectName === defaults.generatorOffice && this.options.instrumentationKey === defaults.instrumentationKeyForOfficeAddinCLITools
+        && jsonData.needToPromptForUsageData(this.options.groupName)) {
         jsonData.writeUsageDataJsonData(this.options.groupName, this.options.usageDataLevel);
+      }
+
+      if (!this.options.isForTesting && this.options.raisePrompt && jsonData.needToPromptForUsageData(this.options.groupName)) {
+        this.usageDataOptIn();
       }
 
       appInsights.setup(this.options.instrumentationKey)


### PR DESCRIPTION
- The fix is to ensure office-addin-scripts packages don't write out the office-addin-usage-data file before Yo Office does
- Created an array of office-addin-scripts packages currently consuming office-addin-usage-data package and check if the project name is contained in that array during object construction.  If it is, then don't write out the office-addin-usage-data file.
- Also fixed some formatting issues

Yo office imports other packages such as office-addin-manifest, which when loaded as part of an import, invoke the following to create a new usageData object:
export const usageDataObject: usageData.OfficeAddinUsageData = new usageData.OfficeAddinUsageData({
    projectName: "office-addin-manifest",
    instrumentationKey:  usageData.instrumentationKeyForOfficeAddinCLITools,
    raisePrompt: false
});

In the constructor for the office-addin-usage-data, we have the following bit of code:

      if (!this.options.isForTesting && this.options.raisePrompt && jsonData.needToPromptForUsageData(this.options.groupName)) {
        this.usageDataOptIn();
      } else {
        jsonData.writeUsageDataJsonData(this.options.groupName, this.options.usageDataLevel);
      }
Because raisePrompt is set to false, we end up calling jsonData.writeUsageDataJsonData with the usageDataLevel turned to off, and write out the office-addin-usage-data file with the setting. Once this file is written, yo office will see it's written and use these settings moving forward.