### PR TITLE
Remove requirement to be in run method for no-context-sync-in-loop rule

### DIFF
--- a/packages/eslint-plugin-office-addins/src/rules/no-context-sync-in-loop.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/no-context-sync-in-loop.ts
@@ -21,7 +21,7 @@ export = {
   },
   create: function (context: any) {
     return {
-      "CallExpression[callee.property.name='run'] :matches(ForStatement, ForInStatement, WhileStatement, DoWhileStatement, ForOfStatement) CallExpression[callee.object.name='context'][callee.property.name='sync']"(
+      ":matches(ForStatement, ForInStatement, WhileStatement, DoWhileStatement, ForOfStatement) CallExpression[callee.object.name='context'][callee.property.name='sync']"(
         node: TSESTree.CallExpression
       ) {
         context.report({


### PR DESCRIPTION
It might flag more then desired, but I think it's better then potentially missing a bunch.