### PR TITLE
Add missing hyphen between "office" and "addin"

### DIFF
--- a/packages/office-addin-debugging/README.md
+++ b/packages/office-addin-debugging/README.md
@@ -13,7 +13,7 @@ Starts debugging.
 
 Syntax:
 
-`office addin-debugging start <manifest> [platform] [options]`
+`office-addin-debugging start <manifest> [platform] [options]`
 
 `manifest`: path to manifest file.
 
@@ -116,7 +116,7 @@ Stops debugging.
 
 Syntax:
 
-`office addin-debugging stop <manifest> [options]`
+`office-addin-debugging stop <manifest> [options]`
 
 `manifest`: path to manifest file.
 

--- a/packages/office-addin-dev-settings/README.md
+++ b/packages/office-addin-dev-settings/README.md
@@ -22,7 +22,7 @@ Display or configure settings related to the appcontainer for an Office Add-in.
 
 Syntax:
 
-`office addin-dev-settings appcontainer <manifest> [options]`
+`office-addin-dev-settings appcontainer <manifest> [options]`
 
 `manifest`: path to manifest file.
 
@@ -50,7 +50,7 @@ Clear developer settings for the Office Add-in.
 
 Syntax:
 
-`office addin-debugging clear <manifest>`
+`office-addin-debugging clear <manifest>`
 
 `manifest`: path to manifest file.
 
@@ -61,7 +61,7 @@ Display or configure debugging settings for an Office Add-in.
 
 Syntax:
 
-`office addin-dev-settings debugging <manifest> [options]`
+`office-addin-dev-settings debugging <manifest> [options]`
 
 `manifest`: path to manifest file. 
 
@@ -94,7 +94,7 @@ Display or configure settings related to live reload for an Office Add-in.
 
 Syntax:
 
-`office addin-dev-settings live-reload <manifest> [options]`
+`office-addin-dev-settings live-reload <manifest> [options]`
 
 `manifest`: path to manifest file. 
 
@@ -117,7 +117,7 @@ Registers an Office Add-in for development.
 
 Syntax:
 
-`office addin-dev-settings register <manifest> [options]`
+`office-addin-dev-settings register <manifest> [options]`
 
 `manifest`: path to manifest file. 
 
@@ -128,7 +128,7 @@ Displays the Office Add-ins registered for development.
 
 Syntax:
 
-`office addin-dev-settings registered [options]`
+`office-addin-dev-settings registered [options]`
 
 #
 
@@ -141,7 +141,7 @@ The setting is not specific to a particular Office Add-in. It applies to the run
 
 Syntax:
 
-`office addin-dev-settings runtime-log [options]`
+`office-addin-dev-settings runtime-log [options]`
 
 Without options, displays whether runtime logging is enabled and the log file path (if enabled).
 
@@ -164,7 +164,7 @@ Start Office and open a document so the Office Add-in is loaded.
 
 Syntax:
 
-`office addin-dev-settings sideload <manifest> [app-type] [options]`
+`office-addin-dev-settings sideload <manifest> [app-type] [options]`
 
 `manifest`: path to manifest file.
 
@@ -202,7 +202,7 @@ http://`HOST`:`PORT`/`PATH` `EXTENSION`
 
 Syntax:
 
-`office addin-dev-settings source-bundle-url [options]`
+`office-addin-dev-settings source-bundle-url [options]`
 
 Without options, displays the current source-bundle-url settings.
 
@@ -234,7 +234,7 @@ Unregisters an Office Add-in for development.
 
 Syntax:
 
-`office addin-dev-settings register <manifest> [options]`
+`office-addin-dev-settings register <manifest> [options]`
 
 `manifest`: path to manifest file. 
 
@@ -247,7 +247,7 @@ Switches the webview runtime in Office for testing and development scenarios.
 
 Syntax:
 
-`office addin-dev-settings webview <manifest> <web-view-type>`
+`office-addin-dev-settings webview <manifest> <web-view-type>`
 
 `manifest`: path to manifest file. 
 

--- a/packages/office-addin-lint/README.md
+++ b/packages/office-addin-lint/README.md
@@ -14,7 +14,7 @@ Check the source code for problems.
 
 Syntax:
 
-`office addin-lint check [options]`
+`office-addin-lint check [options]`
 
 Options:
 
@@ -29,7 +29,7 @@ Apply fixes for problems found in the source code.
 
 Syntax:
 
-`office addin-lint fix [options]`
+`office-addin-lint fix [options]`
 
 Options:
 
@@ -44,7 +44,7 @@ Make the source code prettier.
 
 Syntax:
 
-`office addin-lint prettier [options]`
+`office-addin-lint prettier [options]`
 
 Options:
 

--- a/packages/office-addin-usage-data/README.md
+++ b/packages/office-addin-usage-data/README.md
@@ -2,7 +2,7 @@
 This package allows for reporting usage data events and exception data to the selected telemetry infrastructure (e.g. ApplicationInsights).
 
 # Privacy
-The Office Addin-Usage-Data package collects anonymized usage data and sends it to Microsoft. For more details on how we use this data and under what circumstances it may be shared, 
+The Office-Addin-Usage-Data package collects anonymized usage data and sends it to Microsoft. For more details on how we use this data and under what circumstances it may be shared, 
 please see the [Microsoft privacy statement](https://privacy.microsoft.com/en-us/privacystatement).
 
 The package collects:


### PR DESCRIPTION
Apparently some of the readme files didn't have the right command name.