### PR TITLE
Removing Debug Method console logging

### DIFF
--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -293,6 +293,9 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
         // enable debugging
         if (isDesktopAppType && isWindowsPlatform) {
             await devSettings.enableDebugging(manifestInfo.id, enableDebugging, debuggingMethod, openDevTools);
+            if (enableDebugging) {
+                console.log(`Enabled debugging for add-in ${manifestInfo.id}.`);
+            }
         }
 
         // enable live reload

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -290,14 +290,6 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
             await devSettings.ensureLoopbackIsEnabled(name);
         }
 
-        // enable debugging
-        if (isDesktopAppType && isWindowsPlatform) {
-            await devSettings.enableDebugging(manifestInfo.id, enableDebugging, debuggingMethod, openDevTools);
-            if (enableDebugging) {
-                console.log(`Enabled debugging for add-in ${manifestInfo.id}. Debug method: ${DebuggingMethod[debuggingMethod]}`);
-            }
-        }
-
         // enable live reload
         if (isDesktopAppType && isWindowsPlatform) {
             await devSettings.enableLiveReload(manifestInfo.id, useLiveReload);

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -290,6 +290,11 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
             await devSettings.ensureLoopbackIsEnabled(name);
         }
 
+        // enable debugging
+        if (isDesktopAppType && isWindowsPlatform) {
+            await devSettings.enableDebugging(manifestInfo.id, enableDebugging, debuggingMethod, openDevTools);
+        }
+
         // enable live reload
         if (isDesktopAppType && isWindowsPlatform) {
             await devSettings.enableLiveReload(manifestInfo.id, useLiveReload);


### PR DESCRIPTION
Removed the following code:

 // enable debugging
        if (isDesktopAppType && isWindowsPlatform) {
            await devSettings.enableDebugging(manifestInfo.id, enableDebugging, debuggingMethod, openDevTools);
            if (enableDebugging) {
                console.log(`Enabled debugging for add-in ${manifestInfo.id}. Debug method: ${DebuggingMethod[debuggingMethod]}`);
            }
        }
