### PR TITLE
webview command: show a better name for the webview type

### DIFF
--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -423,10 +423,10 @@ export async function webView(manifestPath: string, webViewString?: string) {
       await devSettings.setWebView(manifest.id!, webViewType);
     }
 
-    console.log(webViewType
-      ? `The web view type is set to ${webViewType}.`
+    const webViewTypeName = devSettings.toWebViewTypeName(webViewType);
+    console.log(webViewTypeName
+      ? `The web view type is set to ${webViewTypeName}.`
       : "The web view type has not been set.");
-
   } catch (err) {
     logErrorMessage(err);
   }

--- a/packages/office-addin-dev-settings/src/dev-settings-windows.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-windows.ts
@@ -229,7 +229,7 @@ function toWebViewType(webViewString?: string): WebViewType | undefined {
 export function toWebViewTypeName(webViewType?: WebViewType): string | undefined {
   switch (webViewType) {
     case WebViewType.Edge:
-      return "legacy Microsoft Edge (EdgeHtml)";
+      return "legacy Microsoft Edge (EdgeHTML)";
     case WebViewType.EdgeChromium:
       return "Microsoft Edge (Chromium)";
     case WebViewType.IE:

--- a/packages/office-addin-dev-settings/src/dev-settings-windows.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-windows.ts
@@ -226,6 +226,19 @@ function toWebViewType(webViewString?: string): WebViewType | undefined {
   }
 }
 
+export function toWebViewTypeName(webViewType?: WebViewType): string | undefined {
+  switch (webViewType) {
+    case WebViewType.Edge:
+      return "legacy Microsoft Edge (EdgeHtml)";
+    case WebViewType.EdgeChromium:
+      return "Microsoft Edge (Chromium)";
+    case WebViewType.IE:
+      return "Microsoft Internet Explorer";
+    default:
+      return undefined;
+  }
+}
+
 export async function unregisterAddIn(addinId: string, manifestPath: string): Promise<void> {
   const key = new registry.RegistryKey(`${DeveloperSettingsRegistryKey}`);
 

--- a/packages/office-addin-dev-settings/src/dev-settings.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings.ts
@@ -10,6 +10,8 @@ import { platform } from "os";
 
 const defaultRuntimeLogFileName = "OfficeAddins.log.txt";
 
+export { toWebViewTypeName } from "./dev-settings-windows";
+
 export enum DebuggingMethod {
   Direct,
   Proxy,


### PR DESCRIPTION
Display the webview type name when viewing or setting the web view type.

The web view type is set to Microsoft Edge (Chromium).
The web view type is set to legacy Microsoft Edge (EdgeHTML).
The web view type is set to Microsoft Internet Explorer.

