### PR TITLE
Fix bug where Outlook exe path has a space in the path

### DIFF
--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -219,7 +219,11 @@ async function getOutlookExePath(): Promise<string | undefined> {
   try {
     const OutlookInstallPathRegistryKey: string = `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\OUTLOOK.EXE`;
     const key = new registry.RegistryKey(`${OutlookInstallPathRegistryKey}`);
-    const outlookExePath: string | undefined = await registry.getStringValue(key, "");
+    let outlookExePath: string | undefined = await registry.getStringValue(key, "");
+    
+    if (outlookExePath) {
+      outlookExePath = `"${outlookExePath}"`;
+    }
 
     return outlookExePath;
   } catch (err) {

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -219,11 +219,7 @@ async function getOutlookExePath(): Promise<string | undefined> {
   try {
     const OutlookInstallPathRegistryKey: string = `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\OUTLOOK.EXE`;
     const key = new registry.RegistryKey(`${OutlookInstallPathRegistryKey}`);
-    let outlookExePath: string | undefined = await registry.getStringValue(key, "");
-    
-    if (outlookExePath) {
-      outlookExePath = `"${outlookExePath}"`;
-    }
+    const outlookExePath: string | undefined = await registry.getStringValue(key, "");
 
     return outlookExePath;
   } catch (err) {
@@ -334,6 +330,10 @@ export async function sideloadAddIn(manifestPath: string, appType: AppType, app?
 
   if (sideloadFile) {
     if (app == OfficeApp.Outlook) {
+      // check to see if Outlook exe path contains spaces and escape the path if it does.
+      if (sideloadFile.indexOf(' ') >= 0){
+        sideloadFile = `"${sideloadFile}"`;
+      }
       startDetachedProcess(sideloadFile);
     } else {
       await open(sideloadFile, { wait: false });


### PR DESCRIPTION
- This addresses the scenario where the Outlook exe path that is to be lauched has a space in it.