### PR TITLE
Add license, repository and bugs information

### DIFF
--- a/packages/eslint-plugin-excel-custom-functions/package.json
+++ b/packages/eslint-plugin-excel-custom-functions/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.19",
   "description": "ESLint rules that report usage of Office Api Code in Shared App",
   "author": "Artur Tarasenko <artarase@microsoft.com>",
+  "license": "MIT",
   "main": "dist/index.js",
   "files": [
     "dist"
@@ -53,6 +54,13 @@
     "semantic-release": "^17.3.7",
     "ts-jest": "^26.4.0",
     "typescript": "^4.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OfficeDev/Office-Addin-Scripts"
+  },
+  "bugs": {
+    "url": "https://github.com/OfficeDev/Office-Addin-Scripts/issues"
   },
   "config": {
     "commitizen": {

--- a/packages/office-addin-prettier-config/package.json
+++ b/packages/office-addin-prettier-config/package.json
@@ -7,5 +7,12 @@
     "test": "echo \"No tests\" "
   },
   "author": "OfficeDev",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OfficeDev/Office-Addin-Scripts"
+  },
+  "bugs": {
+    "url": "https://github.com/OfficeDev/Office-Addin-Scripts/issues"
+  }
 }


### PR DESCRIPTION
Package **eslint-plugin-excel-custom-functions** was missing these fields.

```
eslint-plugin-excel-custom-functions: npm WARN eslint-plugin-excel-custom-functions@0.0.19 requires a peer of eslint@^7.9.0 but none is installed. You must install peer dependencies yourself.
eslint-plugin-excel-custom-functions: npm WARN eslint-plugin-excel-custom-functions@0.0.19 No repository field.
eslint-plugin-excel-custom-functions: npm WARN eslint-plugin-excel-custom-functions@0.0.19 No license field.
```

Package **office-addin-prettier-config** was missing the repository field.

```
office-addin-prettier-config: npm WARN office-addin-prettier-config@1.0.16 No repository field.
```