### PR TITLE
Fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4766,9 +4766,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-fetch-npm": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "root",
   "private": true,
   "scripts": {
+    "audit": "npm audit -- audit-level=critical & lerna exec --concurrency 1 --no-sort --stream npm audit -- --audit-level=critical",
+    "audit:fix": "npm audit fix & lerna exec --concurrency 1 --no-sort --stream npm audit fix",
     "build": "lerna run build",
     "dist-tags": "lerna exec --concurrency 1 --no-sort --stream npm dist-tag ls",
     "postinstall": "lerna bootstrap",

--- a/packages/custom-functions-metadata-plugin/package-lock.json
+++ b/packages/custom-functions-metadata-plugin/package-lock.json
@@ -2136,9 +2136,9 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-libs-browser": {
       "version": "2.2.1",

--- a/packages/custom-functions-metadata/package-lock.json
+++ b/packages/custom-functions-metadata/package-lock.json
@@ -1710,9 +1710,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/packages/office-addin-cli/package-lock.json
+++ b/packages/office-addin-cli/package-lock.json
@@ -908,9 +908,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/packages/office-addin-cli/package.json
+++ b/packages/office-addin-cli/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "commander": "^2.20.3",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",

--- a/packages/office-addin-debugging/package-lock.json
+++ b/packages/office-addin-debugging/package-lock.json
@@ -1429,9 +1429,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.9.2",

--- a/packages/office-addin-debugging/package.json
+++ b/packages/office-addin-debugging/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "child_process": "^1.0.2",
     "commander": "^2.20.3",
-    "node-fetch": "^2.2.0",
+    "node-fetch": "^2.6.1",
     "office-addin-cli": "^1.0.12",
     "office-addin-dev-certs": "^1.5.4",
     "office-addin-dev-settings": "^1.8.5",

--- a/packages/office-addin-dev-certs/package-lock.json
+++ b/packages/office-addin-dev-certs/package-lock.json
@@ -124,6 +124,17 @@
         "picomatch": "^2.0.4"
       }
     },
+    "applicationinsights": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.7.tgz",
+      "integrity": "sha512-+HENzPBdSjnWL9mc+9o+j9pEaVNI4WsH5RNvfmRLfwQYvbJumcBi4S5bUzclug5KCcFP0S4bYJOmm9MV3kv2GA==",
+      "requires": {
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
+        "diagnostic-channel": "0.3.1",
+        "diagnostic-channel-publishers": "0.4.1"
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -144,6 +155,23 @@
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -282,6 +310,16 @@
         }
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -333,6 +371,15 @@
         }
       }
     },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
+    },
     "date-fns": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
@@ -363,11 +410,32 @@
         "object-keys": "^1.0.12"
       }
     },
+    "diagnostic-channel": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+      "integrity": "sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==",
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.1.tgz",
+      "integrity": "sha512-NpZ7IOVUfea/kAx4+ub4NIYZyRCSymjXM5BZxnThs3ul9gAKqjm7J8QDDQW3Ecuo2XxjNLoWLeKmrPUWKNZaYw=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -925,6 +993,11 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-forge": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
@@ -980,6 +1053,37 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "office-addin-cli": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.12.tgz",
+      "integrity": "sha512-3k3RSH1I0rGzfDuvwoNmZ9sAude6CehlKx9XdRurqAHpVvxNEBe+5pOrMFs8fWU9MIXoowvtYVDsZtVs1qpHUw==",
+      "requires": {
+        "commander": "^2.20.3",
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "office-addin-usage-data": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.1.6.tgz",
+      "integrity": "sha512-/5hRuoAge4i5WlT8eCu8RlD1MofT/Fd6VGFzsNWTTY0/ixvYk8Dgiz/kUDkZn41tCASFRJz0Tw8uebbgF6t3cw==",
+      "requires": {
+        "applicationinsights": "^1.7.3",
+        "commander": "^2.20.3",
+        "office-addin-cli": "^0.2.8",
+        "readline-sync": "^1.4.9"
+      },
+      "dependencies": {
+        "office-addin-cli": {
+          "version": "0.2.18",
+          "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.18.tgz",
+          "integrity": "sha512-N6fGjjbnGhCa/XDhx76XFLKzrz2oce1aCzBtlPvIbF2VcHyvmIkHsI8PlH9B8kP/zLRQz5nSGjFidh+5bwOvmw==",
+          "requires": {
+            "commander": "^2.19.0",
+            "node-fetch": "^2.3.0"
+          }
+        }
       }
     },
     "once": {
@@ -1098,6 +1202,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1137,14 +1246,18 @@
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-      "dev": true
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "sinon": {
       "version": "7.5.0",
@@ -1231,6 +1344,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "string-width": {
       "version": "2.1.1",

--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -1291,9 +1291,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.4.0",

--- a/packages/office-addin-lint/package-lock.json
+++ b/packages/office-addin-lint/package-lock.json
@@ -1441,9 +1441,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/packages/office-addin-manifest/package-lock.json
+++ b/packages/office-addin-manifest/package-lock.json
@@ -103,6 +103,17 @@
         "picomatch": "^2.0.4"
       }
     },
+    "applicationinsights": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.7.tgz",
+      "integrity": "sha512-+HENzPBdSjnWL9mc+9o+j9pEaVNI4WsH5RNvfmRLfwQYvbJumcBi4S5bUzclug5KCcFP0S4bYJOmm9MV3kv2GA==",
+      "requires": {
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
+        "diagnostic-channel": "0.3.1",
+        "diagnostic-channel-publishers": "0.4.1"
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -116,6 +127,23 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
       }
     },
     "asynckit": {
@@ -254,6 +282,16 @@
         }
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -312,6 +350,15 @@
         }
       }
     },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
+    },
     "copy-dir": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-0.4.0.tgz",
@@ -357,11 +404,32 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "diagnostic-channel": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+      "integrity": "sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==",
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.1.tgz",
+      "integrity": "sha512-NpZ7IOVUfea/kAx4+ub4NIYZyRCSymjXM5BZxnThs3ul9gAKqjm7J8QDDQW3Ecuo2XxjNLoWLeKmrPUWKNZaYw=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -860,9 +928,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -914,6 +982,37 @@
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
+      }
+    },
+    "office-addin-cli": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.12.tgz",
+      "integrity": "sha512-3k3RSH1I0rGzfDuvwoNmZ9sAude6CehlKx9XdRurqAHpVvxNEBe+5pOrMFs8fWU9MIXoowvtYVDsZtVs1qpHUw==",
+      "requires": {
+        "commander": "^2.20.3",
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "office-addin-usage-data": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.1.6.tgz",
+      "integrity": "sha512-/5hRuoAge4i5WlT8eCu8RlD1MofT/Fd6VGFzsNWTTY0/ixvYk8Dgiz/kUDkZn41tCASFRJz0Tw8uebbgF6t3cw==",
+      "requires": {
+        "applicationinsights": "^1.7.3",
+        "commander": "^2.20.3",
+        "office-addin-cli": "^0.2.8",
+        "readline-sync": "^1.4.9"
+      },
+      "dependencies": {
+        "office-addin-cli": {
+          "version": "0.2.18",
+          "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.18.tgz",
+          "integrity": "sha512-N6fGjjbnGhCa/XDhx76XFLKzrz2oce1aCzBtlPvIbF2VcHyvmIkHsI8PlH9B8kP/zLRQz5nSGjFidh+5bwOvmw==",
+          "requires": {
+            "commander": "^2.19.0",
+            "node-fetch": "^2.3.0"
+          }
+        }
       }
     },
     "once": {
@@ -1032,6 +1131,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1092,14 +1196,18 @@
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-      "dev": true
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -1160,6 +1268,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "string-width": {
       "version": "2.1.1",

--- a/packages/office-addin-manifest/package.json
+++ b/packages/office-addin-manifest/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "commander": "^2.20.3",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "office-addin-cli": "^1.0.12",
     "office-addin-usage-data": "^1.1.6",
     "path": "^0.12.7",

--- a/packages/office-addin-node-debugger/package-lock.json
+++ b/packages/office-addin-node-debugger/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.4.0",

--- a/packages/office-addin-node-debugger/package.json
+++ b/packages/office-addin-node-debugger/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "child_process": "^1.0.2",
     "commander": "^2.20.3",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "office-addin-usage-data": "^1.1.6",
     "ws": "^6.2.1"
   },

--- a/packages/office-addin-sso/package-lock.json
+++ b/packages/office-addin-sso/package-lock.json
@@ -2949,9 +2949,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.9.2",

--- a/packages/office-addin-sso/package.json
+++ b/packages/office-addin-sso/package.json
@@ -29,7 +29,7 @@
     "http-errors": "~1.6.3",
     "jquery": "^3.5.1",
     "morgan": "1.9.1",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "office-addin-usage-data": "^1.1.6",
     "pug": "^2.0.4"
   },

--- a/packages/office-addin-test-server/package-lock.json
+++ b/packages/office-addin-test-server/package-lock.json
@@ -1244,9 +1244,9 @@
             }
         },
         "node-fetch": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "node-forge": {
             "version": "0.9.2",

--- a/packages/office-addin-usage-data/package-lock.json
+++ b/packages/office-addin-usage-data/package-lock.json
@@ -130,7 +130,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -173,7 +173,7 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
@@ -281,7 +281,7 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
@@ -292,7 +292,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -339,7 +339,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -432,7 +432,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -477,7 +477,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -540,7 +540,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
@@ -564,7 +564,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -580,7 +580,7 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
@@ -613,13 +613,13 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
@@ -658,7 +658,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -887,9 +887,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -954,7 +954,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -987,7 +987,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -997,13 +997,13 @@
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -1021,13 +1021,13 @@
     },
     "pify": {
       "version": "3.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/pify/-/pify-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "read-pkg": {
       "version": "4.0.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/read-pkg/-/read-pkg-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
       "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
       "dev": true,
       "requires": {
@@ -1052,7 +1052,7 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
@@ -1096,7 +1096,7 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -1161,13 +1161,13 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "stack-chain": {
       "version": "1.3.7",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/stack-chain/-/stack-chain-1.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
       "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "string-width": {
@@ -1211,7 +1211,7 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
@@ -1331,7 +1331,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -1385,7 +1385,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },


### PR DESCRIPTION
This adds scripts so that you can run `npm run audit` and `npm run audit:fix` to use npm to audit and fix all packages. Note that `npm audit` and `npm audit fix` will just do the root lerna package. Take care to use the correct syntax.

This also fixes the existing vulnerabilities.