### PR TITLE
Exit non zero if manifest is invalid

### DIFF
--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -149,6 +149,8 @@ export async function validate(manifestPath: string, command: commander.Command)
         }
       }
     }
+
+    process.exitCode = validation.isValid ? 0 : 1;
   } catch (err) {
     logErrorMessage(err);
   }


### PR DESCRIPTION
This allows a project to have a devDependency on this project and add a call to
`office-addin-manifest validate manifest.xml` (e.g. during `npm test`) and check the error code in a test,
so if someone changes the manifest in the project you can get immediate feedback
of a broken manifest.