### PR TITLE
Fix issue with granting admin consent

### DIFF
--- a/packages/office-addin-sso/src/configure.ts
+++ b/packages/office-addin-sso/src/configure.ts
@@ -112,7 +112,7 @@ export async function isUserTenantAdmin(userInfo: Object): Promise<boolean> {
         const tenantRoles: Object = await promiseExecuteCommand(azRestCommand);
         let tenantAdminId: string = '';
         tenantRoles['value'].forEach(item => {
-            if (item.displayName === "Company Administrator") {
+            if (item.displayName === "Global Administrator") {
                 tenantAdminId = item.id;
             }
         });


### PR DESCRIPTION
- Azure seems to have recently changed the naming convention for a tenant admin from "Company Administrator" to "Global Administrator" and as a result granting admin consent was failing for the SSO application created via configure-sso
- I believe this should fix https://github.com/OfficeDev/Office-Addin-Taskpane-SSO/issues/25