### PR TITLE
Fixes issue #290 - Application Insights errors

### DIFF
--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -94,11 +94,13 @@ export class OfficeAddinUsageData {
         this.usageDataOptIn();
       }
 
-      appInsights.setup(this.options.instrumentationKey)
-        .setAutoCollectExceptions(false)
-        .start();
-      this.usageDataClient = appInsights.defaultClient;
-      this.removeApplicationInsightsSensitiveInformation();
+      if (this.options.usageDataLevel === "on") {
+        appInsights.setup(this.options.instrumentationKey)
+          .setAutoCollectExceptions(false)
+          .start();
+        this.usageDataClient = appInsights.defaultClient;
+        this.removeApplicationInsightsSensitiveInformation();
+      }
     } catch (err) {
       throw new Error(err);
     }

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -94,7 +94,7 @@ export class OfficeAddinUsageData {
         this.usageDataOptIn();
       }
 
-      if (this.options.usageDataLevel === "on") {
+      if (this.options.usageDataLevel === UsageDataLevel.on) {
         appInsights.setup(this.options.instrumentationKey)
           .setAutoCollectExceptions(false)
           .start();


### PR DESCRIPTION
- Customers with port 443 turned off for outgoing traffic, are hitting an AppInsights.Sender error even when usage data is set to "off".  The reason for this is that we still call the setup method method for appInsights, which makes and https call, even if office-addin-usage-data is set to off.
- The fix is to only call the setup method when office-addin-usage-data usageDataLevel is set to true
- I verifed locally that with port 443 blocked for outgoing traffic and usage data set to off, we no longer hit the AppInsignts.Sender error