### PR TITLE
Add url param for office-addin-manifest to skip icon check in validation service

### DIFF
--- a/packages/office-addin-manifest/package-lock.json
+++ b/packages/office-addin-manifest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-manifest",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -103,6 +103,17 @@
         "picomatch": "^2.0.4"
       }
     },
+    "applicationinsights": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.8.tgz",
+      "integrity": "sha512-B43D4t/taGP5quGviVSdFWqarhIlzyGSi5mfngjbXpR2Ed3VrikJGIr1i5UtGzvwWqEbfIF6i298GvjFaB8RFA==",
+      "requires": {
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
+        "diagnostic-channel": "0.3.1",
+        "diagnostic-channel-publishers": "0.4.2"
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -116,6 +127,23 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
       }
     },
     "asynckit": {
@@ -254,6 +282,16 @@
         }
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -304,6 +342,15 @@
         "yargs": "^13.3.0"
       }
     },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
+    },
     "copy-dir": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-0.4.0.tgz",
@@ -349,11 +396,32 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "diagnostic-channel": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+      "integrity": "sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==",
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.2.tgz",
+      "integrity": "sha512-gbt5BVjwTV1wnng0Xi766DVrRxSeGECAX8Qrig7tKCDfXW2SbK7bKY6A3tgGjk5BB50aXgVXIsbtQiYIkt57Mg=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -887,6 +955,44 @@
         "es-abstract": "^1.5.1"
       }
     },
+    "office-addin-cli": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.16.tgz",
+      "integrity": "sha512-rUkTpcTVkCiETaK67F1yWgxrxRe37+uwW6GwL7E1y2jmsj3lnrEDgiMpL1uOvuar1P6nXQ8vUrEPvVlL/2qHqw==",
+      "requires": {
+        "commander": "^6.2.0",
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "office-addin-usage-data": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.0.20.tgz",
+      "integrity": "sha512-Zx7HPYxsw1uyrcrudr1Dr0dgxNqSHABkSmwvz8OMIEnROfDG7zgQHXdavMMTgJqa0pOydH8JCxwaSS4QUGwm2w==",
+      "requires": {
+        "applicationinsights": "^1.7.3",
+        "commander": "^6.2.0",
+        "office-addin-cli": "^0.2.8",
+        "readline-sync": "^1.4.9"
+      },
+      "dependencies": {
+        "office-addin-cli": {
+          "version": "0.2.18",
+          "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-0.2.18.tgz",
+          "integrity": "sha512-N6fGjjbnGhCa/XDhx76XFLKzrz2oce1aCzBtlPvIbF2VcHyvmIkHsI8PlH9B8kP/zLRQz5nSGjFidh+5bwOvmw==",
+          "requires": {
+            "commander": "^2.19.0",
+            "node-fetch": "^2.3.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            }
+          }
+        }
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -994,6 +1100,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1041,14 +1152,18 @@
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-      "dev": true
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -1109,6 +1224,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "string-width": {
       "version": "2.1.1",

--- a/packages/office-addin-manifest/package-lock.json
+++ b/packages/office-addin-manifest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-manifest",
-  "version": "1.5.13",
+  "version": "1.5.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/office-addin-manifest/package.json
+++ b/packages/office-addin-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-manifest",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "Read and modify Office Add-in manifest files.",
   "main": "./lib/main.js",
   "scripts": {

--- a/packages/office-addin-manifest/package.json
+++ b/packages/office-addin-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-manifest",
-  "version": "1.5.13",
+  "version": "1.5.12",
   "description": "Read and modify Office Add-in manifest files.",
   "main": "./lib/main.js",
   "scripts": {

--- a/packages/office-addin-manifest/src/validate.ts
+++ b/packages/office-addin-manifest/src/validate.ts
@@ -71,7 +71,7 @@ export async function validateManifest(manifestPath: string): Promise<ManifestVa
         let response;
 
         try {
-            response = await fetch("https://validationgateway.omex.office.net/package/api/check",
+            response = await fetch("https://validationgateway.omex.office.net/package/api/check?gates=DisableIconDimensionValidation",
                 {
                     body: stream,
                     headers: {


### PR DESCRIPTION
Adds ?gates=DisableIconDimensionValidation to skip the localhost breaking change in our manifest validation service.

Bumps package version to 1.5.13