### PR TITLE
Add Edge Chromium documentation to Office-Addin-Dev-Settings

### DIFF
--- a/packages/office-addin-dev-settings/README.md
+++ b/packages/office-addin-dev-settings/README.md
@@ -3,17 +3,20 @@
 Provides the ability to configure developer settings for Office Add-ins.
 
 ## Command-Line Interface
-* [appcontainer](#appcontainer)
-* [clear](#clear)
-* [debugging](#debugging)
-* [live-reload](#live-reload)
-* [register](#register)
-* [registered](#registered)
-* [runtime-log](#runtime-log)
-* [sideload](#sideload)
-* [source-bundle-url](#source-bundle-url)
-* [unregister](#unregister)
-* [webview](#webview)
+- [Office-Addin-Dev-Settings](#office-addin-dev-settings)
+  - [Command-Line Interface](#command-line-interface)
+    - [appcontainer](#appcontainer)
+    - [clear](#clear)
+- [](#)
+    - [debugging](#debugging)
+    - [live-reload](#live-reload)
+    - [register](#register)
+    - [registered](#registered)
+    - [runtime-log](#runtime-log)
+    - [sideload](#sideload)
+    - [source-bundle-url](#source-bundle-url)
+    - [unregister](#unregister)
+    - [webview](#webview)
 
 #
 
@@ -256,6 +259,6 @@ Syntax:
 
 `manifest`: path to manifest file. 
 
-`runtime`: Office runtime to load (currently accepts 'ie', 'edge', or 'default'). 
+`runtime`: Office runtime to load (currently accepts 'ie', 'edge', 'edgechromium', or 'default'). 
 
 #

--- a/packages/office-addin-dev-settings/README.md
+++ b/packages/office-addin-dev-settings/README.md
@@ -252,10 +252,10 @@ Switches the webview runtime in Office for testing and development scenarios.
 
 Syntax:
 
-`office addin-dev-settings webview <manifest> <runtime>`
+`office addin-dev-settings webview <manifest> <web-view-type>`
 
 `manifest`: path to manifest file. 
 
-`runtime`: Office runtime to load (currently accepts 'ie', 'edge', 'edgechromium', or 'default'). 
+`runtime`: Office webview to load (currently accepts 'ie', 'edge' or 'edge-chromium, 'edge-legacy', or 'default'). 
 
 #

--- a/packages/office-addin-dev-settings/README.md
+++ b/packages/office-addin-dev-settings/README.md
@@ -3,20 +3,17 @@
 Provides the ability to configure developer settings for Office Add-ins.
 
 ## Command-Line Interface
-- [Office-Addin-Dev-Settings](#office-addin-dev-settings)
-  - [Command-Line Interface](#command-line-interface)
-    - [appcontainer](#appcontainer)
-    - [clear](#clear)
-- [](#)
-    - [debugging](#debugging)
-    - [live-reload](#live-reload)
-    - [register](#register)
-    - [registered](#registered)
-    - [runtime-log](#runtime-log)
-    - [sideload](#sideload)
-    - [source-bundle-url](#source-bundle-url)
-    - [unregister](#unregister)
-    - [webview](#webview)
+* [appcontainer](#appcontainer)
+* [clear](#clear)
+* [debugging](#debugging)
+* [live-reload](#live-reload)
+* [register](#register)
+* [registered](#registered)
+* [runtime-log](#runtime-log)
+* [sideload](#sideload)
+* [source-bundle-url](#source-bundle-url)
+* [unregister](#unregister)
+* [webview](#webview)
 
 #
 

--- a/packages/office-addin-dev-settings/README.md
+++ b/packages/office-addin-dev-settings/README.md
@@ -256,6 +256,6 @@ Syntax:
 
 `manifest`: path to manifest file. 
 
-`runtime`: Office webview to load (currently accepts 'ie', 'edge' or 'edge-chromium, 'edge-legacy', or 'default'). 
+`runtime`: Office webview to load ('edge' or 'edge-chromium, 'edge-legacy', 'ie', or 'default'). 
 
 #

--- a/packages/office-addin-dev-settings/src/cli.ts
+++ b/packages/office-addin-dev-settings/src/cli.ts
@@ -84,8 +84,8 @@ commander
     .action(commands.webView)
     .on("--help", () => {
         console.log("\nFor [web-view-type], choose one of the following values:\n");
-        console.log("\t'edgechromium' for Microsoft Edge (Chromium)");
-        console.log("\t'edge' for legacy Microsoft Edge");
+        console.log("\t'edge' or 'edge-chromium' for Microsoft Edge (Chromium)");
+        console.log("\t'edge-legacy' for the legacy Microsoft Edge (EdgeHTML)");
         console.log("\t'ie' for Internet Explorer 11");
         console.log("\t'default' to remove any preference");
         console.log("\nOmit [web-view-type] to see the current setting.");

--- a/packages/office-addin-dev-settings/src/cli.ts
+++ b/packages/office-addin-dev-settings/src/cli.ts
@@ -84,8 +84,8 @@ commander
     .action(commands.webView)
     .on("--help", () => {
         console.log("\nFor [web-view-type], choose one of the following values:\n");
-        console.log("\t'edgechromium' for the new Chromium-based Microsoft Edge");
-        console.log("\t'edge' for the older Microsoft Edge");
+        console.log("\t'edgechromium' for Microsoft Edge (Chromium)");
+        console.log("\t'edge' for legacy Microsoft Edge");
         console.log("\t'ie' for Internet Explorer 11");
         console.log("\t'default' to remove any preference");
         console.log("\nOmit [web-view-type] to see the current setting.");

--- a/packages/office-addin-dev-settings/src/cli.ts
+++ b/packages/office-addin-dev-settings/src/cli.ts
@@ -84,7 +84,8 @@ commander
     .action(commands.webView)
     .on("--help", () => {
         console.log("\nFor [web-view-type], choose one of the following values:\n");
-        console.log("\t'edge' for Microsoft Edge");
+        console.log("\t'edgechromium' for the new Chromium-based Microsoft Edge");
+        console.log("\t'edge' for the older Microsoft Edge");
         console.log("\t'ie' for Internet Explorer 11");
         console.log("\t'default' to remove any preference");
         console.log("\nOmit [web-view-type] to see the current setting.");

--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -244,12 +244,15 @@ export function parseWebViewType(webViewString?: string): devSettings.WebViewTyp
     case "internet explorer":
     case "internetexplorer":
       return devSettings.WebViewType.IE;
-    case "edge":
+    case "edgelegacy":
+    case "edge-legacy":
     case "spartan":
       return devSettings.WebViewType.Edge;
     case "edge chromium":
     case "edgechromium":
+    case "edge-chromium":
     case "anaheim":
+    case "edge":
       return devSettings.WebViewType.EdgeChromium;
     case "default":
     case "":


### PR DESCRIPTION
The actual code to enable webview switching to Edge Chromium already exists, this just adds the documentation to make it easy for devs to look up.