### PR TITLE
Add ability to read application secret from project .ENV file

### DIFF
--- a/packages/office-addin-sso/src/server.ts
+++ b/packages/office-addin-sso/src/server.ts
@@ -44,9 +44,14 @@ export class SSOService {
 
     private async getSecret(isTest: boolean = false): Promise<void> {
         const manifestInfo = await manifest.readManifestFile(this.manifestPath);
-        const appSecret = getSecretFromCredentialStore(manifestInfo.displayName, isTest);
-        if (appSecret === '') {
-            const errorMessage: string = 'Call to getSecretFromCredentialStore returned empty string';
+        let appSecret: string = process.env.CLIENT_SECRET;
+
+        if (appSecret == "") {
+            appSecret = getSecretFromCredentialStore(manifestInfo.displayName, isTest);
+        }
+        
+        if (appSecret === "") {
+            const errorMessage: string = 'Could not find app secret in .ENV file or getSecretFromCredentialStore returned empty string';
             throw new Error(errorMessage);
         }
         process.env.secret = appSecret;


### PR DESCRIPTION
- We have been getting complaints about the portability of the add-in projects to other environments because we currenrtly rely on the application secret being stored locally on the same machine the add-in is running on.
- By being able to add the secret to the .ENV users can port the project over to other environments