### PR TITLE
validate command should throw error if manifest path isn't valid

### DIFF
--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -129,28 +129,31 @@ export async function modify(manifestPath: string, command: commander.Command) {
 
 export async function validate(manifestPath: string, command: commander.Command) {
   try {
-    const validation: ManifestValidation = await validateManifest(manifestPath);
-
-    if (validation.isValid) {
-      console.log("The manifest is valid.");
-    } else {
-      console.log("The manifest is not valid.");
-    }
-    console.log();
-
-    if (validation.report) {
-      logManifestValidationErrors(validation.report.errors);
-      logManifestValidationWarnings(validation.report.warnings);
-      logManifestValidationInfos(validation.report.notes);
+    const manifest: manifestInfo.ManifestInfo = await manifestInfo.readManifestFile(manifestPath);
+    if (manifest) {
+      const validation: ManifestValidation = await validateManifest(manifestPath);
 
       if (validation.isValid) {
-        if (validation.report.addInDetails) {
-          logManifestValidationSupportedProducts(validation.report.addInDetails.supportedProducts);
+        console.log("The manifest is valid.");
+      } else {
+        console.log("The manifest is not valid.");
+      }
+      console.log();
+  
+      if (validation.report) {
+        logManifestValidationErrors(validation.report.errors);
+        logManifestValidationWarnings(validation.report.warnings);
+        logManifestValidationInfos(validation.report.notes);
+  
+        if (validation.isValid) {
+          if (validation.report.addInDetails) {
+            logManifestValidationSupportedProducts(validation.report.addInDetails.supportedProducts);
+          }
         }
       }
+  
+      process.exitCode = validation.isValid ? 0 : 1;
     }
-
-    process.exitCode = validation.isValid ? 0 : 1;
   } catch (err) {
     logErrorMessage(err);
   }

--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -129,31 +129,28 @@ export async function modify(manifestPath: string, command: commander.Command) {
 
 export async function validate(manifestPath: string, command: commander.Command) {
   try {
-    const manifest: manifestInfo.ManifestInfo = await manifestInfo.readManifestFile(manifestPath);
-    if (manifest) {
-      const validation: ManifestValidation = await validateManifest(manifestPath);
+    const validation: ManifestValidation = await validateManifest(manifestPath);
+
+    if (validation.isValid) {
+      console.log("The manifest is valid.");
+    } else {
+      console.log("The manifest is not valid.");
+    }
+    console.log();
+
+    if (validation.report) {
+      logManifestValidationErrors(validation.report.errors);
+      logManifestValidationWarnings(validation.report.warnings);
+      logManifestValidationInfos(validation.report.notes);
 
       if (validation.isValid) {
-        console.log("The manifest is valid.");
-      } else {
-        console.log("The manifest is not valid.");
-      }
-      console.log();
-  
-      if (validation.report) {
-        logManifestValidationErrors(validation.report.errors);
-        logManifestValidationWarnings(validation.report.warnings);
-        logManifestValidationInfos(validation.report.notes);
-  
-        if (validation.isValid) {
-          if (validation.report.addInDetails) {
-            logManifestValidationSupportedProducts(validation.report.addInDetails.supportedProducts);
-          }
+        if (validation.report.addInDetails) {
+          logManifestValidationSupportedProducts(validation.report.addInDetails.supportedProducts);
         }
       }
-  
-      process.exitCode = validation.isValid ? 0 : 1;
     }
+
+    process.exitCode = validation.isValid ? 0 : 1;
   } catch (err) {
     logErrorMessage(err);
   }

--- a/packages/office-addin-manifest/src/validate.ts
+++ b/packages/office-addin-manifest/src/validate.ts
@@ -3,7 +3,7 @@
 
 import { createReadStream } from "fs";
 import fetch from "node-fetch";
-import { ManifestInfo, readManifestFile } from "./manifestInfo";
+import { readManifestFile } from "./manifestInfo";
 import { usageDataObject } from './defaults';
 
 export class ManifestValidationDetails {
@@ -102,8 +102,7 @@ export async function validateManifest(manifestPath: string): Promise<ManifestVa
                         break;
                 }
             }
-        }
-        
+        }        
         usageDataObject.sendUsageDataSuccessEvent("validateManifest");
 
         return validation;

--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -527,7 +527,7 @@ describe("Unit Tests", function() {
         }
         assert.strictEqual(result, `You need to specify something to change in the manifest.`);
       });
-      it.skip("should handle an invalid manifest file path", async function() {
+      it("should handle an invalid manifest file path", async function() {
         // call  modify, specifying an invalid manifest path with a valid guid and displayName
         const invalidManifest = path.normalize(`${manifestTestFolder}/foo/manifest.xml`);
         const testGuid = uuid.v1();
@@ -559,8 +559,9 @@ describe("Unit Tests", function() {
       it("invalid manifest path", async function() {
         this.timeout(6000);
         let result: string = "";
+        const invalidManifestPath = path.normalize(`${manifestTestFolder}/foo/manifest.xml`);
         try {
-          await validateManifest("test/manifests/invalid.manifest.path.xml");
+          await validateManifest(invalidManifestPath);
         } catch (err) {
           result = err.message;
         }

--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -556,6 +556,16 @@ describe("Unit Tests", function() {
         assert.strictEqual(validation.report!.warnings!.length, 0);
         assert.strictEqual(validation.report!.addInDetails!.supportedProducts!.length > 0, true);
       });
+      it("invalid manifest path", async function() {
+        this.timeout(6000);
+        let result: string = "";
+        try {
+          await validateManifest("test/manifests/invalid.manifest.path.xml");
+        } catch (err) {
+          result = err.message;
+        }
+        assert.strictEqual(result.indexOf("ENOENT: no such file or directory") >= 0, true);
+      });
       it("Excel", async function() {
         this.timeout(6000);
         const validation = await validateManifest("test/manifests/TaskPane.Excel.manifest.xml");


### PR DESCRIPTION
- Call readManifestFile to ensure manifestPath is valid before calling validateManifest. Catch block will catch error if manifest file path is not a valid file and return error to use (e.g. rror: ENOENT: no such file or directory, open 'C:\Office-Addin-Scripts\packages\office-addin-manifest\foo.xml')
- Fixes issue https://github.com/OfficeDev/Office-Addin-Scripts/issues/352