### PR TITLE
Eslint object support

### DIFF
--- a/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
@@ -189,12 +189,12 @@ ruleTester.run('load-object-before-read', rule, {
       errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "format/fill/color" }  }]
     },
     {
-			code: `
-			  var range = worksheet.getSelectedRange();
-			  await context.sync();
-			  console.log(range.font.fill.color);`,
-        errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "font/fill/color" }  }]
-		},
+      code: `
+        var range = worksheet.getSelectedRange();
+        await context.sync();
+        console.log(range.font.fill.color);`,
+      errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "font/fill/color" }  }]
+    },
     {
       code: `
         var range = worksheet.getSelectedRange();

--- a/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
@@ -113,6 +113,14 @@ ruleTester.run('load-object-before-read', rule, {
         console.log(range.address);
         console.log(range.font);`
     },
+		{
+			code: `
+			  var range = worksheet.getSelectedRange();
+			  range.load({ format: { fill: { color: true } }, address: true } );
+			  await context.sync();
+			  console.log(range.format.fill.color);
+			  console.log(range.address);`
+		},
   ],
   invalid: [
     {
@@ -186,6 +194,23 @@ ruleTester.run('load-object-before-read', rule, {
 			  await context.sync();
 			  console.log(range.font.fill.color);`,
         errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "font/fill/color" }  }]
+		},
+    {
+			code: `
+			  var range = worksheet.getSelectedRange();
+			  range.load({ format: { fill: { color: true } } } );
+			  await context.sync();
+			  console.log(range.format.fill.color);
+			  console.log(range.address);`,
+        errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "address" }  }]
+		},
+    {
+			code: `
+			  var range = worksheet.getSelectedRange();
+			  range.load({ format: { fill: { color: false } } } );
+			  await context.sync();
+			  console.log(range.format.fill.color);`,
+        errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "format/fill/color" }  }]
 		},
   ]
 });

--- a/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
@@ -113,14 +113,14 @@ ruleTester.run('load-object-before-read', rule, {
         console.log(range.address);
         console.log(range.font);`
     },
-		{
-			code: `
-			  var range = worksheet.getSelectedRange();
-			  range.load({ format: { fill: { color: true } }, address: true } );
-			  await context.sync();
-			  console.log(range.format.fill.color);
-			  console.log(range.address);`
-		},
+    {
+      code: `
+        var range = worksheet.getSelectedRange();
+        range.load({ format: { fill: { color: true } }, address: true } );
+        await context.sync();
+        console.log(range.format.fill.color);
+        console.log(range.address);`
+    },
   ],
   invalid: [
     {
@@ -196,21 +196,21 @@ ruleTester.run('load-object-before-read', rule, {
         errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "font/fill/color" }  }]
 		},
     {
-			code: `
-			  var range = worksheet.getSelectedRange();
-			  range.load({ format: { fill: { color: true } } } );
-			  await context.sync();
-			  console.log(range.format.fill.color);
-			  console.log(range.address);`,
-        errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "address" }  }]
-		},
+      code: `
+        var range = worksheet.getSelectedRange();
+        range.load({ format: { fill: { color: true } } } );
+        await context.sync();
+        console.log(range.format.fill.color);
+        console.log(range.address);`,
+      errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "address" }  }]
+    },
     {
-			code: `
-			  var range = worksheet.getSelectedRange();
-			  range.load({ format: { fill: { color: false } } } );
-			  await context.sync();
-			  console.log(range.format.fill.color);`,
-        errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "format/fill/color" }  }]
-		},
+      code: `
+        var range = worksheet.getSelectedRange();
+        range.load({ format: { fill: { color: false } } } );
+        await context.sync();
+        console.log(range.format.fill.color);`,
+      errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "format/fill/color" }  }]
+    },
   ]
 });


### PR DESCRIPTION
Added support to load objects.
Load of the type:

`range.load({ format: { fill: { color: true } }, address: true } );` are now supported.