### PR TITLE
Error message for credential store

### DIFF
--- a/packages/office-addin-sso/src/server.ts
+++ b/packages/office-addin-sso/src/server.ts
@@ -38,6 +38,7 @@ export class SSOService {
       usageDataObject.reportSuccess("startSsoService()");
       return Promise.resolve(true);
     } catch (err) {
+      console.error(`Failed to start SSO server. ${err}`);
       usageDataObject.reportException("startSsoService()", err);
       return Promise.reject(false);
     }
@@ -47,7 +48,7 @@ export class SSOService {
     const manifestInfo = await manifest.readManifestFile(this.manifestPath);
     const appSecret = getSecretFromCredentialStore(manifestInfo.displayName, isTest);
     if (appSecret === "") {
-      const errorMessage: string = "Call to getSecretFromCredentialStore returned empty string";
+      const errorMessage: string = `Credential store does not have secret for '${manifestInfo.displayName}'.`;
       throw new Error(errorMessage);
     }
     process.env.secret = appSecret;


### PR DESCRIPTION
Display error message when the credential store does not have secret for the current application.

This changes the behavior of the **getSecret** method called by **startSsoService**.
When the application does not have secret stored in the credential store the script will fail without any indication of what is wrong.

**Current behavior**
```
$ npm run start:server

> outlook-sso@0.0.0 start:server C:\dev\Outlook SSO
> office-addin-sso start manifest.xml

(node:35208) UnhandledPromiseRejectionWarning: false
(Use `node --trace-warnings ...` to show where the warning was created)
(node:35208) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting 
a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:35208) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**Improved behavior**
```
$ npm run start:server

> outlook-sso@0.0.0 start:server C:\dev\Outlook SSO
> office-addin-sso start manifest.xml

Failed to start SSO server. Error: Credential store does not have secret for 'Outlook SSO'.
(node:35208) UnhandledPromiseRejectionWarning: false
(Use `node --trace-warnings ...` to show where the warning was created)
(node:35208) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting 
a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:35208) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```