### PR TITLE
Correcting usage-data package version number

### DIFF
--- a/packages/office-addin-usage-data/package.json
+++ b/packages/office-addin-usage-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-addin-usage-data",
-  "version": "1.0.25",
+  "version": "1.1.8",
   "description": "Provides infrastructure to send usage data events and exceptions.",
   "main": "./lib/main.js",
   "scripts": {


### PR DESCRIPTION
A few publishes ago the version for office-addin-usage-data got changed from 1.1.7 => 1.0.19 which backwards and causes other packages that depend on this to not pickup the changes (since it looks like they have a newer version already).  This will reset the version back forward to correct that.