### PR TITLE
improve npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "lerna bootstrap",
     "publish:next": "lerna publish --dist-tag next",
     "test": "lerna run test",
-    "update-latest-dist-tags": "npm run exec for /f \"usebackq\" %a in (`npm view . name`) do echo @for /f \"usebackq\" %b in (`npm view . dist-tags.next`) do @npm dist-tag add %a@%b",
+    "update-latest-dist-tags": "npm run exec for /f \"usebackq\" %a in (`npm view . name`) do @for /f \"usebackq\" %b in (`npm view . dist-tags.next`) do @npm dist-tag add %a@%b",
     "update-packages": "npm run exec -- npm update --dev"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,15 +2,18 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "audit": "npm audit -- audit-level=critical & lerna exec --concurrency 1 --no-sort --stream npm audit -- --audit-level=critical",
-    "audit:fix": "npm audit fix & lerna exec --concurrency 1 --no-sort --stream npm audit fix",
+    "audit": "npm audit & npm run exec -- npm audit",
+    "audit:fix": "npm audit fix & npm run exec -- npm audit fix",
     "build": "lerna run build",
-    "dist-tags": "lerna exec --concurrency 1 --no-sort --stream npm dist-tag ls",
+    "clean-install-packages": "npm run exec -- npm ci & npm ci",
+    "dist-tags": "npm run exec -- npm dist-tag ls",
+    "install-packages": "npm run exec -- npm install & npm install",
+    "exec": "lerna exec --concurrency 1 --no-bail --no-sort --stream",
     "postinstall": "lerna bootstrap",
     "publish:next": "lerna publish --dist-tag next",
     "test": "lerna run test",
-    "update-latest-dist-tags": "lerna exec --concurrency 1 --no-sort --stream  for /f \"usebackq\" %a in (`npm view . name`) do @for /f \"usebackq\" %b in (`npm view . dist-tags.next`) do @npm dist-tag add %a@%b",
-    "update-packages": "lerna exec --concurrency 1 --no-sort --stream npm update --dev"
+    "update-latest-dist-tags": "npm run exec for /f \"usebackq\" %a in (`npm view . name`) do echo @for /f \"usebackq\" %b in (`npm view . dist-tags.next`) do @npm dist-tag add %a@%b",
+    "update-packages": "npm run exec -- npm update --dev"
   },
   "devDependencies": {
     "lerna": "^3.22.1"


### PR DESCRIPTION
Create "exec" script for running lerna exec.
Update other scripts to use "npm run exec".

Add scripts "install-packages" and "clean-install-packages" which run "npm install" or "npm ci", respectively, and then run "npm install" in the root afterward.