### PR TITLE
startDebugging() - fix default for enableDebugging

### DIFF
--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -255,7 +255,7 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
 
         // Defaults when variable is undefined.
         debuggingMethod: options.debuggingMethod || defaultDebuggingMethod(),
-        enableDebugging: options.enableDebugging || true,        
+        enableDebugging: (options.enableDebugging !== undefined) ? options.enableDebugging : true,        
     };
 
     try {


### PR DESCRIPTION
Office-Addin-TaskPane tests will not run because debugging is enabled even though `enableDebugging: false` was specified.

This is because the || operator does not distinguish between undefined and false.