### PR TITLE
Adding a check to see if load is empty

### DIFF
--- a/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
@@ -57,8 +57,10 @@ export = {
           variable &&
           identifier.parent?.type == TSESTree.AST_NODE_TYPES.MemberExpression
         ) {
-          const propertyName: string = getLoadArgument(identifier.parent);
-          needSync.add({ variable: variable.name, property: propertyName });
+          const propertyName: string | undefined = getLoadArgument(identifier.parent);
+          if (propertyName) {
+            needSync.add({ variable: variable.name, property: propertyName });
+          }
         }
 
         if (operation === "Sync") {

--- a/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
@@ -57,7 +57,9 @@ export = {
           variable &&
           identifier.parent?.type == TSESTree.AST_NODE_TYPES.MemberExpression
         ) {
-          const propertyName: string | undefined = getLoadArgument(identifier.parent);
+          const propertyName: string | undefined = getLoadArgument(
+            identifier.parent
+          );
           if (propertyName) {
             needSync.add({ variable: variable.name, property: propertyName });
           }

--- a/packages/eslint-plugin-office-addins/src/rules/load-object-before-read.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/load-object-before-read.ts
@@ -75,7 +75,10 @@ export = {
           if (node.parent?.type === TSESTree.AST_NODE_TYPES.MemberExpression) {
             if (isLoadFunction(node.parent)) {
               // In case it is a load function
-              loadLocation.set(getLoadArgument(node.parent), node.range[1]);
+              const loadArgument: string | undefined = getLoadArgument(node.parent);
+              if (loadArgument) {
+                loadLocation.set(loadArgument, node.range[1]);
+              }
               return;
             }
           }

--- a/packages/eslint-plugin-office-addins/src/rules/load-object-before-read.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/load-object-before-read.ts
@@ -75,7 +75,9 @@ export = {
           if (node.parent?.type === TSESTree.AST_NODE_TYPES.MemberExpression) {
             if (isLoadFunction(node.parent)) {
               // In case it is a load function
-              const loadArgument: string | undefined = getLoadArgument(node.parent);
+              const loadArgument: string | undefined = getLoadArgument(
+                node.parent
+              );
               if (loadArgument) {
                 loadLocation.set(loadArgument, node.range[1]);
               }

--- a/packages/eslint-plugin-office-addins/src/rules/no-empty-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/no-empty-load.ts
@@ -5,7 +5,7 @@ import {
   Variable,
 } from "@typescript-eslint/experimental-utils/dist/ts-eslint-scope";
 import { isGetFunction } from "../utils/getFunction";
-import { isLoadFunction } from "../utils/load";
+import { getLoadArgument, isLoadFunction } from "../utils/load";
 
 export = {
   name: "no-empty-load",
@@ -27,11 +27,7 @@ export = {
   },
   create: function (context: any) {
     function isEmptyLoad(node: TSESTree.MemberExpression): boolean {
-      return (
-        isLoadFunction(node) &&
-        node.parent?.type == TSESTree.AST_NODE_TYPES.CallExpression &&
-        node.parent.arguments.length === 0
-      );
+      return isLoadFunction(node) && getLoadArgument(node) === "";
     }
 
     function findEmptyLoad(scope: Scope) {

--- a/packages/eslint-plugin-office-addins/src/rules/no-empty-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/no-empty-load.ts
@@ -27,7 +27,7 @@ export = {
   },
   create: function (context: any) {
     function isEmptyLoad(node: TSESTree.MemberExpression): boolean {
-      return isLoadFunction(node) && getLoadArgument(node) === "";
+      return isLoadFunction(node) && !getLoadArgument(node);
     }
 
     function findEmptyLoad(scope: Scope) {

--- a/packages/eslint-plugin-office-addins/src/rules/no-navigational-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/no-navigational-load.ts
@@ -65,8 +65,8 @@ export = {
             node.parent?.type === TSESTree.AST_NODE_TYPES.MemberExpression &&
             isLoadFunction(node.parent)
           ) {
-            const propertyName: string = getLoadArgument(node.parent);
-            if (!isLoadingValidPropeties(propertyName)) {
+            const propertyName: string | undefined = getLoadArgument(node.parent);
+            if (propertyName && !isLoadingValidPropeties(propertyName)) {
               context.report({
                 node: node.parent,
                 messageId: "navigationalLoad",

--- a/packages/eslint-plugin-office-addins/src/rules/no-navigational-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/no-navigational-load.ts
@@ -65,7 +65,9 @@ export = {
             node.parent?.type === TSESTree.AST_NODE_TYPES.MemberExpression &&
             isLoadFunction(node.parent)
           ) {
-            const propertyName: string | undefined = getLoadArgument(node.parent);
+            const propertyName: string | undefined = getLoadArgument(
+              node.parent
+            );
             if (propertyName && !isLoadingValidPropeties(propertyName)) {
               context.report({
                 node: node.parent,

--- a/packages/eslint-plugin-office-addins/src/utils/load.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/load.ts
@@ -52,17 +52,15 @@ export function getLoadArgument(
   ) {
     if (node.parent.arguments.length === 0) {
       return undefined;
-    } else {
-      if (node.parent.arguments[0].type === TSESTree.AST_NODE_TYPES.Literal) {
-        return node.parent.arguments[0].value as string;
-      } else if (
-        node.parent.arguments[0].type ===
-        TSESTree.AST_NODE_TYPES.ObjectExpression
-      ) {
-        return composeObjectExpressionPropertyIntoString(
-          node.parent.arguments[0]
-        );
-      }
+    }
+    if (node.parent.arguments[0].type === TSESTree.AST_NODE_TYPES.Literal) {
+      return node.parent.arguments[0].value as string;
+    } else if (
+      node.parent.arguments[0].type === TSESTree.AST_NODE_TYPES.ObjectExpression
+    ) {
+      return composeObjectExpressionPropertyIntoString(
+        node.parent.arguments[0]
+      );
     }
   }
   throw new Error("error in getLoadArgument function.");

--- a/packages/eslint-plugin-office-addins/src/utils/load.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/load.ts
@@ -48,14 +48,19 @@ export function getLoadArgument(node: TSESTree.MemberExpression): string {
     isLoadFunction(node) &&
     node.parent?.type === TSESTree.AST_NODE_TYPES.CallExpression
   ) {
-    if (node.parent.arguments[0].type === TSESTree.AST_NODE_TYPES.Literal) {
-      return node.parent.arguments[0].value as string;
-    } else if (
-      node.parent.arguments[0].type === TSESTree.AST_NODE_TYPES.ObjectExpression
-    ) {
-      return composeObjectExpressionPropertyIntoString(
-        node.parent.arguments[0]
-      );
+    if (node.parent.arguments.length === 0) {
+      return "";
+    } else {
+      if (node.parent.arguments[0].type === TSESTree.AST_NODE_TYPES.Literal) {
+        return node.parent.arguments[0].value as string;
+      } else if (
+        node.parent.arguments[0].type ===
+        TSESTree.AST_NODE_TYPES.ObjectExpression
+      ) {
+        return composeObjectExpressionPropertyIntoString(
+          node.parent.arguments[0]
+        );
+      }
     }
   }
   throw new Error("error in getLoadArgument function.");

--- a/packages/eslint-plugin-office-addins/src/utils/load.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/load.ts
@@ -41,7 +41,9 @@ function composeObjectExpressionPropertyIntoString(
   return composedProperty;
 }
 
-export function getLoadArgument(node: TSESTree.MemberExpression): string | undefined {
+export function getLoadArgument(
+  node: TSESTree.MemberExpression
+): string | undefined {
   node = findTopLevelExpression(node);
 
   if (

--- a/packages/eslint-plugin-office-addins/src/utils/load.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/load.ts
@@ -41,7 +41,7 @@ function composeObjectExpressionPropertyIntoString(
   return composedProperty;
 }
 
-export function getLoadArgument(node: TSESTree.MemberExpression): string {
+export function getLoadArgument(node: TSESTree.MemberExpression): string | undefined {
   node = findTopLevelExpression(node);
 
   if (
@@ -49,7 +49,7 @@ export function getLoadArgument(node: TSESTree.MemberExpression): string {
     node.parent?.type === TSESTree.AST_NODE_TYPES.CallExpression
   ) {
     if (node.parent.arguments.length === 0) {
-      return "";
+      return undefined;
     } else {
       if (node.parent.arguments[0].type === TSESTree.AST_NODE_TYPES.Literal) {
         return node.parent.arguments[0].value as string;

--- a/packages/eslint-plugin-office-addins/test/rules/no-empty-load.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/no-empty-load.test.ts
@@ -40,13 +40,13 @@ ruleTester.run('no-empty-load', rule, {
     {
       code: `
         var selectedRange = context.workbook.getSelectedRange();
-        selectedRange.load()`,
+        selectedRange.load();`,
       errors: [{ messageId: "emptyLoad"}]
     },
     {
       code: `
         var selectedRange = context.workbook.getSelectedRange();
-        selectedRange.load("")`,
+        selectedRange.load("");`,
       errors: [{ messageId: "emptyLoad"}]
     },
     {

--- a/packages/eslint-plugin-office-addins/test/rules/no-empty-load.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/no-empty-load.test.ts
@@ -45,6 +45,12 @@ ruleTester.run('no-empty-load', rule, {
     },
     {
       code: `
+        var selectedRange = context.workbook.getSelectedRange();
+        selectedRange.load("")`,
+      errors: [{ messageId: "emptyLoad"}]
+    },
+    {
+      code: `
         var myRange;
         myRange = context.workbook.worksheets.getSelectedRange();
         myRange.load();

--- a/packages/eslint-plugin-office-addins/test/rules/no-navigational-load.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/no-navigational-load.test.ts
@@ -40,19 +40,19 @@ ruleTester.run('no-navigational-load', rule, {
                 var myRange = context.workbook.worksheets.notAGet();
                 myRange.load('notAProperty');
                 var test = myRange.notAProperty;`
-    	},
+		},
 		{
 			code: `
                 var range = context.workbook.getRange();
                 range.load({borders: { fill: { color: true } } });
                 if (range.borders.fill.color);`
-    	},
+		},
 		{
 			code: `
                 var range = context.workbook.getRange();
                 range.borders.fill.load("color");
                 console.log(range.borders.fill.color);`
-    	},
+		},
 		{
 			code: `
                 var selectedRange = context.workbook.getSelectedRange();

--- a/packages/eslint-plugin-office-addins/test/rules/no-navigational-load.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/no-navigational-load.test.ts
@@ -53,6 +53,16 @@ ruleTester.run('no-navigational-load', rule, {
                 range.borders.fill.load("color");
                 console.log(range.borders.fill.color);`
     	},
+		{
+			code: `
+                var selectedRange = context.workbook.getSelectedRange();
+                selectedRange.load(''); // Empty`
+		},
+		{
+			code: `
+                var selectedRange = context.workbook.getSelectedRange();
+                selectedRange.load(); // Empty`
+		},
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Fixing the exception that fired when load is empty. The error was being fired on other rules and not on the `emptyLoad` rule, that's why our tests didn't catch the error.