### PR TITLE
Mock bug fixes

### DIFF
--- a/packages/office-addin-mock/src/officeMockObject.ts
+++ b/packages/office-addin-mock/src/officeMockObject.ts
@@ -70,9 +70,9 @@ export class OfficeMockObject {
   /**
    * Mock replacement for the sync method in the Office.js API
    */
-  sync() {
-    this.properties.forEach((property: OfficeMockObject, key: string) => {
-      property.sync();
+  async sync() {
+    this.properties.forEach(async (property: OfficeMockObject, key: string) => {
+      await property.sync();
       this.makePropertyCallable(key);
     });
     if (this.loaded) {

--- a/packages/office-addin-mock/src/possibleErrors.ts
+++ b/packages/office-addin-mock/src/possibleErrors.ts
@@ -1,0 +1,16 @@
+export enum PossibleErrors {
+  /* eslint-disable no-unused-vars */
+  notLoaded = "Error, property was not loaded",
+  notSync = "Error, context.sync() was not called",
+  /* eslint-enable no-unused-vars */
+}
+
+export function isValidError(str: string): boolean {
+  let foundError = false;
+  Object.values(PossibleErrors).forEach((possibleError: string) => {
+    if (str === possibleError) {
+      foundError = true;
+    }
+  });
+  return foundError;
+}

--- a/packages/office-addin-mock/test/officeMockObject.test.ts
+++ b/packages/office-addin-mock/test/officeMockObject.test.ts
@@ -115,6 +115,33 @@ describe("Test OfficeMockObject class", function() {
     });
   });
 
+  describe("Writting values already present at object model", function() {
+    it("Load and Sync", async function() {
+      const officeMock = new OfficeMockObject(testObject);
+      officeMock.range.color = "new color";
+      officeMock.range.load("color");
+      await officeMock.sync();
+      assert.strictEqual(officeMock.range.color, "new color");
+    });
+    it("Only load", async function() {
+      const officeMock = new OfficeMockObject(testObject);
+      officeMock.range.color = "new color";
+      officeMock.range.load("color");
+      assert.strictEqual(officeMock.range.color, "new color");
+    });
+    it("Only sync", async function() {
+      const officeMock = new OfficeMockObject(testObject);
+      officeMock.range.color = "new color";
+      await officeMock.sync();
+      assert.strictEqual(officeMock.range.color, "new color");
+    });
+    it("No load and no sync", async function() {
+      const officeMock = new OfficeMockObject(testObject);
+      officeMock.range.color = "new color";
+      assert.strictEqual(officeMock.range.color, "new color");
+    });
+  });
+
   describe("Different ways to load properties", function() {
     it("Invalid load", async function() {
       const officeMock = new OfficeMockObject(testObject);

--- a/packages/office-addin-mock/test/officeMockObject.test.ts
+++ b/packages/office-addin-mock/test/officeMockObject.test.ts
@@ -40,11 +40,11 @@ describe("Test OfficeMockObject class", function() {
       const officeMock = new OfficeMockObject(testObject);
 
       officeMock.range.load("color");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.color, "blue");
 
       officeMock.range.font.load("size");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.font.size, 12);
 
       assert.strictEqual(officeMock.notAProperty, undefined);
@@ -62,17 +62,17 @@ describe("Test OfficeMockObject class", function() {
       const officeMock = new OfficeMockObject(testObject);
 
       officeMock.range.load("color");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.color, "blue");
 
       officeMock.range.load("color");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.color, "blue");
 
       officeMock.range.load("color");
       assert.strictEqual(officeMock.range.color, "blue");
 
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.color, "blue");
 
       assert.strictEqual(officeMock.notAProperty, undefined);
@@ -80,28 +80,28 @@ describe("Test OfficeMockObject class", function() {
     it("Missing load", async function() {
       const officeMock = new OfficeMockObject(testObject);
       assert.strictEqual(officeMock.range.color, "Error, property was not loaded");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.color, "Error, property was not loaded");
     });
     it("Missing sync", async function() {
       const officeMock = new OfficeMockObject(testObject);
       officeMock.range.load("color");
       assert.strictEqual(officeMock.range.color, "Error, context.sync() was not called");
-      officeMock.sync();
+      await officeMock.sync();
       officeMock.range.load("color");
       assert.strictEqual(officeMock.range.color, "blue");
     });
     it("Functions added", async function() {
       const officeMock = new OfficeMockObject(testObject);
       officeMock.range.load("color");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "blue");
       officeMock.range.color = "green";
       assert.strictEqual(officeMock.range.getColor(), "green");
 
       officeMock.range.setMock("color", "yellow");
       officeMock.range.load("color");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "yellow");
     });
     it("Writting values", async function() {
@@ -123,17 +123,17 @@ describe("Test OfficeMockObject class", function() {
     it("Load on navigation property", async function() {
       const officeMock = new OfficeMockObject(testObject);
       officeMock.load("range");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "blue");
     });
     it("Navigational load", async function() {
       const officeMock = new OfficeMockObject(testObject);
       officeMock.load("range/color");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "blue");
 
       officeMock.load("range/font/size");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.font.size, 12);
   
       assert.throws(() => officeMock.load("range/notANavigational/size"));
@@ -142,14 +142,14 @@ describe("Test OfficeMockObject class", function() {
     it("Multiple properties load", async function() {
       const officeMock = new OfficeMockObject(testObject);
       officeMock.load("range/color, range/font/size");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "blue");
       assert.strictEqual(officeMock.range.font.size, 12);
     });
     it("Comma separated load", async function() {
       const officeMock = new OfficeMockObject(testObject);
       officeMock.load(["range/color", "range/font/type", "range/font/size"]);
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "blue");
       assert.strictEqual(officeMock.range.font.type, "arial");
       assert.strictEqual(officeMock.range.font.size, 12);
@@ -157,25 +157,25 @@ describe("Test OfficeMockObject class", function() {
     it("Load star", async function() {
       const officeMock = new OfficeMockObject(testObject);
       officeMock.range.load("*");
-      officeMock.sync();
+      await officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "blue");
     });
     it("Load navigational property", async function() {
       const contextMock = new OfficeMockObject(contextMockData);
       contextMock.workbook.range.load("format/fill");
-      contextMock.sync();
+      await contextMock.sync();
       assert.strictEqual(contextMock.workbook.range.format.fill.color, "green");
     });
     it("Load object property", async function() {
       const contextMock = new OfficeMockObject(contextMockData);
       contextMock.workbook.range.load({ format: { fill: { color: false } }, address: true } );
-      contextMock.sync();
+      await contextMock.sync();
       assert.strictEqual(contextMock.workbook.range.format.fill.color, "Error, property was not loaded");
       assert.strictEqual(contextMock.workbook.range.address, "C2");
       assert.throws(() => contextMock.load({ format: { notAProperty: false }, address: true } ));
 
       contextMock.workbook.range.load({ format: { fill: { color: true } } } );
-      contextMock.sync();
+      await contextMock.sync();
       assert.strictEqual(contextMock.workbook.range.format.fill.color, "green");
     });
   });


### PR DESCRIPTION
Fixing bugs in the office-addin-mock packages.
The first is adding async to the `sync` function.

The second is supporting calls on existing properties in the object model, followed by `sync` or a `load`.
Examples of that are in the new tests added, which are supported (tested in script lab) but wouldn't work with the mock package.
