### PR TITLE
Adding test config for office-addin-lint

### DIFF
--- a/packages/eslint-plugin-office-addins/src/main.ts
+++ b/packages/eslint-plugin-office-addins/src/main.ts
@@ -24,10 +24,29 @@ module.exports = {
       },
     },
     react: {
+      plugins: ["office-addins", "react"],
       extends: ["plugin:office-addins/recommended", "plugin:react/recommended"],
+      settings: {
+        react: {
+          "version": "detect"
+        },
+      },
     },
     reactnative: {
+      plugins: ["office-addins", "react-native"],
       extends: ["plugin:office-addins/recommended", "plugin:react-native/all"],
+      settings: {
+        react: {
+          "version": "detect"
+        },
+      },
+    },
+    test: {
+      plugins: ["office-addins"],
+      extends: ["plugin:office-addins/recommended"],
+      rules: {
+        "office-addins/no-context-sync-in-loop": "warn",
+      },
     },
   },
 };

--- a/packages/office-addin-lint/config/.eslintrc.test.json
+++ b/packages/office-addin-lint/config/.eslintrc.test.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "office-addins"
+  ],
+  "extends": [
+    "plugin:office-addins/test"
+  ]
+}

--- a/packages/office-addin-lint/src/cli.ts
+++ b/packages/office-addin-lint/src/cli.ts
@@ -14,12 +14,14 @@ commander.version(process.env.npm_package_version || "(version not available)");
 commander
   .command("check")
   .option("--files <files>", `Specifies the source files to check. Default: ${defaults.lintFiles}`)
+  .option("--test", "Use the test lint configuration")
   .description(`Check source files against lint rules.`)
   .action(commands.lint);
 
 commander
   .command("fix")
   .option("--files <files>", `Specifies the source files to fix. Default: ${defaults.lintFiles}`)
+  .option("--test", "Use the test lint configuration")
   .description(`Apply fixes to source based on lint rules.`)
   .action(commands.lintFix);
 

--- a/packages/office-addin-lint/src/commands.ts
+++ b/packages/office-addin-lint/src/commands.ts
@@ -22,7 +22,8 @@ function getPathToFiles(command: commander.Command): string {
 export async function lint(command: commander.Command) {
   try {
     const pathToFiles: string = getPathToFiles(command);
-    await performLintCheck(pathToFiles);
+    const useTestConfig: boolean = command.test;
+    await performLintCheck(pathToFiles, useTestConfig);
     usageDataObject.reportSuccess("lint");
   } catch (err) {
     if (typeof err.status == "number") {
@@ -38,7 +39,8 @@ export async function lint(command: commander.Command) {
 export async function lintFix(command: commander.Command) {
   try {
     const pathToFiles: string = getPathToFiles(command);
-    await performLintFix(pathToFiles);
+    const useTestConfig: boolean = command.test;
+    await performLintFix(pathToFiles, useTestConfig);
     usageDataObject.reportSuccess("lintFix");
   } catch (err) {
     if (typeof err.status == "number") {

--- a/packages/office-addin-lint/src/lint.ts
+++ b/packages/office-addin-lint/src/lint.ts
@@ -21,7 +21,7 @@ function normalizeFilePath(filePath: string): string {
   return filePath.replace(/ /g, "\\ "); // Converting space to '\\'
 }
 
-function getEsLintBaseCommand(useTestConfig: boolean): string {
+function getEsLintBaseCommand(useTestConfig: boolean = false): string {
   const configFilePath = useTestConfig ? eslintTestConfigPath : eslintConfigPath
   const eslintBaseCommand: string = `node ${eslintFilePath} -c ${configFilePath} --resolve-plugins-relative-to ${__dirname}`;
   return eslintBaseCommand;
@@ -32,7 +32,7 @@ export function getLintCheckCommand(files: string, useTestConfig: boolean = fals
   return eslintCommand;
 }
 
-export function performLintCheck(files: string, useTestConfig: boolean) {
+export function performLintCheck(files: string, useTestConfig: boolean = false) {
   try {
     const command = getLintCheckCommand(files, useTestConfig);
     execCommand(command);
@@ -52,7 +52,7 @@ export function getLintFixCommand(files: string, useTestConfig: boolean = false)
   return eslintCommand;
 }
 
-export function performLintFix(files: string, useTestConfig: boolean) {
+export function performLintFix(files: string, useTestConfig: boolean = false) {
   try {
     const command = getLintFixCommand(files, useTestConfig);
     execCommand(command);

--- a/packages/office-addin-lint/src/lint.ts
+++ b/packages/office-addin-lint/src/lint.ts
@@ -4,12 +4,13 @@
 import * as path from "path";
 import { usageDataObject, ESLintExitCode, PrettierExitCode } from "./defaults";
 
-const esLintPath = require.resolve("eslint");
+const eslintPath = require.resolve("eslint");
 const prettierPath = require.resolve("prettier");
-const esLintDir = path.parse(esLintPath).dir;
-const esLintFilePath = path.resolve(esLintDir, "../bin/eslint.js");
+const eslintDir = path.parse(eslintPath).dir;
+const eslintFilePath = path.resolve(eslintDir, "../bin/eslint.js");
 const prettierFilePath = path.resolve(prettierPath, "../bin-prettier.js");
-const esLintConfigPath = path.resolve(__dirname, "../config/.eslintrc.json");
+const eslintConfigPath = path.resolve(__dirname, "../config/.eslintrc.json");
+const eslintTestConfigPath = path.resolve(__dirname, "../config/.eslintrc.test.json");
 
 function execCommand(command: string) {
   const execSync = require("child_process").execSync;
@@ -20,19 +21,20 @@ function normalizeFilePath(filePath: string): string {
   return filePath.replace(/ /g, "\\ "); // Converting space to '\\'
 }
 
-function getEsLintBaseCommand(): string {
-  const eslintBaseCommand: string = `node ${esLintFilePath} -c ${esLintConfigPath} --resolve-plugins-relative-to ${__dirname}`;
+function getEsLintBaseCommand(useTestConfig: boolean): string {
+  const configFilePath = useTestConfig ? eslintTestConfigPath : eslintConfigPath
+  const eslintBaseCommand: string = `node ${eslintFilePath} -c ${configFilePath} --resolve-plugins-relative-to ${__dirname}`;
   return eslintBaseCommand;
 }
 
-export function getLintCheckCommand(files: string): string {
-  const eslintCommand: string = `${getEsLintBaseCommand()} ${normalizeFilePath(files)}`;
+export function getLintCheckCommand(files: string, useTestConfig: boolean = false): string {
+  const eslintCommand: string = `${getEsLintBaseCommand(useTestConfig)} ${normalizeFilePath(files)}`;
   return eslintCommand;
 }
 
-export function performLintCheck(files: string) {
+export function performLintCheck(files: string, useTestConfig: boolean) {
   try {
-    const command = getLintCheckCommand(files);
+    const command = getLintCheckCommand(files, useTestConfig);
     execCommand(command);
     usageDataObject.reportSuccess("performLintCheck()", { exitCode: ESLintExitCode.NoLintErrors });
   } catch (err) {
@@ -45,14 +47,14 @@ export function performLintCheck(files: string) {
   }
 }
 
-export function getLintFixCommand(files: string): string {
-  const eslintCommand: string = `${getEsLintBaseCommand()} --fix ${normalizeFilePath(files)}`;
+export function getLintFixCommand(files: string, useTestConfig: boolean = false): string {
+  const eslintCommand: string = `${getEsLintBaseCommand(useTestConfig)} --fix ${normalizeFilePath(files)}`;
   return eslintCommand;
 }
 
-export function performLintFix(files: string) {
+export function performLintFix(files: string, useTestConfig: boolean) {
   try {
-    const command = getLintFixCommand(files);
+    const command = getLintFixCommand(files, useTestConfig);
     execCommand(command);
     usageDataObject.reportSuccess("performLintFix()", { exitCode: ESLintExitCode.NoLintErrors });
   } catch (err) {

--- a/packages/office-addin-lint/test/src/test.ts
+++ b/packages/office-addin-lint/test/src/test.ts
@@ -11,15 +11,15 @@ describe("test cases", function() {
     it("eslint and prettier commands", async function() {
         const inputFile = "./test/cases/basic/functions.ts";
         const lintExpectedCommand = "./test/cases/basic/functions.ts";
-        const lintTestExpectedCommand = ".eslintrc.test.json"
         const lintFixExpectedCommand = "--fix ./test/cases/basic/functions.ts";
         const prettierExpectedCommand = "--parser typescript --write ./test/cases/basic/functions.ts";
+        const lintExpectedTestConfig = ".eslintrc.test.json";
 
         const lintCheckCommand = prettierLint.getLintCheckCommand(inputFile);
         assert.strictEqual(lintCheckCommand.indexOf(lintExpectedCommand) > 0 , true, "Lint command does not match expected value.");
 
-        const lintCheckTestCommand = prettierLint.getLintCheckCommand(inputFile, true);
-        assert.strictEqual(lintCheckTestCommand.indexOf(lintTestExpectedCommand) > 0 , true, "Lint test command does not match expected value.");
+        const lintCheckConfig = prettierLint.getLintCheckCommand(inputFile, true);
+        assert.strictEqual(lintCheckConfig.indexOf(lintExpectedTestConfig) > 0 , true, "Lint test command does not match expected value.");
 
         const lintFixCommand = prettierLint.getLintFixCommand(inputFile);
         assert.strictEqual(lintFixCommand.indexOf(lintFixExpectedCommand) > 0, true, "Lint fix command does not match expected value.");

--- a/packages/office-addin-lint/test/src/test.ts
+++ b/packages/office-addin-lint/test/src/test.ts
@@ -11,11 +11,15 @@ describe("test cases", function() {
     it("eslint and prettier commands", async function() {
         const inputFile = "./test/cases/basic/functions.ts";
         const lintExpectedCommand = "./test/cases/basic/functions.ts";
+        const lintTestExpectedCommand = ".eslintrc.test.json"
         const lintFixExpectedCommand = "--fix ./test/cases/basic/functions.ts";
         const prettierExpectedCommand = "--parser typescript --write ./test/cases/basic/functions.ts";
 
         const lintCheckCommand = prettierLint.getLintCheckCommand(inputFile);
         assert.strictEqual(lintCheckCommand.indexOf(lintExpectedCommand) > 0 , true, "Lint command does not match expected value.");
+
+        const lintCheckTestCommand = prettierLint.getLintCheckCommand(inputFile, true);
+        assert.strictEqual(lintCheckTestCommand.indexOf(lintTestExpectedCommand) > 0 , true, "Lint test command does not match expected value.");
 
         const lintFixCommand = prettierLint.getLintFixCommand(inputFile);
         assert.strictEqual(lintFixCommand.indexOf(lintFixExpectedCommand) > 0, true, "Lint fix command does not match expected value.");


### PR DESCRIPTION
Adding another config in eslint-plugin-office-addings and a command argument in office-addin-lint to use it.  This will also us to add rules to the test config and then once they are in then the test project only have to adjust their call to use the test lint config instead of symlinking between the different parts locally (plugin, lint, and template).