### PR TITLE
Switch some command to retry on failure

### DIFF
--- a/packages/office-addin-sso/src/commands.ts
+++ b/packages/office-addin-sso/src/commands.ts
@@ -69,7 +69,7 @@ export async function configureSSO(manifestPath: string) {
       // Grant admin consent for application if logged-in user is a tenant admin
       if (await configure.isUserTenantAdmin(userJson)) {
         console.log("Granting admin consent");
-        await configure.grantAdminContent(applicationJson);
+        await configure.grantAdminConsent(applicationJson);
         // Check to set if SharePoint reply urls are set for tenant. If not, set them
         const setSharePointReplyUrls: boolean = await configure.setSharePointTenantReplyUrls(
           applicationJson["publisherDomain"].substr(0, applicationJson["publisherDomain"].indexOf("."))

--- a/packages/office-addin-sso/src/configure.ts
+++ b/packages/office-addin-sso/src/configure.ts
@@ -38,8 +38,8 @@ export async function createNewApplication(
 export async function grantAdminConsent(applicationJson: Object): Promise<void> {
   const azRestCommand: string = `az ad app permission admin-consent --id ${applicationJson["appId"]}`;
   let consented: boolean = await waitUntil(() => tryRunAzureCommand(azRestCommand), 10, 1000);
-  
-  if(!consented) {
+
+  if (!consented) {
     const errorMessage: string = `Unable to set grant admin consent.  See results of each attempts`;
     throw new Error(errorMessage);
   } else {
@@ -201,8 +201,8 @@ export async function setIdentifierUri(applicationJson: Object, port: string): P
     .replace("<App_Id>", applicationJson["appId"])
     .replace("{PORT}", port.toString());
   let identifierSet: boolean = await waitUntil(() => tryRunAzureCommand(azRestCommand), 10, 1000);
-  
-  if(!identifierSet) {
+
+  if (!identifierSet) {
     const errorMessage: string = `Unable to set identifierUri.  See results of each attempt`;
     throw new Error(errorMessage);
   } else {
@@ -214,8 +214,8 @@ export async function setSignInAudience(applicationJson: Object): Promise<void> 
   let azRestCommand: string = fs.readFileSync(defaults.azRestSetSigninAudienceCommandPath, "utf8");
   azRestCommand = azRestCommand.replace("<App_Object_ID>", applicationJson["id"]);
   let signInAudienceSet: boolean = await waitUntil(() => tryRunAzureCommand(azRestCommand), 10, 1000);
-  
-  if(!signInAudienceSet) {
+
+  if (!signInAudienceSet) {
     const errorMessage: string = `Unable to set signInAudience.  See results of each attempt`;
     throw new Error(errorMessage);
   } else {
@@ -321,15 +321,11 @@ export async function setOutlookTenantReplyUrl(): Promise<boolean> {
   }
 }
 
-async function waitUntil(
-  callback: () => Promise<boolean>,
-  retryCount: number,
-  retryDelay: number
-): Promise<boolean> {
+async function waitUntil(callback: () => Promise<boolean>, retryCount: number, retryDelay: number): Promise<boolean> {
   let done: boolean = false;
   let attempts: number = 0;
 
-  while (!done && attempts <=  retryCount) {
+  while (!done && attempts <= retryCount) {
     console.log(`    Attempt ${attempts + 1}`);
     await delay(retryDelay);
     done = await callback();
@@ -345,7 +341,7 @@ function delay(milliseconds: number): Promise<void> {
   });
 }
 
-async function tryRunAzureCommand(azureCommand: string){
+async function tryRunAzureCommand(azureCommand: string) {
   try {
     await promiseExecuteCommand(azureCommand);
     return true;
@@ -368,7 +364,7 @@ async function checkIsApplicationReady(appId: string): Promise<boolean> {
 }
 
 async function isApplicationReady(appId: string): Promise<boolean> {
-  // Check to see if the application is available 
+  // Check to see if the application is available
   let appReady: boolean = false;
   let counter: number = 0;
   while (appReady === false && counter <= 50) {

--- a/packages/office-addin-sso/src/configure.ts
+++ b/packages/office-addin-sso/src/configure.ts
@@ -24,6 +24,10 @@ export async function createNewApplication(
     const rePort = new RegExp("{PORT}", "g");
     azRestCommand = azRestCommand.replace(reName, ssoAppName).replace(rePort, port);
     const applicationJson: Object = await promiseExecuteCommand(azRestCommand, true /* returnJson */);
+
+    if (applicationJson) {
+      await isApplicationReady(applicationJson["appId"]);
+    }
     return applicationJson;
   } catch (err) {
     const errorMessage: string = `Unable to register new application: \n${err}`;
@@ -31,37 +35,15 @@ export async function createNewApplication(
   }
 }
 
-async function applicationReady(applicationJson: Object): Promise<boolean> {
-  try {
-    const azRestCommand: string = `az ad app show --id ${applicationJson["appId"]}`;
-    const appJson: Object = await promiseExecuteCommand(azRestCommand, true /* returnJson */, true /* expectError */);
-    return appJson !== "";
-  } catch (err) {
-    const errorMessage: string = `Unable to get application info: \n${err}`;
+export async function grantAdminConsent(applicationJson: Object): Promise<void> {
+  const azRestCommand: string = `az ad app permission admin-consent --id ${applicationJson["appId"]}`;
+  let consented: boolean = await waitUntil(() => tryRunAzureCommand(azRestCommand), 10, 1000);
+  
+  if(!consented) {
+    const errorMessage: string = `Unable to set grant admin consent.  See results of each attempts`;
     throw new Error(errorMessage);
-  }
-}
-
-export async function grantAdminContent(applicationJson: Object): Promise<void> {
-  try {
-    // Check to see if the application is available before granting admin consent
-    let appReady: boolean = false;
-    let counter: number = 0;
-    while (appReady === false && counter <= 50) {
-      appReady = await applicationReady(applicationJson);
-      counter++;
-    }
-
-    if (counter > 50) {
-      // Application does not appear to be ready to grant admin consent
-      return;
-    }
-
-    const azRestCommand: string = `az ad app permission admin-consent --id ${applicationJson["appId"]}`;
-    await promiseExecuteCommand(azRestCommand);
-  } catch (err) {
-    const errorMessage: string = `Unable to set grant admin consent: \n${err}`;
-    throw new Error(errorMessage);
+  } else {
+    console.log("Consent granted");
   }
 }
 
@@ -213,27 +195,31 @@ export async function setApplicationSecret(applicationJson: Object): Promise<str
 }
 
 export async function setIdentifierUri(applicationJson: Object, port: string): Promise<void> {
-  try {
-    let azRestCommand: string = await fs.readFileSync(defaults.azRestSetIdentifierUriCommmandPath, "utf8");
-    azRestCommand = azRestCommand
-      .replace("<App_Object_ID>", applicationJson["id"])
-      .replace("<App_Id>", applicationJson["appId"])
-      .replace("{PORT}", port.toString());
-    await promiseExecuteCommand(azRestCommand);
-  } catch (err) {
-    const errorMessage: string = `Unable to set identifierUri: \n${err}`;
+  let azRestCommand: string = await fs.readFileSync(defaults.azRestSetIdentifierUriCommmandPath, "utf8");
+  azRestCommand = azRestCommand
+    .replace("<App_Object_ID>", applicationJson["id"])
+    .replace("<App_Id>", applicationJson["appId"])
+    .replace("{PORT}", port.toString());
+  let identifierSet: boolean = await waitUntil(() => tryRunAzureCommand(azRestCommand), 10, 1000);
+  
+  if(!identifierSet) {
+    const errorMessage: string = `Unable to set identifierUri.  See results of each attempt`;
     throw new Error(errorMessage);
+  } else {
+    console.log("Itendifier Set");
   }
 }
 
 export async function setSignInAudience(applicationJson: Object): Promise<void> {
-  try {
-    let azRestCommand: string = fs.readFileSync(defaults.azRestSetSigninAudienceCommandPath, "utf8");
-    azRestCommand = azRestCommand.replace("<App_Object_ID>", applicationJson["id"]);
-    await promiseExecuteCommand(azRestCommand);
-  } catch (err) {
-    const errorMessage: string = `Unable to set signInAudience: \n${err}`;
+  let azRestCommand: string = fs.readFileSync(defaults.azRestSetSigninAudienceCommandPath, "utf8");
+  azRestCommand = azRestCommand.replace("<App_Object_ID>", applicationJson["id"]);
+  let signInAudienceSet: boolean = await waitUntil(() => tryRunAzureCommand(azRestCommand), 10, 1000);
+  
+  if(!signInAudienceSet) {
+    const errorMessage: string = `Unable to set signInAudience.  See results of each attempt`;
     throw new Error(errorMessage);
+  } else {
+    console.log("Sign In Audience Set");
   }
 }
 
@@ -333,4 +319,61 @@ export async function setOutlookTenantReplyUrl(): Promise<boolean> {
     usageDataObject.reportException("setOutlookTenantReplyUrls()", errorMessage);
     throw new Error(errorMessage);
   }
+}
+
+async function waitUntil(
+  callback: () => Promise<boolean>,
+  retryCount: number,
+  retryDelay: number
+): Promise<boolean> {
+  let done: boolean = false;
+  let attempts: number = 0;
+
+  while (!done && attempts <=  retryCount) {
+    console.log(`    Attempt ${attempts + 1}`);
+    await delay(retryDelay);
+    done = await callback();
+    attempts++;
+  }
+
+  return done;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+async function tryRunAzureCommand(azureCommand: string){
+  try {
+    await promiseExecuteCommand(azureCommand);
+    return true;
+  } catch (err) {
+    const errorMessage: string = `    Failed to run ${azureCommand}: \n${err}`;
+    console.log(errorMessage);
+    return false;
+  }
+}
+
+async function checkIsApplicationReady(appId: string): Promise<boolean> {
+  try {
+    const azRestCommand: string = `az ad app show --id ${appId}`;
+    const appJson: Object = await promiseExecuteCommand(azRestCommand, true /* returnJson */, true /* expectError */);
+    return appJson !== "";
+  } catch (err) {
+    const errorMessage: string = `Unable to get application info: \n${err}`;
+    throw new Error(errorMessage);
+  }
+}
+
+async function isApplicationReady(appId: string): Promise<boolean> {
+  // Check to see if the application is available 
+  let appReady: boolean = false;
+  let counter: number = 0;
+  while (appReady === false && counter <= 50) {
+    appReady = await checkIsApplicationReady(appId);
+    counter++;
+  }
+  return appReady;
 }


### PR DESCRIPTION
We are getting errors when trying to configure the new sso app.  It seems that the app isn't quite ready when try to change it, but there doesn't seem to be a great way to check for app readiness.  Adding some failure retries in order eventually get success.