### PR TITLE
Typos in dev-certs ReadMe causing people to run incorrect commands

### DIFF
--- a/packages/office-addin-dev-certs/README.md
+++ b/packages/office-addin-dev-certs/README.md
@@ -26,7 +26,7 @@ Creates an SSL certificate for "localhost" signed by a developer CA certificate 
 
 Syntax:
 
-`office addin-dev-certs install [options]`
+`office-addin-dev-certs install [options]`
 
 Options:
 
@@ -45,7 +45,7 @@ Verify the certificate.
 
 Syntax:
 
-`office addin-dev-certs verify`
+`office-addin-dev-certs verify`
  
 #
 
@@ -54,7 +54,7 @@ Uninstall the certificate.
 
 Syntax:
 
-`office addin-dev-certs uninstall [options]`
+`office-addin-dev-certs uninstall [options]`
 
 Options:
 


### PR DESCRIPTION
- An internal Microsoft person was running into problems when following our ReadMe instructions for office-addin-dev-certs commands