### PR TITLE
Not reporting errors on ambiguous navigational properties

### DIFF
--- a/packages/eslint-plugin-office-addins/src/rules/no-navigational-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/no-navigational-load.ts
@@ -34,12 +34,20 @@ export = {
       if (!lastProperty) return false;
 
       for (const property of properties) {
-        if (getPropertyType(property) !== PropertyType.navigational) {
+        const propertyType = getPropertyType(property);
+        if (
+          propertyType !== PropertyType.navigational &&
+          propertyType !== PropertyType.ambiguous
+        ) {
           return false;
         }
       }
 
-      return getPropertyType(lastProperty) === PropertyType.scalar;
+      const propertyType = getPropertyType(lastProperty);
+      return (
+        propertyType === PropertyType.scalar ||
+        propertyType === PropertyType.ambiguous
+      );
     }
 
     function findNavigationalLoad(scope: Scope) {

--- a/packages/eslint-plugin-office-addins/test/rules/no-navigational-load.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/no-navigational-load.test.ts
@@ -15,6 +15,11 @@ ruleTester.run('no-navigational-load', rule, {
 		},
 		{
 			code: `
+                var selectedRange = context.workbook.getSelectedRange();
+                selectedRange.load("format/font/name");`
+		},
+		{
+			code: `
                 var sheetName = 'Sheet1';
                 var rangeAddress = 'A1:B2';
                 var myRange = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);  


### PR DESCRIPTION
The navigational eslint rule was having a lot of false positives regarding ambiguous properties (that can be navigational or scalar).
I'm putting it so that the rule won't fire a case of ambiguous rules to reduce false positives.