### PR TITLE
Adding outlook version check

### DIFF
--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -31,6 +31,7 @@
         "@types/mocha": "^8.0.3",
         "@types/node": "^14.11.1",
         "@types/node-fetch": "^2.5.7",
+        "@types/semver": "^7.3.4",
         "@types/sinon": "^7.5.2",
         "@types/whatwg-url": "^6.4.0",
         "@types/winreg": "^1.2.30",
@@ -159,6 +160,12 @@
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
+      "dev": true
     },
     "node_modules/@types/sinon": {
       "version": "7.5.2",
@@ -2923,6 +2930,12 @@
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
+    },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "7.5.2",

--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.8.15",
+      "version": "1.8.16",
       "license": "MIT",
       "dependencies": {
         "child_process": "^1.0.2",
@@ -14,8 +14,9 @@
         "inquirer": "^7.3.3",
         "jszip": "^3.5.0",
         "junk": "^3.1.0",
-        "office-addin-cli": "^1.0.16",
-        "office-addin-manifest": "^1.5.15",
+        "office-addin-cli": "^1.0.17",
+        "office-addin-manifest": "^1.5.16",
+        "office-addin-usage-data": "^1.0.23",
         "open": "^6.4.0",
         "whatwg-url": "^7.1.0",
         "winreg": "^1.2.4"
@@ -1776,9 +1777,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.16.tgz",
-      "integrity": "sha512-rUkTpcTVkCiETaK67F1yWgxrxRe37+uwW6GwL7E1y2jmsj3lnrEDgiMpL1uOvuar1P6nXQ8vUrEPvVlL/2qHqw==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.17.tgz",
+      "integrity": "sha512-Q8ldxcxPF69/W4TprG9u3M2zFigQR/bTF3CJDb/BQPgMIMZIOSHhOd1jUNDCufEhwm8uhuywIOhxbemahweFoQ==",
       "dependencies": {
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1"
@@ -1788,15 +1789,15 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.5.15",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.5.15.tgz",
-      "integrity": "sha512-MYXYwS+seNwpzptGJB2we7vOMe0qwyA77rmz9X5cdbHsVqOfH4k+o3E8TMyBXimtwDDpSI4S/Crm4qu1Yeh1ZQ==",
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.5.16.tgz",
+      "integrity": "sha512-s9T/2oHEYAkosuns143THGyDyoxcpgRowrkRF4qQJFqYjU2ruklQw+FujmsFLmOxvGGcgXrk6XeoEwR3vD3QAw==",
       "dependencies": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.0.16",
-        "office-addin-usage-data": "^1.0.22",
+        "office-addin-cli": "^1.0.17",
+        "office-addin-usage-data": "^1.0.23",
         "path": "^0.12.7",
         "uuid": "^3.4.0",
         "xml2js": "^0.4.23"
@@ -4237,24 +4238,24 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.16.tgz",
-      "integrity": "sha512-rUkTpcTVkCiETaK67F1yWgxrxRe37+uwW6GwL7E1y2jmsj3lnrEDgiMpL1uOvuar1P6nXQ8vUrEPvVlL/2qHqw==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.0.17.tgz",
+      "integrity": "sha512-Q8ldxcxPF69/W4TprG9u3M2zFigQR/bTF3CJDb/BQPgMIMZIOSHhOd1jUNDCufEhwm8uhuywIOhxbemahweFoQ==",
       "requires": {
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1"
       }
     },
     "office-addin-manifest": {
-      "version": "1.5.15",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.5.15.tgz",
-      "integrity": "sha512-MYXYwS+seNwpzptGJB2we7vOMe0qwyA77rmz9X5cdbHsVqOfH4k+o3E8TMyBXimtwDDpSI4S/Crm4qu1Yeh1ZQ==",
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.5.16.tgz",
+      "integrity": "sha512-s9T/2oHEYAkosuns143THGyDyoxcpgRowrkRF4qQJFqYjU2ruklQw+FujmsFLmOxvGGcgXrk6XeoEwR3vD3QAw==",
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.0.16",
-        "office-addin-usage-data": "^1.0.22",
+        "office-addin-cli": "^1.0.17",
+        "office-addin-usage-data": "^1.0.23",
         "path": "^0.12.7",
         "uuid": "^3.4.0",
         "xml2js": "^0.4.23"

--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -39,6 +39,7 @@
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.1",
     "@types/node-fetch": "^2.5.7",
+    "@types/semver": "^7.3.4",
     "@types/sinon": "^7.5.2",
     "@types/whatwg-url": "^6.4.0",
     "@types/winreg": "^1.2.30",

--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -27,6 +27,7 @@
     "junk": "^3.1.0",
     "office-addin-cli": "^1.0.17",
     "office-addin-manifest": "^1.5.16",
+    "office-addin-usage-data": "^1.0.23",
     "open": "^6.4.0",
     "whatwg-url": "^7.1.0",
     "winreg": "^1.2.4"

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -213,8 +213,8 @@ function isSideloadingSupportedForWebHost(app: OfficeApp): boolean {
   return false;
 }
 
-function hasOfficeVersion(targetVersion: string, currentVersion: string): boolean {
-  return semver.gte(currentVersion, targetVersion)
+function hasOfficeVersion(targetVersion: string, currentVersion: string | undefined): boolean {
+  return currentVersion ? semver.gte(currentVersion, targetVersion) : false;
 }
 
 async function getOutlookVersion(): Promise<string | undefined> {
@@ -228,11 +228,6 @@ async function getOutlookVersion(): Promise<string | undefined> {
   catch (err) {
     return undefined;
   }
-}
-
-async function hasOutlookVersion(version: string): Promise<boolean> {
-  const currentVersion: string | undefined = await getOutlookVersion();
-  return currentVersion ? hasOfficeVersion(version, currentVersion) : false;
 }
 
 async function getOutlookExePath(): Promise<string | undefined> {
@@ -338,7 +333,8 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
       await registerAddIn(manifestPath);
       // for Outlook, open Outlook.exe; for other Office apps, open the document
       if (app == OfficeApp.Outlook) {
-        if (!(await hasOutlookVersion("16.0.13709"))) {
+        const version = await getOutlookVersion();
+        if (!hasOfficeVersion("16.0.13709", version)) {
           throw new ExpectedError(`The current version of Outlook does not support sideload. Please use version 16.0.13709 or greater.`);
         }
         sideloadFile = await getOutlookExePath();

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -213,8 +213,8 @@ function isSideloadingSupportedForWebHost(app: OfficeApp): boolean {
   return false;
 }
 
-function hasOfficeVersion(targetVersion: string, currentVersion: string | undefined): boolean {
-  return currentVersion ? semver.gte(currentVersion, targetVersion) : false;
+function hasOfficeVersion(targetVersion: string, currentVersion: string): boolean {
+  return semver.gte(currentVersion, targetVersion);
 }
 
 async function getOutlookVersion(): Promise<string | undefined> {
@@ -333,8 +333,8 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
       await registerAddIn(manifestPath);
       // for Outlook, open Outlook.exe; for other Office apps, open the document
       if (app == OfficeApp.Outlook) {
-        const version = await getOutlookVersion();
-        if (!hasOfficeVersion("16.0.13709", version)) {
+        const version: string | undefined = await getOutlookVersion();
+        if (version && !hasOfficeVersion("16.0.13709", version)) {
           throw new ExpectedError(`The current version of Outlook does not support sideload. Please use version 16.0.13709 or greater.`);
         }
         sideloadFile = await getOutlookExePath();

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -13,7 +13,7 @@ import {
   readManifestFile,
 } from "office-addin-manifest";
 import open = require("open");
-import semverlt = require('semver/functions/lt');
+import semver = require('semver');
 import * as os from "os";
 import * as path from "path";
 import * as util from "util";
@@ -330,7 +330,7 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
       // for Outlook, open Outlook.exe; for other Office apps, open the document
       if (app == OfficeApp.Outlook) {
         const version = await getOutlookVersion();
-        if (version && semverlt(version, "16.0.13709")) {
+        if (version && semver.lt(version, "16.0.13709")) {
           throw new ExpectedError(`The current version of Outlook (${version}) does not support sideload. Please use version 16.0.13709 or greater.`);
         }
         sideloadFile = await getOutlookExePath();

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -339,16 +339,6 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
       break;
     case AppType.Web:
       if (!document) {
-        throw new ExpectedError(`For sideload to web, you need to specify a document url.`);
-      }
-
-      // for Outlook, open Outlook.exe; for other Office apps, open the document
-      sideloadFile = (app === OfficeApp.Outlook)
-        ? await getOutlookExePath()
-        : await generateSideloadFile(app, manifest, document);
-      break;
-    case AppType.Web:
-      if (!document) {
         throw new Error(`For sideload to web, you need to specify a document url.`);
       }
 

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -331,7 +331,7 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
       // for Outlook, open Outlook.exe; for other Office apps, open the document
       if (app == OfficeApp.Outlook) {
         const version = await getOutlookVersion();
-        if (version && semver.gt(version, "16.0.13709")) {
+        if (version && semver.lt(version, "16.0.13709")) {
           throw new ExpectedError(`Outlook install version should be 16.0.13709 or greater. Current version: ${version}`);
         }
         sideloadFile = await getOutlookExePath();

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -13,7 +13,7 @@ import {
   readManifestFile,
 } from "office-addin-manifest";
 import open = require("open");
-import semver = require('semver');
+import semverlt = require('semver/functions/lt');
 import * as os from "os";
 import * as path from "path";
 import * as util from "util";
@@ -215,8 +215,7 @@ function isSideloadingSupportedForWebHost(app: OfficeApp): boolean {
 
 async function getOutlookVersion(): Promise<string | undefined> {
   try {
-    const OutlookInstallPathVersionRegistryKey = `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Office\\ClickToRun\\Configuration`;
-    const key = new registry.RegistryKey(`${OutlookInstallPathVersionRegistryKey}`);
+    const key = new registry.RegistryKey(`HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Office\\ClickToRun\\Configuration`);
     const outlookInstallVersion: string | undefined = await registry.getStringValue(key, "ClientVersionToReport");
     const outlookSmallerVersion = outlookInstallVersion?.split(`.`, 3).join(`.`);
     
@@ -331,8 +330,8 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
       // for Outlook, open Outlook.exe; for other Office apps, open the document
       if (app == OfficeApp.Outlook) {
         const version = await getOutlookVersion();
-        if (version && semver.lt(version, "16.0.13709")) {
-          throw new ExpectedError(`Outlook install version should be 16.0.13709 or greater. Current version: ${version}`);
+        if (version && semverlt(version, "16.0.13709")) {
+          throw new ExpectedError(`The current version of Outlook (${version}) does not support sideload. Please use version 16.0.13709 or greater.`);
         }
         sideloadFile = await getOutlookExePath();
       } else {

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -220,8 +220,7 @@ async function getOutlookVersion(): Promise<string | undefined> {
     return outlookInstallVersion;
   }
   catch (err) {
-    const errorMessage: string = `Unable to find Outlook version location: \n${err}`;
-    throw new Error(errorMessage);  
+    return undefined;
   }
 }
 

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -330,7 +330,7 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
       if (app == OfficeApp.Outlook) {
         const version = await getOutlookVersion() ?? "";
         if (version < "16.0.13709.10000") {
-          throw new ExpectedError("Outlook install version should be 16.0.13709.10000 or greater");
+          throw new ExpectedError(`Outlook install version should be 16.0.13709.10000 or greater. Current version: ${version}`);
         }
         sideloadFile = await getOutlookExePath();
       } else {

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -328,8 +328,8 @@ export async function sideloadAddIn(manifestPath: string, app?: OfficeApp, canPr
       await registerAddIn(manifestPath);
       // for Outlook, open Outlook.exe; for other Office apps, open the document
       if (app == OfficeApp.Outlook) {
-        const version = await getOutlookVersion() ?? "";
-        if (version < "16.0.13709.10000") {
+        const version = await getOutlookVersion();
+        if (version && version < "16.0.13709.10000") {
           throw new ExpectedError(`Outlook install version should be 16.0.13709.10000 or greater. Current version: ${version}`);
         }
         sideloadFile = await getOutlookExePath();


### PR DESCRIPTION
Checking  the Outlook install version as part of the sideload command to determine if it's a valid version (needs to >= 16.0.13709.10000)

Tested with my computer with the version installed and tested with: 16.0.13628.20346
It successfully throws an ```ExpectedError``` in that case.