### PR TITLE
Removes isTest param from sideloadAddin

### DIFF
--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -369,7 +369,7 @@ export async function startDebugging(options: StartDebuggingOptions) {
 
         try {
             console.log(`Sideloading the Office Add-in...`);
-            await sideloadAddIn(manifestPath, appType, app, true, document, false /* isTest */);
+            await sideloadAddIn(manifestPath, appType, app, true, document);
         } catch (err) {
             throw new Error(`Unable to sideload the Office Add-in. \n${err}`);
         }

--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -325,7 +325,7 @@ export async function sideload(manifestPath: string, appType: string, command: c
       throw new Error(`Unsupported sideload plaform argument: ${appType}`);
     }
 
-    await sideloadAddIn(manifestPath, appType, app, canPrompt, document, isTest);
+    await sideloadAddIn(manifestPath, appType, app, canPrompt, document);
   } catch (err) {
     logErrorMessage(err);
   }

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -274,11 +274,12 @@ function makePathUnique(originalPath: string, tryToDelete: boolean = false): str
  * @param canPrompt
  */
 export async function sideloadAddIn(manifestPath: string, appType: AppType, app?: OfficeApp, canPrompt: boolean = false,
-  document?: string, isTest: boolean = false): Promise<void> {
+  document?: string): Promise<void> {
   const isDesktop: boolean = appType === AppType.Desktop ? true : false;
   let sideloadFile: string | undefined;
   const manifest: ManifestInfo = await readManifestFile(manifestPath);
   const appsInManifest = getOfficeAppsForManifestHosts(manifest.hosts);
+  const isTest: boolean = process.env.WEB_SIDELOAD_TEST !== undefined;
 
   if (!isDesktop && document === undefined) {
     throw new Error(`For sideload to web, you need to specify a document url.`);

--- a/packages/office-addin-dev-settings/test/unit-tests/test.ts
+++ b/packages/office-addin-dev-settings/test/unit-tests/test.ts
@@ -566,7 +566,7 @@ describe("Sideload to Desktop", function() {
     const manifestPath = fspath.resolve(manifestsFolder, "manifest.unsupportedhost.xml");
     try {
       await devSettingsSideload.sideloadAddIn(manifestPath, devSettingsSideload.AppType.Desktop, officeAddinManifest.OfficeApp.Project, true /* canPrompt */,
-         undefined /* document */, undefined /* devServerPort */);
+         undefined /* document */);
     } catch (err) {
       error = err;
     }


### PR DESCRIPTION
- Now we can just check is process environment variable WEB_SIDELOAD_TEST is set and if it is we will append the test query param to the end of the sideload url to suppress sideload warning opt-in and warning dialog
- I validated this works in the context of web UI tests I created at https://github.com/TCourtneyOwen/Office-Addin-TaskPane/tree/add-web-tests