### PR TITLE
Adding rule to endOfLine auto

### DIFF
--- a/packages/office-addin-lint/config/.eslintrc.json
+++ b/packages/office-addin-lint/config/.eslintrc.json
@@ -4,7 +4,7 @@
       "@typescript-eslint"
     ],
     "rules": {
-      "prettier/prettier": "error",
+      "prettier/prettier": ["error", { "endOfLine": "auto" }],
       "no-eval": "error",
       "no-delete-var": "warn",
       "no-octal": "warn",


### PR DESCRIPTION
Create the end of line auto rule to fix the end of line issues in Windows for the template projects.

Tests:
On taskpane project, opened a test PR with this change to see that the lining errors disappeared: [https://github.com/OfficeDev/Office-Addin-TaskPane/pull/108](url)