### PR TITLE
Making File Paths more Strictly

### DIFF
--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -371,9 +371,21 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
             ? "Debugging started."
             : "Started.");
 
-        usageDataObject.reportSuccess("startDebugging()");
+        usageDataObject.reportSuccess("startDebugging()", 
+            {
+                app: app, 
+                document: document, 
+                appType: appType
+            }
+        );
     } catch (err) {
-        usageDataObject.reportException("startDebugging()", err);
+        usageDataObject.reportException("startDebugging()", err, 
+            {
+                app: app, 
+                document: document, 
+                appType: appType
+            }
+        );
         throw err;
     }
 }

--- a/packages/office-addin-dev-settings/src/appcontainer.ts
+++ b/packages/office-addin-dev-settings/src/appcontainer.ts
@@ -143,7 +143,7 @@ export async function getAppcontainerNameFromManifest(manifestPath: string): Pro
   const sourceLocation = manifest.defaultSettings ? manifest.defaultSettings.sourceLocation : undefined;
 
   if (sourceLocation === undefined) {
-    throw new Error(`The source location could not be retrieved from the manifest.`);
+    throw new ExpectedError(`The source location could not be retrieved from the manifest.`);
   }
 
   return getAppcontainerName(sourceLocation, false);

--- a/packages/office-addin-dev-settings/src/dev-settings.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings.ts
@@ -126,7 +126,7 @@ export async function enableRuntimeLogging(path?: string): Promise<string> {
         const file = fs.openSync(path, "a+");
         fs.closeSync(file);
       } catch (err) {
-        throw new Error(pathExists
+        throw new ExpectedError(pathExists
           ? `You need to specify the path to a writable file. Unable to write to: "${path}".`
           : `You need to specify the path where the file can be written. Unable to write to: "${path}".`);
       }

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -57,7 +57,7 @@ export async function generateSideloadFile(app: OfficeApp, manifest: ManifestInf
   const templatePath = document && document !== "" ? path.resolve(document) : getTemplatePath(app, addInType);
 
   if (!templatePath) {
-    throw new ExpectedError("Sideload is not supported.");
+    throw new ExpectedError(`Sideload is not supported for apptype: ${addInType}.`);
   }
 
   const templateBuffer = await readFileAsync(templatePath);

--- a/packages/office-addin-manifest/src/addInTypes.ts
+++ b/packages/office-addin-manifest/src/addInTypes.ts
@@ -50,7 +50,7 @@ export function parseAddInType(value: string): AddInType {
   const addInType = toAddInType(value);
 
   if (!addInType) {
-    throw new Error(`${value} is not a valid Office add-in type.`);
+    throw new ExpectedError(`${value} is not a valid Office add-in type.`);
   }
 
   return addInType;

--- a/packages/office-addin-manifest/src/addInTypes.ts
+++ b/packages/office-addin-manifest/src/addInTypes.ts
@@ -1,6 +1,8 @@
 // copyright (c) Microsoft Corporation. All rights reserved.
 // licensed under the MIT license.
 
+import { ExpectedError } from "office-addin-usage-data";
+
 /**
  * The types of Office add-ins.
  */
@@ -48,7 +50,7 @@ export function parseAddInType(value: string): AddInType {
   const addInType = toAddInType(value);
 
   if (!addInType) {
-    throw new Error(`${value} is not a valid Office add-in type.`);
+    throw new ExpectedError(`${value} is not a valid Office add-in type.`);
   }
 
   return addInType;

--- a/packages/office-addin-manifest/src/addInTypes.ts
+++ b/packages/office-addin-manifest/src/addInTypes.ts
@@ -50,7 +50,7 @@ export function parseAddInType(value: string): AddInType {
   const addInType = toAddInType(value);
 
   if (!addInType) {
-    throw new ExpectedError(`${value} is not a valid Office add-in type.`);
+    throw new Error(`${value} is not a valid Office add-in type.`);
   }
 
   return addInType;

--- a/packages/office-addin-usage-data/package-lock.json
+++ b/packages/office-addin-usage-data/package-lock.json
@@ -5,22 +5,28 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.12.13"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
     "@babel/highlight": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
@@ -179,7 +185,7 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
@@ -315,14 +321,14 @@
       "dev": true
     },
     "concurrently": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.0.0.tgz",
-      "integrity": "sha512-Ik9Igqnef2ONLjN2o/OVx1Ow5tymVvvEwQeYCQdD/oV+CN9oWhxLk7ibcBdOtv0UzBqHCEKRwbKceYoTK8t3fQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.0.2.tgz",
+      "integrity": "sha512-u+1Q0dJG5BidgUTpz9CU16yoHTt/oApFDQ3mbvHwSDgMjU7aGqy0q8ZQyaZyaNxdwRKTD872Ux3Twc6//sWA+Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "date-fns": "^2.16.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "read-pkg": "^5.2.0",
         "rxjs": "^6.6.3",
         "spawn-command": "^0.0.2-1",
@@ -341,9 +347,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -400,9 +406,9 @@
       }
     },
     "date-fns": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.18.0.tgz",
-      "integrity": "sha512-NYyAg4wRmGVU4miKq5ivRACOODdZRY3q5WLmOJSq8djyzftYphU7dTHLcEtLqEvfqMKQ0jVv91P4BAwIjsXIcw==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.1.tgz",
+      "integrity": "sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA==",
       "dev": true
     },
     "debug": {
@@ -525,12 +531,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -640,9 +640,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "inflight": {
@@ -663,7 +663,7 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
@@ -687,6 +687,15 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
       "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
+    },
+    "is-core-module": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -764,7 +773,8 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "lines-and-columns": {
       "version": "1.1.6",
@@ -974,11 +984,6 @@
         "semver": "^5.7.0"
       }
     },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -996,11 +1001,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -1034,23 +1034,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
-      }
-    },
-    "office-addin-cli": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.1.1.tgz",
-      "integrity": "sha512-Ey6+mHPZkBSM4UXVtNEK8w509k9vCRygDvqwjGKt/JNHUGUx7yxk1JhC0MPfGehDSlFX4LbQAp8muern8fgxXQ==",
-      "requires": {
-        "commander": "^6.2.1",
-        "node-fetch": "^2.6.1",
-        "read-package-json-fast": "^2.0.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
-        }
       }
     },
     "once": {
@@ -1122,15 +1105,6 @@
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
-    "read-package-json-fast": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.2.tgz",
-      "integrity": "sha512-5fyFUyO9B799foVk4n6ylcoAktG/FbE3jwRKxvwaeSrIunaoMc0u81dzXxjeAFKOce7O5KncdfwpGvvs6r5PsQ==",
-      "requires": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -1164,11 +1138,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -1182,9 +1157,9 @@
       }
     },
     "rxjs": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -1370,15 +1345,15 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "tslint": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.0.tgz",
-      "integrity": "sha512-fXjYd/61vU6da04E505OZQGb2VCN2Mq3doeWcOIryuG+eqdmFUXTYVwdhnbEu2k46LNLgUYt9bI5icQze/j0bQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1389,10 +1364,10 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.10.0",
+        "tslib": "^1.13.0",
         "tsutils": "^2.29.0"
       },
       "dependencies": {
@@ -1549,7 +1524,8 @@
     "y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",
@@ -1605,17 +1581,17 @@
           }
         },
         "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
           "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "20.2.6",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
-      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
       "dev": true
     },
     "yargs-unparser": {

--- a/packages/office-addin-usage-data/package.json
+++ b/packages/office-addin-usage-data/package.json
@@ -33,7 +33,7 @@
     "mocha": "^7.1.1",
     "rimraf": "^3.0.2",
     "ts-node": "^8.8.1",
-    "tslint": "^6.1.0",
+    "tslint": "^6.1.3",
     "typescript": "^3.8.3"
   },
   "repository": {

--- a/packages/office-addin-usage-data/package.json
+++ b/packages/office-addin-usage-data/package.json
@@ -29,7 +29,7 @@
     "@types/es6-promise": "3.3.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.34",
-    "concurrently": "^6.0.0",
+    "concurrently": "^6.0.2",
     "mocha": "^7.1.1",
     "rimraf": "^3.0.2",
     "ts-node": "^8.8.1",

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -272,11 +272,10 @@ export class OfficeAddinUsageData {
   public maskFilePaths(err: Error): Error {
     try {
       const regexRemoveUserFilePaths = /[\/\\](.*)[\/\\]/gmi;
-      const regexRemoveRelativeUserFilePathsFromStack = /\/(.*)\//gmi;
       const regexRemoveAbsoluteUserFilePathsFromStack = /\w:\\(?:[^\\\s]+\\)+/gmi;
-
-      err.message = err.message.replace(regexRemoveUserFilePaths, "");
-      err.stack = err.stack.replace(regexRemoveRelativeUserFilePathsFromStack, "");
+      const regexRemoveFirstFilePathFromStack = /\\(.*)\./i;
+      err.message = err.message.replace(regexRemoveUserFilePaths, "\\");
+      err.stack = err.stack.replace(regexRemoveFirstFilePathFromStack, "\\.");
       err.stack = err.stack.replace(regexRemoveAbsoluteUserFilePathsFromStack, "");
       return err;
     } catch (err) {

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -272,11 +272,12 @@ export class OfficeAddinUsageData {
   public maskFilePaths(err: Error): Error {
     try {
       const regexRemoveUserFilePaths = /[\/\\](.*)[\/\\]/gmi;
-      const regexRemoveUserFilePathsFromStack = /\w:[\\\/](?:[^[\\\/]\s]+[\\\/])+/gmi;
+      const regexRemoveRelativeUserFilePathsFromStack = /\/(.*)\//gmi;
+      const regexRemoveAbsoluteUserFilePathsFromStack = /\w:\\(?:[^\\\s]+\\)+/gmi;
 
       err.message = err.message.replace(regexRemoveUserFilePaths, "");
-      err.stack = err.stack.replace(regexRemoveUserFilePaths, "");
-      err.stack = err.stack.replace(regexRemoveUserFilePathsFromStack, "");
+      err.stack = err.stack.replace(regexRemoveRelativeUserFilePathsFromStack, "");
+      err.stack = err.stack.replace(regexRemoveAbsoluteUserFilePathsFromStack, "");
       return err;
     } catch (err) {
       this.reportError("maskFilePaths", err);

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -271,8 +271,9 @@ export class OfficeAddinUsageData {
    */
   public maskFilePaths(err: Error): Error {
     try {
-      const regexRemoveUserFilePaths = /\/(.*)\//gmi;
-      const regexRemoveUserFilePathsFromStack = /\w:\\(?:[^\\\s]+\\)+/gmi;
+      const regexRemoveUserFilePaths = /[\/\\](.*)[\/\\]/gmi;
+      const regexRemoveUserFilePathsFromStack = /\w:[\\\/](?:[^[\\\/]\s]+[\\\/])+/gmi;
+
       err.message = err.message.replace(regexRemoveUserFilePaths, "");
       err.stack = err.stack.replace(regexRemoveUserFilePaths, "");
       err.stack = err.stack.replace(regexRemoveUserFilePathsFromStack, "");

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -159,7 +159,7 @@ describe("Test office-addin-usage data-package", function() {
     });
   });
   describe("Test maskFilePaths method", () => {
-    it("should return a parsed file path error", () => {
+    it("should parse error file paths with slashs", () => {
       addInUsageData.setUsageDataOff();
       const compareError = new Error();
       compareError.name = "TestData-test";
@@ -170,7 +170,9 @@ describe("Test office-addin-usage data-package", function() {
       assert.equal(compareError.name, err.name);
       assert.equal(compareError.message, err.message);
       assert.equal(err.stack.includes(compareError.stack), true);
-
+    });
+    it("should parse error file paths with backslashs", () => {
+      addInUsageData.setUsageDataOff();
       const compareErrorWithBackslash = new Error();
       compareErrorWithBackslash.message = "this error contains a file path:C:\\excel file .xlsx";
       compareErrorWithBackslash.stack = "this error contains a file path:C:\\.xlsx";;

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -163,17 +163,17 @@ describe("Test office-addin-usage data-package", function() {
       addInUsageData.setUsageDataOff();
       const compareError = new Error();
       compareError.name = "TestData-test";
-      compareError.message = "this error contains a file path:C:index.js";
+      compareError.message = "this error contains a file path:C:\\index.js";
       // may throw error if change any part of the top of the test file
-      compareError.stack = "this error contains a file path:C:index.js";
+      compareError.stack = "this error contains a file path:C:\\.js";
       addInUsageData.maskFilePaths(err);
       assert.equal(compareError.name, err.name);
       assert.equal(compareError.message, err.message);
       assert.equal(err.stack.includes(compareError.stack), true);
 
       const compareErrorWithBackslash = new Error();
-      compareErrorWithBackslash.message = "this error contains a file path:C:excel file .xlsx";
-      compareErrorWithBackslash.stack = "this error contains a file path:C:excel file .xlsx";;
+      compareErrorWithBackslash.message = "this error contains a file path:C:\\excel file .xlsx";
+      compareErrorWithBackslash.stack = "this error contains a file path:C:\\.xlsx";;
       addInUsageData.maskFilePaths(errWithBackslash);
       assert.equal(compareErrorWithBackslash.message, errWithBackslash.message);
       assert.equal(errWithBackslash.stack.includes(compareErrorWithBackslash.stack), true);

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -12,7 +12,7 @@ import * as jsonData from "../src/usageDataSettings";
 
 let addInUsageData: officeAddinUsageData.OfficeAddinUsageData;
 const err = new Error(`this error contains a file path:C:/${os.homedir()}/AppData/Roaming/npm/node_modules//alanced-match/index.js`);
-const errWithBackslash = new Error(`this error contains a file path C:\\Users\\admin\\AppData\\Local\Temp\\excel file .xlsx`);
+const errWithBackslash = new Error(`this error contains a file path:C:\\Users\\admin\\AppData\\Local\Temp\\excel file .xlsx`);
 let usageData: string;
 const usageDataObject: officeAddinUsageData.IUsageDataOptions = {
   groupName: "office-addin-usage-data",
@@ -172,8 +172,8 @@ describe("Test office-addin-usage data-package", function() {
       assert.equal(err.stack.includes(compareError.stack), true);
 
       const compareErrorWithBackslash = new Error();
-      compareErrorWithBackslash.message = "this error contains a file path C:excel file .xlsx";
-      compareErrorWithBackslash.stack = "this error contains a file path C:excel file .xlsx";;
+      compareErrorWithBackslash.message = "this error contains a file path:C:excel file .xlsx";
+      compareErrorWithBackslash.stack = "this error contains a file path:C:excel file .xlsx";;
       addInUsageData.maskFilePaths(errWithBackslash);
       assert.equal(compareErrorWithBackslash.message, errWithBackslash.message);
       assert.equal(errWithBackslash.stack.includes(compareErrorWithBackslash.stack), true);

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -12,6 +12,7 @@ import * as jsonData from "../src/usageDataSettings";
 
 let addInUsageData: officeAddinUsageData.OfficeAddinUsageData;
 const err = new Error(`this error contains a file path:C:/${os.homedir()}/AppData/Roaming/npm/node_modules//alanced-match/index.js`);
+const errWithBackslash = new Error(`this error contains a file path C:\\Users\\admin\\AppData\\Local\Temp\\excel file .xlsx`);
 let usageData: string;
 const usageDataObject: officeAddinUsageData.IUsageDataOptions = {
   groupName: "office-addin-usage-data",
@@ -169,6 +170,13 @@ describe("Test office-addin-usage data-package", function() {
       assert.equal(compareError.name, err.name);
       assert.equal(compareError.message, err.message);
       assert.equal(err.stack.includes(compareError.stack), true);
+
+      const compareErrorWithBackslash = new Error();
+      compareErrorWithBackslash.message = "this error contains a file path C:excel file .xlsx";
+      compareErrorWithBackslash.stack = "this error contains a file path C:excel file .xlsx";;
+      addInUsageData.maskFilePaths(errWithBackslash);
+      assert.equal(compareErrorWithBackslash.message, errWithBackslash.message);
+      assert.equal(errWithBackslash.stack.includes(compareErrorWithBackslash.stack), true);
     });
   });
 


### PR DESCRIPTION
What was done:
- Added some Expected Errors on some errors that were missing.
- Adding better debug message to `Sideload is not supported` error.
- Changing the `maskFilePaths` function to trim absolute files up to extension.
  - Before: C:\path\filename.ext would be trimmed to C:\\filename.ext
  - Now: C:\path\filename.ext would be trimmed to C:\\.ext
  - This needed to be done because sometimes the filename may contain an UID
- Adding more unit tests for this `maskFilePaths` function.