### PR TITLE
Update README.md

### DIFF
--- a/packages/office-addin-dev-certs/README.md
+++ b/packages/office-addin-dev-certs/README.md
@@ -69,7 +69,7 @@ Uninstall the CA certificate for all users. You must be an Administrator.
 ```js
 var https = require('https')
 var devCerts = require("office-addin-dev-certs");
-var options =  devCerts.getHttpsServerOptions();
+var options =  await devCerts.getHttpsServerOptions();
 
 var server = https.createServer(options, function (req, res) {
   res.end('This is servered over HTTPS')


### PR DESCRIPTION
Add missing await.

I know this is on top level, but passing options to `https.createServer()` is incorrect, since it's a `Promise`.