### PR TITLE
Make app type unrequired for sideload

### DIFF
--- a/packages/office-addin-debugging/src/commands.ts
+++ b/packages/office-addin-debugging/src/commands.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import { logErrorMessage, parseNumber } from "office-addin-cli";
 import * as devSettings from "office-addin-dev-settings";
 import { OfficeApp, parseOfficeApp } from "office-addin-manifest";
-import { AppType, parseAppType, parseDebuggingMethod, parsePlatform, Platform, startDebugging } from "./start";
+import { AppType, parseDebuggingMethod, parsePlatform, Platform, startDebugging } from "./start";
 import { stopDebugging } from "./stop";
 
 function determineManifestPath(platform: Platform, dev: boolean): string {
@@ -41,7 +41,7 @@ function parseDevServerPort(optionValue: any): number | undefined {
 export async function start(manifestPath: string, platform: string | undefined, command: commander.Command) {
     try {
         const appPlatformToDebug: Platform | undefined = parsePlatform(platform || process.env.npm_package_config_app_platform_to_debug || Platform.Win32);
-        const appTypeToDebug: AppType | undefined = parseAppType(appPlatformToDebug || process.env.npm_package_config_app_type_to_debug || AppType.Desktop);
+        const appTypeToDebug: AppType | undefined = devSettings.parseAppType(appPlatformToDebug || process.env.npm_package_config_app_type_to_debug || AppType.Desktop);
         const appToDebug: string | undefined = command.app || process.env.npm_package_config_app_to_debug;
         const app: OfficeApp | undefined = appToDebug ? parseOfficeApp(appToDebug) : undefined;
         const dev: boolean = command.prod ? false : true;

--- a/packages/office-addin-debugging/src/commands.ts
+++ b/packages/office-addin-debugging/src/commands.ts
@@ -76,8 +76,7 @@ export async function start(manifestPath: string, platform: string | undefined, 
         }
 
 
-        await startDebugging({
-            manifestPath,
+        await startDebugging(manifestPath, {
             appType: appTypeToDebug,
             app,
             debuggingMethod,

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -271,12 +271,12 @@ export async function startDebugging(options: StartDebuggingOptions) {
         openDevTools,
         document,
     } = {
-        // Defaults
-        debuggingMethod: defaultDebuggingMethod(),
-        enableDebugging: true,
+        // Supplied Options
+        ...options,
 
-        // Override with supplied options
-        ...options
+        // Defaults when variable is undefined.
+        debuggingMethod: definedOrOther(options.debuggingMethod, defaultDebuggingMethod()),
+        enableDebugging: definedOrOther(options.enableDebugging, true),
     };
 
     try {
@@ -383,6 +383,18 @@ export async function startDebugging(options: StartDebuggingOptions) {
         usageDataObject.sendUsageDataException("startDebugging", err);
         throw err;
     }
+}
+
+/**
+ * @param option 
+ * @param other 
+ * @returns other if option is undefined or option
+ */
+function definedOrOther<T>(option:T | undefined, other: T) {
+    if (option === undefined) {
+        return other;
+    }
+    return option;
 }
 
 export async function waitUntil(callback: (() => Promise<boolean>), retryCount: number, retryDelay: number): Promise<boolean> {

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -178,11 +178,6 @@ export async function runPackager(commandLine: string, host: string = "localhost
 export interface StartDebuggingOptions {
 
     /**
-     * The path to the manifest file.
-     */
-    manifestPath: string,
-
-    /**
      * The type of application to debug.
      */
     appType: AppType,
@@ -254,9 +249,8 @@ export interface StartDebuggingOptions {
  * Start debugging
  * @param options startDebugging options.
  */
-export async function startDebugging(options: StartDebuggingOptions) {
+export async function startDebugging(manifestPath: string, options: StartDebuggingOptions) {
     const {
-        manifestPath,
         appType,
         app,
         debuggingMethod,
@@ -294,7 +288,7 @@ export async function startDebugging(options: StartDebuggingOptions) {
         console.log(enableDebugging
             ? "Debugging is being started..."
             : "Starting without debugging...");
-        console.log(`App type: ${appType.toString()}`);
+        console.log(`App type: ${appType}`);
 
         const manifestInfo = await readManifestFile(manifestPath);
 
@@ -312,7 +306,7 @@ export async function startDebugging(options: StartDebuggingOptions) {
         if (isDesktopAppType && isWindowsPlatform) {
             await devSettings.enableDebugging(manifestInfo.id, enableDebugging, debuggingMethod, openDevTools);
             if (enableDebugging) {
-                console.log(`Enabled debugging for add-in ${manifestInfo.id}. Debug method: ${debuggingMethod.toString()}`);
+                console.log(`Enabled debugging for add-in ${manifestInfo.id}. Debug method: ${DebuggingMethod[debuggingMethod]}`);
             }
         }
 

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -269,8 +269,8 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
         ...options,
 
         // Defaults when variable is undefined.
-        debuggingMethod: definedOrOther(options.debuggingMethod, defaultDebuggingMethod()),
-        enableDebugging: definedOrOther(options.enableDebugging, true),
+        debuggingMethod: options.debuggingMethod || defaultDebuggingMethod(),
+        enableDebugging: options.enableDebugging || true,        
     };
 
     try {
@@ -363,7 +363,7 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
 
         try {
             console.log(`Sideloading the Office Add-in...`);
-            await sideloadAddIn(manifestPath, appType, app, true, document);
+            await sideloadAddIn(manifestPath, app, true, appType, document);
         } catch (err) {
             throw new Error(`Unable to sideload the Office Add-in. \n${err}`);
         }
@@ -377,18 +377,6 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
         usageDataObject.sendUsageDataException("startDebugging", err);
         throw err;
     }
-}
-
-/**
- * @param option 
- * @param other 
- * @returns other if option is undefined or option
- */
-function definedOrOther<T>(option:T | undefined, other: T) {
-    if (option === undefined) {
-        return other;
-    }
-    return option;
 }
 
 export async function waitUntil(callback: (() => Promise<boolean>), retryCount: number, retryDelay: number): Promise<boolean> {

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -60,21 +60,6 @@ export async function isPackagerRunning(statusUrl: string): Promise<boolean> {
     }
 }
 
-export function parseAppType(text: string): AppType | undefined {
-    switch (text) {
-        case "desktop":
-        case "macos":
-        case "win32":
-        case "ios":
-        case "android":
-            return AppType.Desktop;
-        case "web":
-            return AppType.Web;
-        default:
-            return undefined;
-    }
-}
-
 export function parseDebuggingMethod(text: string): DebuggingMethod | undefined {
     switch (text) {
         case "direct":

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -274,6 +274,9 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
     };
 
     try {
+        if (appType === undefined) {
+            throw new Error("Please specify the application type to debug.");
+        }
 
         const isWindowsPlatform = (process.platform === "win32");
         const isDesktopAppType = (appType === AppType.Desktop);

--- a/packages/office-addin-dev-settings/README.md
+++ b/packages/office-addin-dev-settings/README.md
@@ -164,10 +164,11 @@ Start Office and open a document so the Office Add-in is loaded.
 
 Syntax:
 
-`office addin-dev-settings sideload <manifest> <app-type> [options]`
+`office addin-dev-settings sideload <manifest> [app-type] [options]`
 
 `manifest`: path to manifest file.
 
+`app-type`: host application type to sideload ("desktop" or "web").
 
 Note:
 
@@ -179,11 +180,6 @@ Options:
 `--app`
 
 Specify the Office application to load.
-
-`-t`
-`--type`
-
-Specify the application type to sideload ("desktop" or "web")
 
 `-d`
 `--document`

--- a/packages/office-addin-dev-settings/README.md
+++ b/packages/office-addin-dev-settings/README.md
@@ -168,7 +168,6 @@ Syntax:
 
 `manifest`: path to manifest file.
 
-`app-type`: host application type to sideload ("desktop" or "web").
 
 Note:
 
@@ -180,6 +179,11 @@ Options:
 `--app`
 
 Specify the Office application to load.
+
+`-t`
+`--type`
+
+Specify the application type to sideload ("desktop" or "web")
 
 `-d`
 `--document`

--- a/packages/office-addin-dev-settings/src/cli.ts
+++ b/packages/office-addin-dev-settings/src/cli.ts
@@ -56,13 +56,17 @@ commander
     .description("Configure the runtime log for all Office Add-ins.")
     .action(commands.runtimeLogging);
 
-commander
-    .command("sideload <manifest-path>")
+    commander
+    .command("sideload <manifest-path> [app-type]")
     .description("Launch Office with the Office Add-in loaded.")
-    .option("-a,--app <app>", `The Office app to launch. ("Excel", "Outlook", "PowerPoint", or "Word")`)    
+    .option("-a,--app <app>", `The Office app to launch. ("Excel", "Outlook", "PowerPoint", or "Word")`)
     .option("-d,--document <document>", `The location of the document to be sideloaded - this can be an absolute file path or url`)
-    .option("-t, --type <type>", `Application type to sideload ("desktop" or "web")`)
-    .action(commands.sideload);
+    .action(commands.sideload)
+    .on("--help", () => {
+        console.log("\nFor [app-type], choose one of the following values:\n");
+        console.log("\t'desktop' for sideloading desktop add-ins");
+        console.log("\t'web' for sideloading web add-ins");
+    });
 
 commander
     .command("source-bundle-url <manifest-path>")

--- a/packages/office-addin-dev-settings/src/cli.ts
+++ b/packages/office-addin-dev-settings/src/cli.ts
@@ -57,16 +57,12 @@ commander
     .action(commands.runtimeLogging);
 
 commander
-    .command("sideload <manifest-path> <app-type.")
+    .command("sideload <manifest-path>")
     .description("Launch Office with the Office Add-in loaded.")
-    .option("-a,--app <app>", `The Office app to launch. ("Excel", "PowerPoint", or "Word")`)
+    .option("-a,--app <app>", `The Office app to launch. ("Excel", "Outlook", "PowerPoint", or "Word")`)    
     .option("-d,--document <document>", `The location of the document to be sideloaded - this can be an absolute file path or url`)
-    .action(commands.sideload)
-    .on("--help", () => {
-        console.log("\nFor <app-type>, choose one of the following values:\n");
-        console.log("\t'desktop' for sideloading desktop add-ins");
-        console.log("\t'web' for sideloading web add-ins");
-    });
+    .option("-t, --type <type>", `Application type to sideload ("desktop" or "web")`)
+    .action(commands.sideload);
 
 commander
     .command("source-bundle-url <manifest-path>")

--- a/packages/office-addin-dev-settings/src/cli.ts
+++ b/packages/office-addin-dev-settings/src/cli.ts
@@ -56,16 +56,16 @@ commander
     .description("Configure the runtime log for all Office Add-ins.")
     .action(commands.runtimeLogging);
 
-    commander
+commander
     .command("sideload <manifest-path> [app-type]")
     .description("Launch Office with the Office Add-in loaded.")
     .option("-a,--app <app>", `The Office app to launch. ("Excel", "Outlook", "PowerPoint", or "Word")`)
     .option("-d,--document <document>", `The location of the document to be sideloaded - this can be an absolute file path or url`)
     .action(commands.sideload)
     .on("--help", () => {
-        console.log("\nFor [app-type], choose one of the following values:\n");
-        console.log("\t'desktop' for sideloading desktop add-ins");
-        console.log("\t'web' for sideloading web add-ins");
+        console.log("\n[app-type] specifies the type of Office app::\n");
+        console.log("\t'desktop': Office app for Windows or Mac (default),");
+        console.log("\t'web': Office running in the web browser");
     });
 
 commander

--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -13,7 +13,7 @@ import {
   removeLoopbackExemptionForAppcontainer,
 } from "./appcontainer";
 import * as devSettings from "./dev-settings";
-import { AppType, sideloadAddIn } from "./sideload";
+import { AppType, parseAppType, sideloadAddIn } from "./sideload";
 
 export async function appcontainer(manifestPath: string, command: commander.Command) {
   if (isAppcontainerSupported()) {
@@ -230,19 +230,6 @@ export async function liveReload(manifestPath: string, command: commander.Comman
     await disableLiveReload(manifestPath);
   } else {
     await isLiveReloadEnabled(manifestPath);
-  }
-}
-
-function parseAppType(appType: string | undefined): AppType | undefined {
-  switch (appType ? appType.toLowerCase() : undefined) {
-    case "desktop":
-      return AppType.Desktop;
-    case "web":
-      return AppType.Web;
-    case undefined:
-      return undefined
-    default:
-      throw new Error(`Please select a valid app-type instead of '${appType}'.`);    
   }
 }
 

--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -314,18 +314,18 @@ export async function runtimeLogging(command: commander.Command) {
   }
 }
 
-export async function sideload(manifestPath: string, appType: string, command: commander.Command) {
+export async function sideload(manifestPath: string, command: commander.Command) {
   try {
     const app: OfficeApp | undefined = command.app ? parseOfficeApp(command.app) : undefined;
     const canPrompt = true;
     const document: string | undefined = command.document ? command.document : undefined;
-    const isTest: boolean | undefined = command.test ? true : false;
+    const appType: AppType = command.type || AppType.Desktop;
 
     if (appType !== AppType.Desktop && appType !== AppType.Web) {
       throw new Error(`Unsupported sideload plaform argument: ${appType}`);
     }
 
-    await sideloadAddIn(manifestPath, appType, app, canPrompt, document);
+    await sideloadAddIn(manifestPath, app, canPrompt, appType, document);
   } catch (err) {
     logErrorMessage(err);
   }

--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -233,6 +233,19 @@ export async function liveReload(manifestPath: string, command: commander.Comman
   }
 }
 
+function parseAppType(appType: string | undefined): AppType | undefined {
+  switch (appType ? appType.toLowerCase() : undefined) {
+    case "desktop":
+      return AppType.Desktop;
+    case "web":
+      return AppType.Web;
+    case undefined:
+      return undefined
+    default:
+      throw new Error(`Please select a valid app-type instead of '${appType}'.`);    
+  }
+}
+
 function parseStringCommandOption(optionValue: any): string | undefined {
   return (typeof(optionValue) === "string") ? optionValue : undefined;
 }
@@ -314,16 +327,12 @@ export async function runtimeLogging(command: commander.Command) {
   }
 }
 
-export async function sideload(manifestPath: string, command: commander.Command) {
+export async function sideload(manifestPath: string, type: string | undefined, command: commander.Command) {
   try {
     const app: OfficeApp | undefined = command.app ? parseOfficeApp(command.app) : undefined;
     const canPrompt = true;
     const document: string | undefined = command.document ? command.document : undefined;
-    const appType: AppType = command.type || AppType.Desktop;
-
-    if (appType !== AppType.Desktop && appType !== AppType.Web) {
-      throw new Error(`Unsupported sideload plaform argument: ${appType}`);
-    }
+    const appType: AppType | undefined = parseAppType(type || process.env.npm_package_config_app_platform_to_debug);
 
     await sideloadAddIn(manifestPath, app, canPrompt, appType, document);
   } catch (err) {

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -29,6 +29,28 @@ export enum AppType {
 }
 
 /**
+ * Parse the input text and get the associated AppType
+ * @param text app-type/platform text
+ * @returns AppType or undefined.
+ */
+export function parseAppType(text: string | undefined): AppType | undefined {
+  switch (text ? text.toLowerCase() : undefined) {
+    case "desktop":
+    case "macos":
+    case "win32":
+    case "ios":
+    case "android":
+      return AppType.Desktop;
+    case "web":
+      return AppType.Web;
+    case undefined:
+      return undefined
+    default:
+      throw new Error(`Please select a valid app-type instead of '${text}'.`); 
+  }
+}
+
+/**
  * Create an Office document in the temporary files directory
  * which can be opened to launch the Office app and load the add-in.
  * @param app Office app

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -201,8 +201,7 @@ function getWebExtensionPath(
 }
 
 function isSideloadingSupportedForDesktopHost(app: OfficeApp): boolean {
-  if (app === OfficeApp.Excel || app === OfficeApp.Outlook && process.platform === "win32" && process.env.OUTLOOK_SIDELOAD_ENABLED != undefined ||
-    app === OfficeApp.PowerPoint || app === OfficeApp.Word) {
+  if (app === OfficeApp.Excel || app === OfficeApp.Outlook && process.platform === "win32" || app === OfficeApp.PowerPoint || app === OfficeApp.Word) {
     return true;
   }
   return false;
@@ -273,8 +272,8 @@ function makePathUnique(originalPath: string, tryToDelete: boolean = false): str
  * @param app Office app to launch.
  * @param canPrompt
  */
-export async function sideloadAddIn(manifestPath: string, appType: AppType, app?: OfficeApp, canPrompt: boolean = false,
-  document?: string): Promise<void> {
+export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPrompt: boolean = false,
+  appType?: AppType, document?: string): Promise<void> {  
   const isDesktop: boolean = appType === AppType.Desktop ? true : false;
   let sideloadFile: string | undefined;
   const manifest: ManifestInfo = await readManifestFile(manifestPath);

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -273,7 +273,12 @@ function makePathUnique(originalPath: string, tryToDelete: boolean = false): str
  * @param canPrompt
  */
 export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPrompt: boolean = false,
-  appType?: AppType, document?: string): Promise<void> {  
+  appType?: AppType, document?: string): Promise<void> {
+
+  if (appType === undefined) {
+    appType = AppType.Desktop;
+  }
+
   const isDesktop: boolean = appType === AppType.Desktop ? true : false;
   let sideloadFile: string | undefined;
   const manifest: ManifestInfo = await readManifestFile(manifestPath);

--- a/packages/office-addin-dev-settings/test/unit-tests/test.ts
+++ b/packages/office-addin-dev-settings/test/unit-tests/test.ts
@@ -565,8 +565,8 @@ describe("Sideload to Desktop", function() {
     let error;
     const manifestPath = fspath.resolve(manifestsFolder, "manifest.unsupportedhost.xml");
     try {
-      await devSettingsSideload.sideloadAddIn(manifestPath, devSettingsSideload.AppType.Desktop, officeAddinManifest.OfficeApp.Project, true /* canPrompt */,
-         undefined /* document */);
+      await devSettingsSideload.sideloadAddIn(manifestPath, officeAddinManifest.OfficeApp.Project, true /* canPrompt */,
+        devSettingsSideload.AppType.Desktop, undefined /* document */);
     } catch (err) {
       error = err;
     }
@@ -599,8 +599,8 @@ describe("Sideload to web", function() {
     let error;
     let manifestPath = fspath.resolve(manifestsFolder, "manifest.invalidsourcelocationforweb.xml");
     try {
-      await devSettingsSideload.sideloadAddIn(manifestPath, devSettingsSideload.AppType.Web, officeAddinManifest.OfficeApp.Excel,
-        true /* canPrompt */, docurl);
+      await devSettingsSideload.sideloadAddIn(manifestPath, officeAddinManifest.OfficeApp.Excel, true /* canPrompt */,
+        devSettingsSideload.AppType.Web, docurl);
     } catch (err) {
       error = err;
     }
@@ -611,7 +611,7 @@ describe("Sideload to web", function() {
     let error;
     let manifestPath = fspath.resolve(manifestsFolder, "manifest.xml");
     try {
-      await devSettingsSideload.sideloadAddIn(manifestPath, devSettingsSideload.AppType.Web, officeAddinManifest.OfficeApp.Excel, true /* canPrompt */);
+      await devSettingsSideload.sideloadAddIn(manifestPath, officeAddinManifest.OfficeApp.Excel, true /* canPrompt */, devSettingsSideload.AppType.Web);
     } catch (err) {
       error = err;
     }
@@ -622,8 +622,8 @@ describe("Sideload to web", function() {
     let error;
     let manifestPath = fspath.resolve(manifestsFolder, "manifest.outlook.xml");
     try {
-      await devSettingsSideload.sideloadAddIn(manifestPath, devSettingsSideload.AppType.Web, officeAddinManifest.OfficeApp.Outlook,
-        true /* canPrompt */, docurl);
+      await devSettingsSideload.sideloadAddIn(manifestPath, officeAddinManifest.OfficeApp.Outlook, true /* canPrompt */,
+        devSettingsSideload.AppType.Web, docurl);
     } catch (err) {
       error = err;
     }


### PR DESCRIPTION
Make appType param not required for sideload command
    
- Update sideload cli to reflect type is once again an option, not required 
- Update sideloadAddin to make appType optional and revert param ordering for method back to previous method signature so this is not a breaking change
- Update Readme to reflect that type is now an option
- Remove check for Outlook sideloading environment variable so we can enable Outlook sideloading (we don't have to include this in this PR but I thought it would be nice to get this enabled soon)
- Incorporate changes from StartDebuggingOptions to fix issue with default options not being set properly. Also remove manifestPath from StartDebuggingOptions as it's not really an option - it's required