### PR TITLE
Making enableLiveReload default to true

### DIFF
--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -264,7 +264,8 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
         // Defaults when variable is undefined.
         debuggingMethod: options.debuggingMethod || defaultDebuggingMethod(),
         enableDebugging: options.enableDebugging ?? true,   
-        enableSideload: options.enableSideload ?? true
+        enableSideload: options.enableSideload ?? true,
+        enableLiveReload: options.enableLiveReload ?? true
     };
 
     try {


### PR DESCRIPTION
This change is needed to workaround a minor and subtle that is happening when startDebugging is called directly, with this `liveReload` not set. 

The reason for the fix is that the template Excel Custom Functions on the script `npm run test` doesn't properly load the custom functions given this bug. 