### PR TITLE
Update import ref for xregexp

### DIFF
--- a/packages/custom-functions-metadata/src/generate.ts
+++ b/packages/custom-functions-metadata/src/generate.ts
@@ -3,7 +3,7 @@
 
 import * as fs from "fs";
 import * as ts from "typescript";
-import * as XRegExp from "xregexp";
+import XRegExp = require("xregexp");
 
 export interface ICustomFunctionsMetadata {
   functions: IFunction[];


### PR DESCRIPTION
Import for default xregexp wasn't working when package was consumed by other project.  This import statement works better.