### PR TITLE
Fix sync after load rule bug

### DIFF
--- a/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
@@ -68,11 +68,14 @@ export = {
           const propertyName: string = findPropertiesRead(
             reference.identifier.parent
           );
-          const variableProperty: VariableProperty = { variable: variable.name, property: propertyName };
+          const variableProperty: VariableProperty = {
+            variable: variable.name,
+            property: propertyName,
+          };
           if (
-            needSync.has(variableProperty) 
-            && wasLoaded.has(variableProperty) 
-            && hasSync
+            needSync.has(variableProperty) &&
+            wasLoaded.has(variableProperty) &&
+            hasSync
           ) {
             const node = reference.identifier;
             context.report({

--- a/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
@@ -43,6 +43,8 @@ export = {
 
     function findLoadBeforeSync(): void {
       const needSync: VariablePropertySet = new VariablePropertySet();
+      const wasLoaded: VariablePropertySet = new VariablePropertySet();
+      let hasSync = false;
 
       apiReferences.forEach((apiReference) => {
         const operation = apiReference.operation;
@@ -54,9 +56,11 @@ export = {
             reference.identifier.parent
           );
           needSync.add({ variable: variable.name, property: propertyName });
+          wasLoaded.add({ variable: variable.name, property: propertyName });
         }
 
         if (operation === "Sync") {
+          hasSync = true;
           needSync.clear();
         }
 
@@ -64,9 +68,11 @@ export = {
           const propertyName: string = findPropertiesRead(
             reference.identifier.parent
           );
-
+          const variableProperty: VariableProperty = { variable: variable.name, property: propertyName };
           if (
-            needSync.has({ variable: variable.name, property: propertyName })
+            needSync.has(variableProperty) 
+            && wasLoaded.has(variableProperty) 
+            && hasSync
           ) {
             const node = reference.identifier;
             context.report({

--- a/packages/eslint-plugin-office-addins/test/rules/call-sync-after-load.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/call-sync-after-load.test.ts
@@ -27,7 +27,19 @@ ruleTester.run('call-sync-after-load', rule, {
         await context.sync();
         property.load("props");
         console.log(property.props);`
-    }
+    },
+    {
+      code: `
+        var property = worksheet.getItem("sheet");
+        await context.sync();
+        console.log(property.values);`
+    },
+    {
+      code: `
+        var property = worksheet.getItem("sheet");
+        property.load("values");
+        console.log(property.values);`
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixed the load after load rule bug where it was also firing when there was no sync (only load).
We don't want to fire in this case, as it would create a case where one code would fire twice with rule call-sync-before-read (any code missing sync but that had load).
