### PR TITLE
Replace deprecated packages

### DIFF
--- a/packages/custom-functions-metadata-plugin/package-lock.json
+++ b/packages/custom-functions-metadata-plugin/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "custom-functions-metadata-plugin",
-      "version": "1.2.1",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
-        "custom-functions-metadata": "^1.2.1",
+        "custom-functions-metadata": "^1.2.3",
         "es6-promise": "^4.2.8",
         "loader-utils": "^2.0.0",
         "webpack": "^5.24.4"
@@ -18,7 +18,7 @@
         "@types/loader-utils": "^2.0.2",
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.2",
-        "office-addin-lint": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
         "typescript": "^4.3.5"
       }
@@ -33,12 +33,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -56,50 +56,50 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -115,12 +115,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -224,44 +224,44 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -270,12 +270,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -291,12 +291,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1257,14 +1257,14 @@
       }
     },
     "node_modules/custom-functions-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.2.1.tgz",
-      "integrity": "sha512-7wq6Tn3myPD5/lRrXkYOXzItA09ieEGYvtO/HraBAXXrkRCtEyXZ2ABFa8MQOc3Hr1ERnBFoEzHmGF4LFz9UnQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.2.3.tgz",
+      "integrity": "sha512-vK4+m+OOP6Z3K94Wvx4in+PbWzOga/id3OwdHyS0fHJ/3eo5NlkX9prGM9t/WNeblg5UbvMneiP2ox16jZjE7g==",
       "dependencies": {
         "assert": "^1.5.0",
         "commander": "^6.2.0",
         "nconf": "^0.11.3",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "xregexp": "^4.3.0"
       },
       "bin": {
@@ -1580,9 +1580,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1593,7 +1593,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -1645,31 +1645,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -2750,9 +2750,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2876,9 +2876,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -2897,9 +2897,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -2907,11 +2907,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -2928,20 +2928,20 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dev": true,
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -4006,12 +4006,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -4025,41 +4025,41 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -4069,12 +4069,12 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -4138,9 +4138,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
     "@babel/runtime-corejs3": {
@@ -4153,51 +4153,51 @@
       }
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "globals": {
@@ -4209,12 +4209,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -4969,14 +4969,14 @@
       }
     },
     "custom-functions-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.2.1.tgz",
-      "integrity": "sha512-7wq6Tn3myPD5/lRrXkYOXzItA09ieEGYvtO/HraBAXXrkRCtEyXZ2ABFa8MQOc3Hr1ERnBFoEzHmGF4LFz9UnQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.2.3.tgz",
+      "integrity": "sha512-vK4+m+OOP6Z3K94Wvx4in+PbWzOga/id3OwdHyS0fHJ/3eo5NlkX9prGM9t/WNeblg5UbvMneiP2ox16jZjE7g==",
       "requires": {
         "assert": "^1.5.0",
         "commander": "^6.2.0",
         "nconf": "^0.11.3",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "xregexp": "^4.3.0"
       },
       "dependencies": {
@@ -5242,9 +5242,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5255,7 +5255,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -5282,25 +5282,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -5660,9 +5660,9 @@
       }
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true
     },
     "import-fresh": {
@@ -6075,9 +6075,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -6165,9 +6165,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -6182,9 +6182,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -6192,11 +6192,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "dependencies": {
@@ -6209,20 +6209,20 @@
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dev": true,
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "dependencies": {

--- a/packages/custom-functions-metadata-plugin/package-lock.json
+++ b/packages/custom-functions-metadata-plugin/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "custom-functions-metadata": "^1.2.3",
-        "es6-promise": "^4.2.8",
         "loader-utils": "^2.0.0",
         "webpack": "^5.24.4"
       },
@@ -1484,11 +1483,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5144,11 +5138,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/custom-functions-metadata-plugin/package.json
+++ b/packages/custom-functions-metadata-plugin/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "custom-functions-metadata": "^1.2.3",
-    "es6-promise": "^4.2.8",
     "loader-utils": "^2.0.0",
     "webpack": "^5.24.4"
   },

--- a/packages/custom-functions-metadata-plugin/tsconfig.json
+++ b/packages/custom-functions-metadata-plugin/tsconfig.json
@@ -12,8 +12,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
     },
     "include": [

--- a/packages/custom-functions-metadata/package-lock.json
+++ b/packages/custom-functions-metadata/package-lock.json
@@ -25,6 +25,7 @@
         "@types/node-fetch": "^2.5.10",
         "@types/xregexp": "^3.0.30",
         "concurrently": "^6.2.2",
+        "es6-promise": "^4.2.8",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
         "office-addin-prettier-config": "^1.1.1",
@@ -1336,6 +1337,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -4937,6 +4944,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/custom-functions-metadata/package-lock.json
+++ b/packages/custom-functions-metadata/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "custom-functions-metadata",
-      "version": "1.2.1",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "assert": "^1.5.0",
         "commander": "^6.2.0",
         "nconf": "^0.11.3",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "xregexp": "^4.3.0"
       },
       "bin": {
@@ -20,15 +20,14 @@
       },
       "devDependencies": {
         "@types/assert": "^1.4.6",
-        "@types/es6-promise": "^3.3.0",
         "@types/mocha": "^7.0.2",
         "@types/node": "^14.17.2",
         "@types/node-fetch": "^2.5.10",
         "@types/xregexp": "^3.0.30",
         "concurrently": "^6.2.2",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^1.4.1",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-lint": "^1.4.3",
+        "office-addin-prettier-config": "^1.1.1",
         "rimraf": "^3.0.2",
         "ts-node": "^10.1.0",
         "typescript": "^4.3.5"
@@ -44,12 +43,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -67,50 +66,50 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -126,12 +125,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -211,9 +210,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -232,44 +231,44 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -278,12 +277,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -299,12 +298,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -446,16 +445,6 @@
       "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.4.6.tgz",
       "integrity": "sha512-r/N9gGdYr2MfZSbdi6w6VH3+qS1KboBqZ0bkDiTD2RdAls3smYDK/jy8jhGyGTZglFgLTCknH1MBJG8M4sd+6A==",
       "dev": true
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "deprecated": "This is a stub types definition for es6-promise (https://github.com/jakearchibald/ES6-Promise). es6-promise provides its own type definitions, so you don't need @types/es6-promise installed!",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -1348,12 +1337,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1444,9 +1427,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1457,7 +1440,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -1509,31 +1492,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -2099,9 +2082,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -2861,9 +2844,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -2882,9 +2865,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -2892,11 +2875,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -2904,20 +2887,20 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dev": true,
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -3970,12 +3953,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -3989,41 +3972,41 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -4033,12 +4016,12 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -4102,9 +4085,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
     "@babel/runtime-corejs3": {
@@ -4117,51 +4100,51 @@
       }
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "globals": {
@@ -4173,12 +4156,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -4298,15 +4281,6 @@
       "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.4.6.tgz",
       "integrity": "sha512-r/N9gGdYr2MfZSbdi6w6VH3+qS1KboBqZ0bkDiTD2RdAls3smYDK/jy8jhGyGTZglFgLTCknH1MBJG8M4sd+6A==",
       "dev": true
-    },
-    "@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "*"
-      }
     },
     "@types/json-schema": {
       "version": "7.0.9",
@@ -4964,12 +4938,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -5081,9 +5049,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5094,7 +5062,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -5121,25 +5089,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -5516,9 +5484,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true
     },
     "import-fresh": {
@@ -6062,9 +6030,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -6079,9 +6047,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -6089,29 +6057,29 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dev": true,
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/custom-functions-metadata/package-lock.json
+++ b/packages/custom-functions-metadata/package-lock.json
@@ -25,7 +25,6 @@
         "@types/node-fetch": "^2.5.10",
         "@types/xregexp": "^3.0.30",
         "concurrently": "^6.2.2",
-        "es6-promise": "^4.2.8",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
         "office-addin-prettier-config": "^1.1.1",
@@ -1337,12 +1336,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -4944,12 +4937,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/custom-functions-metadata/package.json
+++ b/packages/custom-functions-metadata/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@types/assert": "^1.4.6",
-    "@types/es6-promise": "^3.3.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.17.2",
     "@types/node-fetch": "^2.5.10",

--- a/packages/custom-functions-metadata/package.json
+++ b/packages/custom-functions-metadata/package.json
@@ -38,6 +38,7 @@
     "@types/node-fetch": "^2.5.10",
     "@types/xregexp": "^3.0.30",
     "concurrently": "^6.2.2",
+    "es6-promise": "^4.2.8",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",
     "office-addin-prettier-config": "^1.1.1",

--- a/packages/custom-functions-metadata/package.json
+++ b/packages/custom-functions-metadata/package.json
@@ -38,7 +38,6 @@
     "@types/node-fetch": "^2.5.10",
     "@types/xregexp": "^3.0.30",
     "concurrently": "^6.2.2",
-    "es6-promise": "^4.2.8",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",
     "office-addin-prettier-config": "^1.1.1",

--- a/packages/custom-functions-metadata/tsconfig.json
+++ b/packages/custom-functions-metadata/tsconfig.json
@@ -11,8 +11,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
     },
     "include": [

--- a/packages/eslint-config-office-addins/package-lock.json
+++ b/packages/eslint-config-office-addins/package-lock.json
@@ -6,17 +6,16 @@
   "packages": {
     "": {
       "name": "eslint-config-office-addins",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "eslint": "^7.32.0",
-        "eslint-plugin-office-addins": "^1.1.1"
+        "eslint-plugin-office-addins": "^1.1.2"
       },
       "devDependencies": {
-        "@types/es6-promise": "^3.3.0",
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.2",
-        "office-addin-lint": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
         "rimraf": "^2.7.1",
         "typescript": "^4.3.5"
       },
@@ -261,16 +260,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "deprecated": "This is a stub types definition for es6-promise (https://github.com/jakearchibald/ES6-Promise). es6-promise provides its own type definitions, so you don't need @types/es6-promise installed!",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "*"
       }
     },
     "node_modules/@types/json-schema": {
@@ -1031,12 +1020,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1122,9 +1105,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
         "@typescript-eslint/experimental-utils": "^4.31.0",
@@ -1134,7 +1117,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -2119,9 +2102,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -2236,9 +2219,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dev": true,
       "dependencies": {
         "commander": "^6.2.1",
@@ -2250,9 +2233,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -2260,11 +2243,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -2272,19 +2255,19 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ=="
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dev": true,
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -3338,15 +3321,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -3885,12 +3859,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -4019,9 +3987,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
         "@typescript-eslint/experimental-utils": "^4.31.0",
@@ -4031,7 +3999,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -4665,9 +4633,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -4746,9 +4714,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dev": true,
       "requires": {
         "commander": "^6.2.1",
@@ -4757,9 +4725,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -4767,28 +4735,28 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ=="
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dev": true,
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/eslint-config-office-addins/package-lock.json
+++ b/packages/eslint-config-office-addins/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.2",
+        "es6-promise": "^4.2.8",
         "office-addin-lint": "^1.4.3",
         "rimraf": "^2.7.1",
         "typescript": "^4.3.5"
@@ -1019,6 +1020,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -3858,6 +3865,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/eslint-config-office-addins/package-lock.json
+++ b/packages/eslint-config-office-addins/package-lock.json
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.2",
-        "es6-promise": "^4.2.8",
         "office-addin-lint": "^1.4.3",
         "rimraf": "^2.7.1",
         "typescript": "^4.3.5"
@@ -1020,12 +1019,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -3865,12 +3858,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/eslint-config-office-addins/package.json
+++ b/packages/eslint-config-office-addins/package.json
@@ -21,7 +21,6 @@
     "prettier": "^2.1.2"
   },
   "devDependencies": {
-    "@types/es6-promise": "^3.3.0",
     "@types/node": "^14.17.2",
     "concurrently": "^6.2.2",
     "office-addin-lint": "^1.4.3",

--- a/packages/eslint-config-office-addins/package.json
+++ b/packages/eslint-config-office-addins/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@types/node": "^14.17.2",
     "concurrently": "^6.2.2",
-    "es6-promise": "^4.2.8",
     "office-addin-lint": "^1.4.3",
     "rimraf": "^2.7.1",
     "typescript": "^4.3.5"

--- a/packages/eslint-config-office-addins/package.json
+++ b/packages/eslint-config-office-addins/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/node": "^14.17.2",
     "concurrently": "^6.2.2",
+    "es6-promise": "^4.2.8",
     "office-addin-lint": "^1.4.3",
     "rimraf": "^2.7.1",
     "typescript": "^4.3.5"

--- a/packages/eslint-config-office-addins/tsconfig.json
+++ b/packages/eslint-config-office-addins/tsconfig.json
@@ -11,8 +11,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
     },
     "include": [

--- a/packages/eslint-plugin-excel-custom-functions/package-lock.json
+++ b/packages/eslint-plugin-excel-custom-functions/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "eslint-plugin-excel-custom-functions",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@types/custom-functions-runtime": "^1.5.1",
@@ -26,8 +26,8 @@
         "@typescript-eslint/parser": "^4.2.0",
         "@typescript-eslint/scope-manager": "^4.2.0",
         "jest": "^27.2.4",
-        "office-addin-lint": "^1.4.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.1.2",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
@@ -4236,9 +4236,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -4249,7 +4249,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -4301,31 +4301,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -8229,9 +8229,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -8453,9 +8453,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dev": true,
       "dependencies": {
         "commander": "^6.2.1",
@@ -8467,9 +8467,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -8477,11 +8477,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -8489,20 +8489,20 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dev": true,
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -13527,9 +13527,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -13540,7 +13540,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -13567,25 +13567,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -16567,9 +16567,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -16741,9 +16741,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dev": true,
       "requires": {
         "commander": "^6.2.1",
@@ -16752,9 +16752,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -16762,29 +16762,29 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dev": true,
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/eslint-plugin-office-addins/package-lock.json
+++ b/packages/eslint-plugin-office-addins/package-lock.json
@@ -26,6 +26,7 @@
         "@types/jest": "^27.0.1",
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.1",
+        "es6-promise": "^4.2.8",
         "jest": "^27.2.4",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5"
@@ -3571,6 +3572,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -12290,6 +12297,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/eslint-plugin-office-addins/package-lock.json
+++ b/packages/eslint-plugin-office-addins/package-lock.json
@@ -26,7 +26,6 @@
         "@types/jest": "^27.0.1",
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.1",
-        "es6-promise": "^4.2.8",
         "jest": "^27.2.4",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5"
@@ -3572,12 +3571,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -12297,12 +12290,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/eslint-plugin-office-addins/package-lock.json
+++ b/packages/eslint-plugin-office-addins/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "eslint-plugin-office-addins",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -17,13 +17,12 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
       },
       "devDependencies": {
-        "@types/es6-promise": "^3.3.0",
         "@types/jest": "^27.0.1",
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.1",
@@ -2332,16 +2331,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "deprecated": "This is a stub types definition for es6-promise (https://github.com/jakearchibald/ES6-Promise). es6-promise provides its own type definitions, so you don't need @types/es6-promise installed!",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -3582,12 +3571,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -8129,9 +8112,9 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -11384,15 +11367,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -12316,12 +12290,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -15730,9 +15698,9 @@
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ=="
     },
     "once": {
       "version": "1.4.0",

--- a/packages/eslint-plugin-office-addins/package.json
+++ b/packages/eslint-plugin-office-addins/package.json
@@ -33,6 +33,7 @@
     "@types/jest": "^27.0.1",
     "@types/node": "^14.17.2",
     "concurrently": "^6.2.1",
+    "es6-promise": "^4.2.8",
     "jest": "^27.2.4",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.5"

--- a/packages/eslint-plugin-office-addins/package.json
+++ b/packages/eslint-plugin-office-addins/package.json
@@ -33,7 +33,6 @@
     "@types/jest": "^27.0.1",
     "@types/node": "^14.17.2",
     "concurrently": "^6.2.1",
-    "es6-promise": "^4.2.8",
     "jest": "^27.2.4",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.5"

--- a/packages/eslint-plugin-office-addins/package.json
+++ b/packages/eslint-plugin-office-addins/package.json
@@ -30,7 +30,6 @@
     "typescript": "^4.4.2"
   },
   "devDependencies": {
-    "@types/es6-promise": "^3.3.0",
     "@types/jest": "^27.0.1",
     "@types/node": "^14.17.2",
     "concurrently": "^6.2.1",

--- a/packages/eslint-plugin-office-addins/tsconfig.json
+++ b/packages/eslint-plugin-office-addins/tsconfig.json
@@ -13,8 +13,7 @@
         "strict": true,
         "target": "es6",
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
     },
     "include": [

--- a/packages/office-addin-cli/package-lock.json
+++ b/packages/office-addin-cli/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "office-addin-cli",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^6.2.1",
@@ -24,10 +24,10 @@
         "@typescript-eslint/eslint-plugin": "^4.26.0",
         "concurrently": "^6.2.2",
         "eslint": "7.32.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.4.0",
         "mocha": "^9.1.1",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.1.2",
         "rimraf": "^3.0.2",
         "sinon": "^7.5.0",
@@ -1588,9 +1588,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1601,7 +1601,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -3275,9 +3275,9 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/once": {
@@ -5502,9 +5502,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5515,7 +5515,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -6669,9 +6669,9 @@
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "once": {

--- a/packages/office-addin-debugging/package-lock.json
+++ b/packages/office-addin-debugging/package-lock.json
@@ -29,7 +29,6 @@
         "@types/node-fetch": "^2.5.10",
         "@types/ws": "^6.0.4",
         "concurrently": "^6.2.2",
-        "es6-promise": "^4.2.8",
         "express": "^4.16.4",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
@@ -1653,12 +1652,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -6467,12 +6460,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-debugging/package-lock.json
+++ b/packages/office-addin-debugging/package-lock.json
@@ -6,24 +6,23 @@
   "packages": {
     "": {
       "name": "office-addin-debugging",
-      "version": "4.3.1",
+      "version": "4.3.3",
       "license": "MIT",
       "dependencies": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-dev-certs": "^1.7.1",
-        "office-addin-dev-settings": "^1.10.1",
-        "office-addin-manifest": "^1.7.1",
-        "office-addin-node-debugger": "^0.6.1",
-        "office-addin-usage-data": "^1.4.1"
+        "office-addin-cli": "^1.3.2",
+        "office-addin-dev-certs": "^1.7.3",
+        "office-addin-dev-settings": "^1.10.3",
+        "office-addin-manifest": "^1.7.3",
+        "office-addin-node-debugger": "^0.6.3",
+        "office-addin-usage-data": "^1.4.3"
       },
       "bin": {
         "office-addin-debugging": "cli.js"
       },
       "devDependencies": {
-        "@types/es6-promise": "0.0.32",
         "@types/express": "^4.17.3",
         "@types/mocha": "^5.2.5",
         "@types/node": "^14.17.2",
@@ -32,7 +31,7 @@
         "concurrently": "^6.2.2",
         "express": "^4.16.4",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
         "rimraf": "^2.7.1",
         "ts-node": "^10.1.0",
         "typescript": "^4.3.5",
@@ -49,12 +48,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -72,50 +71,50 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -131,12 +130,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -207,9 +206,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -219,44 +218,44 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -265,12 +264,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -309,12 +308,12 @@
       "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -515,12 +514,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-      "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
-      "dev": true
     },
     "node_modules/@types/express": {
       "version": "4.17.3",
@@ -1753,9 +1746,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1766,7 +1759,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -1818,31 +1811,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -2628,9 +2621,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -3613,9 +3606,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -3634,25 +3627,25 @@
       }
     },
     "node_modules/office-addin-dev-certs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.1.tgz",
-      "integrity": "sha512-geCkk7S1SWCHwEil6+90HGj8xJc4hPRPlE5Z/Q6wIX6lAMRAEZOhZqC2fMayR7wvfhTA01eNyNT8jSVOhyH37g==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.3.tgz",
+      "integrity": "sha512-EGEHXWMOFNyT/kTth46tlJ1+0+yTy0CPFtrHV2qxCEECbrYetXwRVl4Iax+O9F4Xmr67eIOnh8/L1EBIwdySXQ==",
       "dependencies": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "mkcert": "^1.4.0",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1"
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3"
       },
       "bin": {
         "office-addin-dev-certs": "cli.js"
       }
     },
     "node_modules/office-addin-dev-settings": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.10.1.tgz",
-      "integrity": "sha512-MUVcqLgPB2DsAdVtSplx62ed4k9lkS3hpgrcxq1E2juEz4n760HhkWrsEX2ZFKd/xS1CCkhGANF264ibfsoy7Q==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.10.3.tgz",
+      "integrity": "sha512-ap5jINGqN+uahfD+hmFK9OXFBU2sVTlFWThtAmA/Jtb7tAcNkiMpQMwoVgBdTrDIkUj/UmaEIatfm7aF/uUcEQ==",
       "dependencies": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
@@ -3660,9 +3653,9 @@
         "inquirer": "^7.3.3",
         "jszip": "^3.7.1",
         "junk": "^3.1.0",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-manifest": "^1.7.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-manifest": "^1.7.3",
+        "office-addin-usage-data": "^1.4.3",
         "open": "^6.4.0",
         "whatwg-url": "^7.1.0",
         "winreg": "^1.2.4"
@@ -3705,9 +3698,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -3715,11 +3708,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -3727,15 +3720,15 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.1.tgz",
-      "integrity": "sha512-8m3Y5QOoTU3WriqWn7TYKGnivaDEUTw7xpoPo15gtoys//fgIB/wsEvA43lQ/ZAavUJayWo7+NERClLHNxXOjA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.3.tgz",
+      "integrity": "sha512-i6NEQgsB6ttX2Lu+56VHfZr+lPpaHXXEehml75lq8FMLR+maF3fSYcTVICVRMDJDMYMKiHKtKCvaXVAzlVtg5A==",
       "dependencies": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -3801,14 +3794,14 @@
       }
     },
     "node_modules/office-addin-node-debugger": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.6.1.tgz",
-      "integrity": "sha512-gNxqvCfjprXTHidH9ZIyvfUy2yYtlybgajUiAxPxmLDOm0pMK2GPW0IEuPhB1S6pfk1ho+dK9NBbES/NNlvOjA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.6.3.tgz",
+      "integrity": "sha512-nvvWJI/KQwSKtLgCCDjWyBJMgR4VG7XQfLE0YQ7HGXAlaMu3P+zptbdCu+t7wFWVj729GSm3cHmSwdmgjqojMw==",
       "dependencies": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-usage-data": "^1.4.3",
         "ws": "^7.4.6"
       },
       "bin": {
@@ -3816,19 +3809,19 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -5240,12 +5233,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -5259,41 +5252,41 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -5303,12 +5296,12 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -5366,57 +5359,57 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "debug": {
@@ -5443,12 +5436,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -5613,12 +5606,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/es6-promise": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-      "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
-      "dev": true
     },
     "@types/express": {
       "version": "4.17.3",
@@ -6612,9 +6599,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -6625,7 +6612,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -6652,25 +6639,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -7191,9 +7178,9 @@
       }
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true
     },
     "immediate": {
@@ -7903,9 +7890,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -7920,22 +7907,22 @@
       }
     },
     "office-addin-dev-certs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.1.tgz",
-      "integrity": "sha512-geCkk7S1SWCHwEil6+90HGj8xJc4hPRPlE5Z/Q6wIX6lAMRAEZOhZqC2fMayR7wvfhTA01eNyNT8jSVOhyH37g==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.3.tgz",
+      "integrity": "sha512-EGEHXWMOFNyT/kTth46tlJ1+0+yTy0CPFtrHV2qxCEECbrYetXwRVl4Iax+O9F4Xmr67eIOnh8/L1EBIwdySXQ==",
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "mkcert": "^1.4.0",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1"
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3"
       }
     },
     "office-addin-dev-settings": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.10.1.tgz",
-      "integrity": "sha512-MUVcqLgPB2DsAdVtSplx62ed4k9lkS3hpgrcxq1E2juEz4n760HhkWrsEX2ZFKd/xS1CCkhGANF264ibfsoy7Q==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.10.3.tgz",
+      "integrity": "sha512-ap5jINGqN+uahfD+hmFK9OXFBU2sVTlFWThtAmA/Jtb7tAcNkiMpQMwoVgBdTrDIkUj/UmaEIatfm7aF/uUcEQ==",
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
@@ -7943,9 +7930,9 @@
         "inquirer": "^7.3.3",
         "jszip": "^3.7.1",
         "junk": "^3.1.0",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-manifest": "^1.7.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-manifest": "^1.7.3",
+        "office-addin-usage-data": "^1.4.3",
         "open": "^6.4.0",
         "whatwg-url": "^7.1.0",
         "winreg": "^1.2.4"
@@ -7979,9 +7966,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -7989,24 +7976,24 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-manifest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.1.tgz",
-      "integrity": "sha512-8m3Y5QOoTU3WriqWn7TYKGnivaDEUTw7xpoPo15gtoys//fgIB/wsEvA43lQ/ZAavUJayWo7+NERClLHNxXOjA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.3.tgz",
+      "integrity": "sha512-i6NEQgsB6ttX2Lu+56VHfZr+lPpaHXXEehml75lq8FMLR+maF3fSYcTVICVRMDJDMYMKiHKtKCvaXVAzlVtg5A==",
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -8059,31 +8046,31 @@
       }
     },
     "office-addin-node-debugger": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.6.1.tgz",
-      "integrity": "sha512-gNxqvCfjprXTHidH9ZIyvfUy2yYtlybgajUiAxPxmLDOm0pMK2GPW0IEuPhB1S6pfk1ho+dK9NBbES/NNlvOjA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.6.3.tgz",
+      "integrity": "sha512-nvvWJI/KQwSKtLgCCDjWyBJMgR4VG7XQfLE0YQ7HGXAlaMu3P+zptbdCu+t7wFWVj729GSm3cHmSwdmgjqojMw==",
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-usage-data": "^1.4.3",
         "ws": "^7.4.6"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/office-addin-debugging/package-lock.json
+++ b/packages/office-addin-debugging/package-lock.json
@@ -29,6 +29,7 @@
         "@types/node-fetch": "^2.5.10",
         "@types/ws": "^6.0.4",
         "concurrently": "^6.2.2",
+        "es6-promise": "^4.2.8",
         "express": "^4.16.4",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
@@ -1652,6 +1653,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -6460,6 +6467,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-debugging/package.json
+++ b/packages/office-addin-debugging/package.json
@@ -40,7 +40,6 @@
     "@types/node-fetch": "^2.5.10",
     "@types/ws": "^6.0.4",
     "concurrently": "^6.2.2",
-    "es6-promise": "^4.2.8",
     "express": "^4.16.4",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",

--- a/packages/office-addin-debugging/package.json
+++ b/packages/office-addin-debugging/package.json
@@ -34,7 +34,6 @@
     "office-addin-usage-data": "^1.4.3"
   },
   "devDependencies": {
-    "@types/es6-promise": "0.0.32",
     "@types/express": "^4.17.3",
     "@types/mocha": "^5.2.5",
     "@types/node": "^14.17.2",

--- a/packages/office-addin-debugging/package.json
+++ b/packages/office-addin-debugging/package.json
@@ -40,6 +40,7 @@
     "@types/node-fetch": "^2.5.10",
     "@types/ws": "^6.0.4",
     "concurrently": "^6.2.2",
+    "es6-promise": "^4.2.8",
     "express": "^4.16.4",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",

--- a/packages/office-addin-debugging/tsconfig.json
+++ b/packages/office-addin-debugging/tsconfig.json
@@ -12,8 +12,7 @@
         "noImplicitUseStrict": true,
         "types": [
             "node",
-            "node-fetch",
-            "es6-promise"
+            "node-fetch"
         ]
     },
     "include": [

--- a/packages/office-addin-dev-certs/package-lock.json
+++ b/packages/office-addin-dev-certs/package-lock.json
@@ -25,6 +25,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.2",
+        "es6-promise": "^4.2.8",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
@@ -1311,6 +1312,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5012,6 +5019,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-dev-certs/package-lock.json
+++ b/packages/office-addin-dev-certs/package-lock.json
@@ -6,28 +6,27 @@
   "packages": {
     "": {
       "name": "office-addin-dev-certs",
-      "version": "1.7.1",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "mkcert": "^1.4.0",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1"
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3"
       },
       "bin": {
         "office-addin-dev-certs": "cli.js"
       },
       "devDependencies": {
-        "@types/es6-promise": "0.0.32",
         "@types/fs-extra": "^5.1.0",
         "@types/mkcert": "^1.2.0",
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.2",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
         "sinon": "^7.5.0",
         "ts-node": "^10.1.0",
@@ -44,12 +43,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -67,50 +66,50 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -126,12 +125,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -211,9 +210,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -223,44 +222,44 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -269,12 +268,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -290,12 +289,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -466,12 +465,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
-      "dev": true
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-      "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
       "dev": true
     },
     "node_modules/@types/fs-extra": {
@@ -1410,9 +1403,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1423,7 +1416,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -1475,31 +1468,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -2070,9 +2063,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -2893,9 +2886,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -2914,9 +2907,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -2924,11 +2917,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -2936,19 +2929,19 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -4049,12 +4042,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -4068,41 +4061,41 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -4112,12 +4105,12 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -4181,57 +4174,57 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "globals": {
@@ -4243,12 +4236,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -4397,12 +4390,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
-      "dev": true
-    },
-    "@types/es6-promise": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-      "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
       "dev": true
     },
     "@types/fs-extra": {
@@ -5138,9 +5125,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5151,7 +5138,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -5178,25 +5165,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -5578,9 +5565,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true
     },
     "import-fresh": {
@@ -6181,9 +6168,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -6198,9 +6185,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -6208,28 +6195,28 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/office-addin-dev-certs/package-lock.json
+++ b/packages/office-addin-dev-certs/package-lock.json
@@ -25,7 +25,6 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",
         "concurrently": "^6.2.2",
-        "es6-promise": "^4.2.8",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
@@ -1312,12 +1311,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5019,12 +5012,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-dev-certs/package.json
+++ b/packages/office-addin-dev-certs/package.json
@@ -45,6 +45,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^14.17.2",
     "concurrently": "^6.2.2",
+    "es6-promise": "^4.2.8",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",
     "rimraf": "^3.0.2",

--- a/packages/office-addin-dev-certs/package.json
+++ b/packages/office-addin-dev-certs/package.json
@@ -45,7 +45,6 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^14.17.2",
     "concurrently": "^6.2.2",
-    "es6-promise": "^4.2.8",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",
     "rimraf": "^3.0.2",

--- a/packages/office-addin-dev-certs/package.json
+++ b/packages/office-addin-dev-certs/package.json
@@ -40,7 +40,6 @@
     "office-addin-usage-data": "^1.4.3"
   },
   "devDependencies": {
-    "@types/es6-promise": "0.0.32",
     "@types/fs-extra": "^5.1.0",
     "@types/mkcert": "^1.2.0",
     "@types/mocha": "^5.2.7",

--- a/packages/office-addin-dev-certs/tsconfig.json
+++ b/packages/office-addin-dev-certs/tsconfig.json
@@ -11,8 +11,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
     },
     "include": [

--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -36,6 +36,7 @@
         "@types/whatwg-url": "^6.4.0",
         "@types/winreg": "^1.2.30",
         "concurrently": "^6.2.2",
+        "es6-promise": "^4.2.8",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
@@ -1434,6 +1435,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5870,6 +5877,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -36,7 +36,6 @@
         "@types/whatwg-url": "^6.4.0",
         "@types/winreg": "^1.2.30",
         "concurrently": "^6.2.2",
-        "es6-promise": "^4.2.8",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
@@ -1435,12 +1434,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5877,12 +5870,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "office-addin-dev-settings",
-      "version": "1.10.1",
+      "version": "1.10.3",
       "license": "MIT",
       "dependencies": {
         "child_process": "^1.0.2",
@@ -15,9 +15,9 @@
         "inquirer": "^7.3.3",
         "jszip": "^3.7.1",
         "junk": "^3.1.0",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-manifest": "^1.7.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-manifest": "^1.7.3",
+        "office-addin-usage-data": "^1.4.3",
         "open": "^6.4.0",
         "whatwg-url": "^7.1.0",
         "winreg": "^1.2.4"
@@ -26,7 +26,6 @@
         "office-addin-dev-settings": "cli.js"
       },
       "devDependencies": {
-        "@types/es6-promise": "^3.3.0",
         "@types/fs-extra": "^9.0.1",
         "@types/inquirer": "^6.5.0",
         "@types/mocha": "^8.0.3",
@@ -38,7 +37,7 @@
         "@types/winreg": "^1.2.30",
         "concurrently": "^6.2.2",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
         "sinon": "^7.5.0",
         "ts-node": "^10.1.0",
@@ -55,12 +54,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -78,50 +77,50 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -137,12 +136,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -151,9 +150,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -163,44 +162,44 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -209,12 +208,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -230,12 +229,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -407,16 +406,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "deprecated": "This is a stub types definition for es6-promise (https://github.com/jakearchibald/ES6-Promise). es6-promise provides its own type definitions, so you don't need @types/es6-promise installed!",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "*"
-      }
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.1",
@@ -1446,12 +1435,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1539,9 +1522,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1552,7 +1535,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -1604,31 +1587,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -2348,9 +2331,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -3412,9 +3395,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -3433,9 +3416,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -3443,11 +3426,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -3455,15 +3438,15 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.1.tgz",
-      "integrity": "sha512-8m3Y5QOoTU3WriqWn7TYKGnivaDEUTw7xpoPo15gtoys//fgIB/wsEvA43lQ/ZAavUJayWo7+NERClLHNxXOjA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.3.tgz",
+      "integrity": "sha512-i6NEQgsB6ttX2Lu+56VHfZr+lPpaHXXEehml75lq8FMLR+maF3fSYcTVICVRMDJDMYMKiHKtKCvaXVAzlVtg5A==",
       "dependencies": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -3473,19 +3456,19 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -4821,12 +4804,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -4840,41 +4823,41 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -4884,68 +4867,68 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "globals": {
@@ -4957,12 +4940,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -5112,15 +5095,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
-    },
-    "@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "*"
-      }
     },
     "@types/fs-extra": {
       "version": "9.0.1",
@@ -5897,12 +5871,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -6069,9 +6037,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -6082,7 +6050,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -6109,25 +6077,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -6554,9 +6522,9 @@
       }
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true
     },
     "immediate": {
@@ -7347,9 +7315,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -7364,9 +7332,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -7374,43 +7342,43 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-manifest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.1.tgz",
-      "integrity": "sha512-8m3Y5QOoTU3WriqWn7TYKGnivaDEUTw7xpoPo15gtoys//fgIB/wsEvA43lQ/ZAavUJayWo7+NERClLHNxXOjA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.3.tgz",
+      "integrity": "sha512-i6NEQgsB6ttX2Lu+56VHfZr+lPpaHXXEehml75lq8FMLR+maF3fSYcTVICVRMDJDMYMKiHKtKCvaXVAzlVtg5A==",
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -46,6 +46,7 @@
     "@types/whatwg-url": "^6.4.0",
     "@types/winreg": "^1.2.30",
     "concurrently": "^6.2.2",
+    "es6-promise": "^4.2.8",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",
     "rimraf": "^3.0.2",

--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -46,7 +46,6 @@
     "@types/whatwg-url": "^6.4.0",
     "@types/winreg": "^1.2.30",
     "concurrently": "^6.2.2",
-    "es6-promise": "^4.2.8",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",
     "rimraf": "^3.0.2",

--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -36,7 +36,6 @@
     "winreg": "^1.2.4"
   },
   "devDependencies": {
-    "@types/es6-promise": "^3.3.0",
     "@types/fs-extra": "^9.0.1",
     "@types/inquirer": "^6.5.0",
     "@types/mocha": "^8.0.3",

--- a/packages/office-addin-dev-settings/tsconfig.json
+++ b/packages/office-addin-dev-settings/tsconfig.json
@@ -11,8 +11,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
     },
     "include": [

--- a/packages/office-addin-lint/package-lock.json
+++ b/packages/office-addin-lint/package-lock.json
@@ -31,6 +31,7 @@
         "@types/node-fetch": "^2.5.10",
         "assert": "^1.4.1",
         "concurrently": "^6.2.2",
+        "es6-promise": "^4.2.8",
         "mocha": "^9.1.1",
         "rimraf": "^3.0.2",
         "ts-node": "^10.1.0",
@@ -1382,6 +1383,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -4832,6 +4839,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-lint/package-lock.json
+++ b/packages/office-addin-lint/package-lock.json
@@ -31,7 +31,6 @@
         "@types/node-fetch": "^2.5.10",
         "assert": "^1.4.1",
         "concurrently": "^6.2.2",
-        "es6-promise": "^4.2.8",
         "mocha": "^9.1.1",
         "rimraf": "^3.0.2",
         "ts-node": "^10.1.0",
@@ -1383,12 +1382,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -4839,12 +4832,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-lint/package-lock.json
+++ b/packages/office-addin-lint/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "office-addin-lint",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -14,11 +14,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -26,7 +26,6 @@
       },
       "devDependencies": {
         "@types/assert": "^1.4.6",
-        "@types/es6-promise": "^3.3.0",
         "@types/mocha": "^5.2.5",
         "@types/node": "^14.17.2",
         "@types/node-fetch": "^2.5.10",
@@ -543,16 +542,6 @@
       "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.4.tgz",
       "integrity": "sha512-CaFVW21Ulu0J9sUaEWJjwmhkDkeoxa4fniVSERzZC13sU9v8NNM2lMlkfZZv60j47D+qDt0Lyo8skVP3CTXUdA==",
       "dev": true
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "deprecated": "This is a stub types definition for es6-promise (https://github.com/jakearchibald/ES6-Promise). es6-promise provides its own type definitions, so you don't need @types/es6-promise installed!",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -1394,12 +1383,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1485,9 +1468,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
         "@typescript-eslint/experimental-utils": "^4.31.0",
@@ -1497,7 +1480,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -2832,9 +2815,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -2845,18 +2828,18 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ=="
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -4249,15 +4232,6 @@
       "integrity": "sha512-CaFVW21Ulu0J9sUaEWJjwmhkDkeoxa4fniVSERzZC13sU9v8NNM2lMlkfZZv60j47D+qDt0Lyo8skVP3CTXUdA==",
       "dev": true
     },
-    "@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -4859,12 +4833,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -4942,9 +4910,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
         "@typescript-eslint/experimental-utils": "^4.31.0",
@@ -4954,7 +4922,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -5881,9 +5849,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -5891,18 +5859,18 @@
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ=="
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/office-addin-lint/package.json
+++ b/packages/office-addin-lint/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@types/assert": "^1.4.6",
-    "@types/es6-promise": "^3.3.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^14.17.2",
     "@types/node-fetch": "^2.5.10",

--- a/packages/office-addin-lint/package.json
+++ b/packages/office-addin-lint/package.json
@@ -43,6 +43,7 @@
     "@types/node-fetch": "^2.5.10",
     "assert": "^1.4.1",
     "concurrently": "^6.2.2",
+    "es6-promise": "^4.2.8",
     "mocha": "^9.1.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.1.0",

--- a/packages/office-addin-lint/package.json
+++ b/packages/office-addin-lint/package.json
@@ -43,7 +43,6 @@
     "@types/node-fetch": "^2.5.10",
     "assert": "^1.4.1",
     "concurrently": "^6.2.2",
-    "es6-promise": "^4.2.8",
     "mocha": "^9.1.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.1.0",

--- a/packages/office-addin-lint/tsconfig.json
+++ b/packages/office-addin-lint/tsconfig.json
@@ -11,8 +11,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
     },
     "include": [

--- a/packages/office-addin-manifest/package-lock.json
+++ b/packages/office-addin-manifest/package-lock.json
@@ -30,7 +30,6 @@
         "@types/xml2js": "^0.4.5",
         "concurrently": "^6.2.2",
         "copy-dir": "^0.4.0",
-        "es6-promise": "^4.2.8",
         "fs-extra": "^7.0.0",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
@@ -1309,12 +1308,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5250,12 +5243,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-manifest/package-lock.json
+++ b/packages/office-addin-manifest/package-lock.json
@@ -22,7 +22,6 @@
         "office-addin-manifest": "cli.js"
       },
       "devDependencies": {
-        "@types/es6-promise": "0.0.32",
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",
         "@types/node-fetch": "^2.5.10",
@@ -365,12 +364,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
-      "dev": true
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-      "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -4544,12 +4537,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
-      "dev": true
-    },
-    "@types/es6-promise": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-      "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
       "dev": true
     },
     "@types/json-schema": {

--- a/packages/office-addin-manifest/package-lock.json
+++ b/packages/office-addin-manifest/package-lock.json
@@ -30,6 +30,7 @@
         "@types/xml2js": "^0.4.5",
         "concurrently": "^6.2.2",
         "copy-dir": "^0.4.0",
+        "es6-promise": "^4.2.8",
         "fs-extra": "^7.0.0",
         "mocha": "^9.1.1",
         "office-addin-lint": "^1.4.3",
@@ -1308,6 +1309,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5243,6 +5250,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-manifest/package.json
+++ b/packages/office-addin-manifest/package.json
@@ -40,7 +40,6 @@
     "@types/xml2js": "^0.4.5",
     "concurrently": "^6.2.2",
     "copy-dir": "^0.4.0",
-    "es6-promise": "^4.2.8",
     "fs-extra": "^7.0.0",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",

--- a/packages/office-addin-manifest/package.json
+++ b/packages/office-addin-manifest/package.json
@@ -32,7 +32,6 @@
     "xml2js": "^0.4.23"
   },
   "devDependencies": {
-    "@types/es6-promise": "0.0.32",
     "@types/mocha": "^5.2.7",
     "@types/node": "^14.17.2",
     "@types/node-fetch": "^2.5.10",

--- a/packages/office-addin-manifest/package.json
+++ b/packages/office-addin-manifest/package.json
@@ -40,6 +40,7 @@
     "@types/xml2js": "^0.4.5",
     "concurrently": "^6.2.2",
     "copy-dir": "^0.4.0",
+    "es6-promise": "^4.2.8",
     "fs-extra": "^7.0.0",
     "mocha": "^9.1.1",
     "office-addin-lint": "^1.4.3",

--- a/packages/office-addin-manifest/tsconfig.json
+++ b/packages/office-addin-manifest/tsconfig.json
@@ -11,8 +11,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
     },
     "include": [

--- a/packages/office-addin-mock/package-lock.json
+++ b/packages/office-addin-mock/package-lock.json
@@ -6,20 +6,19 @@
   "packages": {
     "": {
       "name": "office-addin-mock",
-      "version": "0.1.1",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.2.8",
-        "office-addin-usage-data": "^1.4.1"
+        "office-addin-usage-data": "^1.4.3"
       },
       "devDependencies": {
-        "@types/es6-promise": "3.3.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^14.17.2",
         "assert": "^2.0.0",
         "concurrently": "^6.2.1",
         "mocha": "^9.1.2",
-        "office-addin-lint": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
         "ts-node": "^10.2.1",
         "typescript": "^4.4.3"
@@ -35,12 +34,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -49,71 +48,71 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -145,9 +144,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -157,44 +156,44 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -203,12 +202,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -224,12 +223,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -364,16 +363,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "deprecated": "This is a stub types definition for es6-promise (https://github.com/jakearchibald/ES6-Promise). es6-promise provides its own type definitions, so you don't need @types/es6-promise installed!",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -1402,9 +1391,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1415,7 +1404,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -1467,31 +1456,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -2052,9 +2041,9 @@
       "dev": true
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -2750,9 +2739,9 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2922,9 +2911,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -2935,9 +2924,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -2945,11 +2934,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -2957,19 +2946,19 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -4178,67 +4167,67 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -4263,57 +4252,57 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "globals": {
@@ -4325,12 +4314,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -4440,15 +4429,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
-    },
-    "@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "*"
-      }
     },
     "@types/json-schema": {
       "version": "7.0.9",
@@ -5235,9 +5215,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5248,7 +5228,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -5275,25 +5255,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -5672,9 +5652,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true
     },
     "import-fresh": {
@@ -6175,9 +6155,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -6301,9 +6281,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -6311,9 +6291,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -6321,28 +6301,28 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/office-addin-mock/package-lock.json
+++ b/packages/office-addin-mock/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "es6-promise": "^4.2.8",
         "office-addin-usage-data": "^1.4.3"
       },
       "devDependencies": {
@@ -1294,11 +1293,6 @@
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
       "dev": true
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5107,11 +5101,6 @@
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
       "dev": true
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-mock/package.json
+++ b/packages/office-addin-mock/package.json
@@ -15,7 +15,6 @@
     "office-js"
   ],
   "dependencies": {
-    "es6-promise": "^4.2.8",
     "office-addin-usage-data": "^1.4.3"
   },
   "devDependencies": {

--- a/packages/office-addin-mock/package.json
+++ b/packages/office-addin-mock/package.json
@@ -19,7 +19,6 @@
     "office-addin-usage-data": "^1.4.3"
   },
   "devDependencies": {
-    "@types/es6-promise": "3.3.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "^14.17.2",
     "assert": "^2.0.0",

--- a/packages/office-addin-mock/tsconfig.json
+++ b/packages/office-addin-mock/tsconfig.json
@@ -11,7 +11,6 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "es6-promise",
             "node"
         ]
     },

--- a/packages/office-addin-node-debugger/package-lock.json
+++ b/packages/office-addin-node-debugger/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node-fetch": "^2.5.10",
         "@types/ws": "^5.1.2",
         "concurrently": "^6.2.2",
+        "es6-promise": "^4.2.8",
         "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
         "typescript": "^4.3.5"
@@ -1132,6 +1133,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -4087,6 +4094,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-node-debugger/package-lock.json
+++ b/packages/office-addin-node-debugger/package-lock.json
@@ -6,25 +6,24 @@
   "packages": {
     "": {
       "name": "office-addin-node-debugger",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-usage-data": "^1.4.3",
         "ws": "^7.4.6"
       },
       "bin": {
         "office-addin-node-debugger": "cli.js"
       },
       "devDependencies": {
-        "@types/es6-promise": "0.0.32",
         "@types/node": "^14.17.2",
         "@types/node-fetch": "^2.5.10",
         "@types/ws": "^5.1.2",
         "concurrently": "^6.2.2",
-        "office-addin-lint": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
         "typescript": "^4.3.5"
       }
@@ -39,12 +38,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -53,50 +52,50 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -112,12 +111,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -197,9 +196,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -209,44 +208,44 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -255,12 +254,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -276,12 +275,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -371,12 +370,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-      "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
-      "dev": true
     },
     "node_modules/@types/events": {
       "version": "3.0.0",
@@ -1231,9 +1224,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1244,7 +1237,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -1296,31 +1289,31 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -1811,9 +1804,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -2389,9 +2382,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -2402,9 +2395,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -2412,11 +2405,11 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -2424,19 +2417,19 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -3276,52 +3269,52 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -3331,12 +3324,12 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -3400,57 +3393,57 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "globals": {
@@ -3462,12 +3455,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -3538,12 +3531,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@types/es6-promise": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-      "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
-      "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
@@ -4194,9 +4181,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -4207,7 +4194,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -4234,25 +4221,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -4595,9 +4582,9 @@
       }
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true
     },
     "import-fresh": {
@@ -5014,9 +5001,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -5024,9 +5011,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -5034,28 +5021,28 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/office-addin-node-debugger/package-lock.json
+++ b/packages/office-addin-node-debugger/package-lock.json
@@ -23,7 +23,6 @@
         "@types/node-fetch": "^2.5.10",
         "@types/ws": "^5.1.2",
         "concurrently": "^6.2.2",
-        "es6-promise": "^4.2.8",
         "office-addin-lint": "^1.4.3",
         "rimraf": "^3.0.2",
         "typescript": "^4.3.5"
@@ -1133,12 +1132,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -4094,12 +4087,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-node-debugger/package.json
+++ b/packages/office-addin-node-debugger/package.json
@@ -33,6 +33,7 @@
     "@types/node-fetch": "^2.5.10",
     "@types/ws": "^5.1.2",
     "concurrently": "^6.2.2",
+    "es6-promise": "^4.2.8",
     "office-addin-lint": "^1.4.3",
     "rimraf": "^3.0.2",
     "typescript": "^4.3.5"

--- a/packages/office-addin-node-debugger/package.json
+++ b/packages/office-addin-node-debugger/package.json
@@ -29,7 +29,6 @@
     "ws": "^7.4.6"
   },
   "devDependencies": {
-    "@types/es6-promise": "0.0.32",
     "@types/node": "^14.17.2",
     "@types/node-fetch": "^2.5.10",
     "@types/ws": "^5.1.2",

--- a/packages/office-addin-node-debugger/package.json
+++ b/packages/office-addin-node-debugger/package.json
@@ -33,7 +33,6 @@
     "@types/node-fetch": "^2.5.10",
     "@types/ws": "^5.1.2",
     "concurrently": "^6.2.2",
-    "es6-promise": "^4.2.8",
     "office-addin-lint": "^1.4.3",
     "rimraf": "^3.0.2",
     "typescript": "^4.3.5"

--- a/packages/office-addin-node-debugger/tsconfig.json
+++ b/packages/office-addin-node-debugger/tsconfig.json
@@ -13,8 +13,7 @@
         "types": [
             "node",
             "ws",
-            "node-fetch",
-            "es6-promise"
+            "node-fetch"
         ]
     },
     "include": [

--- a/packages/office-addin-prettier-config/package-lock.json
+++ b/packages/office-addin-prettier-config/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "office-addin-prettier-config",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT"
     }
   }

--- a/packages/office-addin-sso/package-lock.json
+++ b/packages/office-addin-sso/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "office-addin-sso",
-      "version": "1.2.1",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^3.0.0",
@@ -20,8 +20,8 @@
         "jquery": "^3.5.1",
         "morgan": "1.9.1",
         "node-fetch": "^2.6.1",
-        "office-addin-lint": "^1.4.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-lint": "^1.4.3",
+        "office-addin-usage-data": "^1.4.3",
         "pug": "^3.0.2"
       },
       "bin": {
@@ -29,7 +29,6 @@
       },
       "devDependencies": {
         "@types/cors": "2.8.4",
-        "@types/es6-promise": "^3.3.0",
         "@types/express": "4.16.0",
         "@types/jquery": "^3.3.34",
         "@types/mocha": "^5.2.7",
@@ -37,10 +36,10 @@
         "concurrently": "^6.2.2",
         "cpy-cli": "^3.1.1",
         "mocha": "^9.1.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-dev-certs": "^1.7.1",
-        "office-addin-manifest": "^1.7.1",
-        "office-addin-test-helpers": "^1.2.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-dev-certs": "^1.7.3",
+        "office-addin-manifest": "^1.7.3",
+        "office-addin-test-helpers": "^1.2.3",
         "rimraf": "^3.0.2",
         "ts-node": "^10.1.0",
         "typescript": "^4.3.5"
@@ -55,11 +54,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dependencies": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -68,46 +67,46 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -122,11 +121,11 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -199,9 +198,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -210,41 +209,41 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -253,11 +252,11 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -293,11 +292,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -486,16 +485,6 @@
       "dev": true,
       "dependencies": {
         "@types/express": "*"
-      }
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "deprecated": "This is a stub types definition for es6-promise (https://github.com/jakearchibald/ES6-Promise). es6-promise provides its own type definitions, so you don't need @types/es6-promise installed!",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "*"
       }
     },
     "node_modules/@types/express": {
@@ -2424,9 +2413,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
         "@typescript-eslint/experimental-utils": "^4.31.0",
@@ -2436,7 +2425,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -2486,30 +2475,30 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dependencies": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -3456,9 +3445,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "engines": {
         "node": ">= 4"
       }
@@ -4877,9 +4866,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -4890,37 +4879,37 @@
       }
     },
     "node_modules/office-addin-dev-certs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.1.tgz",
-      "integrity": "sha512-geCkk7S1SWCHwEil6+90HGj8xJc4hPRPlE5Z/Q6wIX6lAMRAEZOhZqC2fMayR7wvfhTA01eNyNT8jSVOhyH37g==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.3.tgz",
+      "integrity": "sha512-EGEHXWMOFNyT/kTth46tlJ1+0+yTy0CPFtrHV2qxCEECbrYetXwRVl4Iax+O9F4Xmr67eIOnh8/L1EBIwdySXQ==",
       "dev": true,
       "dependencies": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "mkcert": "^1.4.0",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1"
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3"
       },
       "bin": {
         "office-addin-dev-certs": "cli.js"
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
         "@typescript-eslint/parser": "^4.15.1",
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -4928,16 +4917,16 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.1.tgz",
-      "integrity": "sha512-8m3Y5QOoTU3WriqWn7TYKGnivaDEUTw7xpoPo15gtoys//fgIB/wsEvA43lQ/ZAavUJayWo7+NERClLHNxXOjA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.3.tgz",
+      "integrity": "sha512-i6NEQgsB6ttX2Lu+56VHfZr+lPpaHXXEehml75lq8FMLR+maF3fSYcTVICVRMDJDMYMKiHKtKCvaXVAzlVtg5A==",
       "dev": true,
       "dependencies": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -5018,14 +5007,14 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ=="
     },
     "node_modules/office-addin-test-helpers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/office-addin-test-helpers/-/office-addin-test-helpers-1.2.1.tgz",
-      "integrity": "sha512-SyB/CK0IhlEF/ZlA2s6xXuNB8yxkcpi4901wnCdLN/A7gaSkGvIo+sCoHdfidWsEiuJUNHjeFviY+N06ZXrVSA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/office-addin-test-helpers/-/office-addin-test-helpers-1.2.3.tgz",
+      "integrity": "sha512-rbCZtTrxJgT3Wm9y843Oqrh0csA1154gAU8kmJirM7kVs5Fz5h4JFGu7unn8I3D+V45gihmaKqcs6z1HEbAKIw==",
       "dev": true,
       "dependencies": {
         "es6-promise": "^4.2.8",
@@ -5033,13 +5022,13 @@
       }
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
@@ -7146,47 +7135,47 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-      "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "requires": {
-        "@babel/types": "^7.15.6",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.15.4",
-        "@babel/template": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -7195,11 +7184,11 @@
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -7256,52 +7245,52 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-      "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA=="
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng=="
     },
     "@babel/template": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.4",
-        "@babel/helper-function-name": "^7.15.4",
-        "@babel/helper-hoist-variables": "^7.15.4",
-        "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/parser": "^7.15.4",
-        "@babel/types": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "debug": {
@@ -7325,11 +7314,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -7482,15 +7471,6 @@
       "dev": true,
       "requires": {
         "@types/express": "*"
-      }
-    },
-    "@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "*"
       }
     },
     "@types/express": {
@@ -9021,9 +9001,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
         "@typescript-eslint/experimental-utils": "^4.31.0",
@@ -9033,7 +9013,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -9058,24 +9038,24 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -9749,9 +9729,9 @@
       }
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -10796,9 +10776,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -10806,48 +10786,48 @@
       }
     },
     "office-addin-dev-certs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.1.tgz",
-      "integrity": "sha512-geCkk7S1SWCHwEil6+90HGj8xJc4hPRPlE5Z/Q6wIX6lAMRAEZOhZqC2fMayR7wvfhTA01eNyNT8jSVOhyH37g==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.3.tgz",
+      "integrity": "sha512-EGEHXWMOFNyT/kTth46tlJ1+0+yTy0CPFtrHV2qxCEECbrYetXwRVl4Iax+O9F4Xmr67eIOnh8/L1EBIwdySXQ==",
       "dev": true,
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "mkcert": "^1.4.0",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1"
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3"
       }
     },
     "office-addin-lint": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-      "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+      "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
         "@typescript-eslint/parser": "^4.15.1",
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-prettier-config": "^1.1.0",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-prettier-config": "^1.1.1",
+        "office-addin-usage-data": "^1.4.3",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-manifest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.1.tgz",
-      "integrity": "sha512-8m3Y5QOoTU3WriqWn7TYKGnivaDEUTw7xpoPo15gtoys//fgIB/wsEvA43lQ/ZAavUJayWo7+NERClLHNxXOjA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.3.tgz",
+      "integrity": "sha512-i6NEQgsB6ttX2Lu+56VHfZr+lPpaHXXEehml75lq8FMLR+maF3fSYcTVICVRMDJDMYMKiHKtKCvaXVAzlVtg5A==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.3.1",
-        "office-addin-usage-data": "^1.4.1",
+        "office-addin-cli": "^1.3.2",
+        "office-addin-usage-data": "^1.4.3",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -10912,14 +10892,14 @@
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ=="
     },
     "office-addin-test-helpers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/office-addin-test-helpers/-/office-addin-test-helpers-1.2.1.tgz",
-      "integrity": "sha512-SyB/CK0IhlEF/ZlA2s6xXuNB8yxkcpi4901wnCdLN/A7gaSkGvIo+sCoHdfidWsEiuJUNHjeFviY+N06ZXrVSA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/office-addin-test-helpers/-/office-addin-test-helpers-1.2.3.tgz",
+      "integrity": "sha512-rbCZtTrxJgT3Wm9y843Oqrh0csA1154gAU8kmJirM7kVs5Fz5h4JFGu7unn8I3D+V45gihmaKqcs6z1HEbAKIw==",
       "dev": true,
       "requires": {
         "es6-promise": "^4.2.8",
@@ -10927,13 +10907,13 @@
       }
     },
     "office-addin-usage-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-      "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+      "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       }
     },

--- a/packages/office-addin-sso/package.json
+++ b/packages/office-addin-sso/package.json
@@ -39,7 +39,6 @@
   },
   "devDependencies": {
     "@types/cors": "2.8.4",
-    "@types/es6-promise": "^3.3.0",
     "@types/express": "4.16.0",
     "@types/jquery": "^3.3.34",
     "@types/mocha": "^5.2.7",

--- a/packages/office-addin-sso/tsconfig.json
+++ b/packages/office-addin-sso/tsconfig.json
@@ -11,8 +11,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ],
         "typeRoots": [
             "./node_modules/@types/"

--- a/packages/office-addin-test-helpers/package-lock.json
+++ b/packages/office-addin-test-helpers/package-lock.json
@@ -9,7 +9,6 @@
             "version": "1.2.3",
             "license": "MIT",
             "dependencies": {
-                "es6-promise": "^4.2.8",
                 "isomorphic-fetch": "^3.0.0"
             },
             "devDependencies": {
@@ -1335,11 +1334,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -4884,11 +4878,6 @@
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
             }
-        },
-        "es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "escalade": {
             "version": "3.1.1",

--- a/packages/office-addin-test-helpers/package-lock.json
+++ b/packages/office-addin-test-helpers/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "office-addin-test-helpers",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "license": "MIT",
             "dependencies": {
                 "es6-promise": "^4.2.8",
@@ -14,14 +14,13 @@
             },
             "devDependencies": {
                 "@types/es6-collections": "^0.5.31",
-                "@types/es6-promise": "0.0.32",
                 "@types/express": "^4.17.3",
                 "@types/isomorphic-fetch": "^0.0.35",
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^14.17.2",
                 "concurrently": "^6.2.2",
                 "mocha": "^9.1.1",
-                "office-addin-lint": "^1.4.1",
+                "office-addin-lint": "^1.4.3",
                 "rimraf": "^3.0.2",
                 "ts-node": "^10.1.0",
                 "typescript": "^4.3.5"
@@ -37,12 +36,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-            "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+            "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.15.6",
+                "@babel/types": "^7.16.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -60,50 +59,50 @@
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-            "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+            "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-get-function-arity": "^7.15.4",
-                "@babel/template": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/helper-get-function-arity": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-get-function-arity": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-            "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+            "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-            "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+            "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-            "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+            "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -119,12 +118,12 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+            "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -195,9 +194,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-            "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+            "version": "7.16.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+            "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -207,44 +206,44 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-            "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+            "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/code-frame": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template/node_modules/@babel/code-frame": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-            "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+            "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.14.5"
+                "@babel/highlight": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-            "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+            "version": "7.16.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+            "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/generator": "^7.15.4",
-                "@babel/helper-function-name": "^7.15.4",
-                "@babel/helper-hoist-variables": "^7.15.4",
-                "@babel/helper-split-export-declaration": "^7.15.4",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-function-name": "^7.16.0",
+                "@babel/helper-hoist-variables": "^7.16.0",
+                "@babel/helper-split-export-declaration": "^7.16.0",
+                "@babel/parser": "^7.16.3",
+                "@babel/types": "^7.16.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -253,12 +252,12 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-            "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+            "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.14.5"
+                "@babel/highlight": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -274,12 +273,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.15.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-            "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+            "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.14.9",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -439,12 +438,6 @@
             "version": "0.5.31",
             "resolved": "https://registry.npmjs.org/@types/es6-collections/-/es6-collections-0.5.31.tgz",
             "integrity": "sha512-djEvbdTH5Uw7V0WqdMQLG4NK3+iu/FMZy/ylyhWEFnW5xOsXEWpivo/dhP+cR43Az+ipytza7dTSnpsWCxKYAw==",
-            "dev": true
-        },
-        "node_modules/@types/es6-promise": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-            "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
             "dev": true
         },
         "node_modules/@types/express": {
@@ -1439,9 +1432,9 @@
             }
         },
         "node_modules/eslint-plugin-office-addins": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-            "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+            "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
             "dev": true,
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1452,7 +1445,7 @@
                 "eslint-plugin-prettier": "^4.0.0",
                 "eslint-plugin-react": "^7.25.1",
                 "eslint-plugin-react-native": "^3.11.0",
-                "office-addin-prettier-config": "^1.1.0",
+                "office-addin-prettier-config": "^1.1.1",
                 "prettier": "^2.4.0",
                 "requireindex": "~1.2.0",
                 "typescript": "^4.4.2"
@@ -1504,31 +1497,31 @@
             }
         },
         "node_modules/eslint-plugin-react": {
-            "version": "7.26.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-            "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+            "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
             "dev": true,
             "dependencies": {
-                "array-includes": "^3.1.3",
-                "array.prototype.flatmap": "^1.2.4",
+                "array-includes": "^3.1.4",
+                "array.prototype.flatmap": "^1.2.5",
                 "doctrine": "^2.1.0",
-                "estraverse": "^5.2.0",
+                "estraverse": "^5.3.0",
                 "jsx-ast-utils": "^2.4.1 || ^3.0.0",
                 "minimatch": "^3.0.4",
-                "object.entries": "^1.1.4",
-                "object.fromentries": "^2.0.4",
-                "object.hasown": "^1.0.0",
-                "object.values": "^1.1.4",
+                "object.entries": "^1.1.5",
+                "object.fromentries": "^2.0.5",
+                "object.hasown": "^1.1.0",
+                "object.values": "^1.1.5",
                 "prop-types": "^15.7.2",
                 "resolve": "^2.0.0-next.3",
                 "semver": "^6.3.0",
-                "string.prototype.matchall": "^4.0.5"
+                "string.prototype.matchall": "^4.0.6"
             },
             "engines": {
                 "node": ">=4"
             },
             "peerDependencies": {
-                "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
             }
         },
         "node_modules/eslint-plugin-react-native": {
@@ -2081,9 +2074,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+            "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -2811,9 +2804,9 @@
             }
         },
         "node_modules/office-addin-cli": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-            "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+            "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
             "dev": true,
             "dependencies": {
                 "commander": "^6.2.1",
@@ -2825,9 +2818,9 @@
             }
         },
         "node_modules/office-addin-lint": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-            "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+            "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
             "dev": true,
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -2835,11 +2828,11 @@
                 "commander": "^6.2.0",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.1.0",
-                "eslint-plugin-office-addins": "^1.1.1",
+                "eslint-plugin-office-addins": "^1.1.2",
                 "eslint-plugin-prettier": "^3.3.1",
-                "office-addin-cli": "^1.3.1",
-                "office-addin-prettier-config": "^1.1.0",
-                "office-addin-usage-data": "^1.4.1",
+                "office-addin-cli": "^1.3.2",
+                "office-addin-prettier-config": "^1.1.1",
+                "office-addin-usage-data": "^1.4.3",
                 "prettier": "^2.2.1"
             },
             "bin": {
@@ -2847,20 +2840,20 @@
             }
         },
         "node_modules/office-addin-prettier-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-            "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+            "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
             "dev": true
         },
         "node_modules/office-addin-usage-data": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-            "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+            "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
             "dev": true,
             "dependencies": {
                 "applicationinsights": "^1.7.3",
                 "commander": "^6.2.0",
-                "office-addin-cli": "^1.3.1",
+                "office-addin-cli": "^1.3.2",
                 "readline-sync": "^1.4.9"
             },
             "bin": {
@@ -3890,12 +3883,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-            "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+            "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.6",
+                "@babel/types": "^7.16.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -3909,41 +3902,41 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-            "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+            "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.15.4",
-                "@babel/template": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/helper-get-function-arity": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-            "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+            "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-            "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+            "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-            "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+            "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -3953,12 +3946,12 @@
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+            "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -4016,57 +4009,57 @@
             }
         },
         "@babel/parser": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-            "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+            "version": "7.16.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+            "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
             "dev": true
         },
         "@babel/template": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-            "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+            "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/code-frame": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.15.8",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-                    "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+                    "version": "7.16.0",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+                    "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.14.5"
+                        "@babel/highlight": "^7.16.0"
                     }
                 }
             }
         },
         "@babel/traverse": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-            "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+            "version": "7.16.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+            "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/generator": "^7.15.4",
-                "@babel/helper-function-name": "^7.15.4",
-                "@babel/helper-hoist-variables": "^7.15.4",
-                "@babel/helper-split-export-declaration": "^7.15.4",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-function-name": "^7.16.0",
+                "@babel/helper-hoist-variables": "^7.16.0",
+                "@babel/helper-split-export-declaration": "^7.16.0",
+                "@babel/parser": "^7.16.3",
+                "@babel/types": "^7.16.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.15.8",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-                    "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+                    "version": "7.16.0",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+                    "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.14.5"
+                        "@babel/highlight": "^7.16.0"
                     }
                 },
                 "globals": {
@@ -4078,12 +4071,12 @@
             }
         },
         "@babel/types": {
-            "version": "7.15.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-            "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+            "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.14.9",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -4221,12 +4214,6 @@
             "version": "0.5.31",
             "resolved": "https://registry.npmjs.org/@types/es6-collections/-/es6-collections-0.5.31.tgz",
             "integrity": "sha512-djEvbdTH5Uw7V0WqdMQLG4NK3+iu/FMZy/ylyhWEFnW5xOsXEWpivo/dhP+cR43Az+ipytza7dTSnpsWCxKYAw==",
-            "dev": true
-        },
-        "@types/es6-promise": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-            "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
             "dev": true
         },
         "@types/express": {
@@ -5015,9 +5002,9 @@
             "requires": {}
         },
         "eslint-plugin-office-addins": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-            "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+            "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
             "dev": true,
             "requires": {
                 "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5028,7 +5015,7 @@
                 "eslint-plugin-prettier": "^4.0.0",
                 "eslint-plugin-react": "^7.25.1",
                 "eslint-plugin-react-native": "^3.11.0",
-                "office-addin-prettier-config": "^1.1.0",
+                "office-addin-prettier-config": "^1.1.1",
                 "prettier": "^2.4.0",
                 "requireindex": "~1.2.0",
                 "typescript": "^4.4.2"
@@ -5055,25 +5042,25 @@
             }
         },
         "eslint-plugin-react": {
-            "version": "7.26.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-            "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+            "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.1.3",
-                "array.prototype.flatmap": "^1.2.4",
+                "array-includes": "^3.1.4",
+                "array.prototype.flatmap": "^1.2.5",
                 "doctrine": "^2.1.0",
-                "estraverse": "^5.2.0",
+                "estraverse": "^5.3.0",
                 "jsx-ast-utils": "^2.4.1 || ^3.0.0",
                 "minimatch": "^3.0.4",
-                "object.entries": "^1.1.4",
-                "object.fromentries": "^2.0.4",
-                "object.hasown": "^1.0.0",
-                "object.values": "^1.1.4",
+                "object.entries": "^1.1.5",
+                "object.fromentries": "^2.0.5",
+                "object.hasown": "^1.1.0",
+                "object.values": "^1.1.5",
                 "prop-types": "^15.7.2",
                 "resolve": "^2.0.0-next.3",
                 "semver": "^6.3.0",
-                "string.prototype.matchall": "^4.0.5"
+                "string.prototype.matchall": "^4.0.6"
             },
             "dependencies": {
                 "doctrine": {
@@ -5440,9 +5427,9 @@
             "dev": true
         },
         "ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+            "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
             "dev": true
         },
         "import-fresh": {
@@ -5966,9 +5953,9 @@
             }
         },
         "office-addin-cli": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-            "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+            "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
             "dev": true,
             "requires": {
                 "commander": "^6.2.1",
@@ -5977,9 +5964,9 @@
             }
         },
         "office-addin-lint": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-            "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+            "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
             "dev": true,
             "requires": {
                 "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -5987,29 +5974,29 @@
                 "commander": "^6.2.0",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.1.0",
-                "eslint-plugin-office-addins": "^1.1.1",
+                "eslint-plugin-office-addins": "^1.1.2",
                 "eslint-plugin-prettier": "^3.3.1",
-                "office-addin-cli": "^1.3.1",
-                "office-addin-prettier-config": "^1.1.0",
-                "office-addin-usage-data": "^1.4.1",
+                "office-addin-cli": "^1.3.2",
+                "office-addin-prettier-config": "^1.1.1",
+                "office-addin-usage-data": "^1.4.3",
                 "prettier": "^2.2.1"
             }
         },
         "office-addin-prettier-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-            "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+            "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
             "dev": true
         },
         "office-addin-usage-data": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-            "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+            "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
             "dev": true,
             "requires": {
                 "applicationinsights": "^1.7.3",
                 "commander": "^6.2.0",
-                "office-addin-cli": "^1.3.1",
+                "office-addin-cli": "^1.3.2",
                 "readline-sync": "^1.4.9"
             }
         },

--- a/packages/office-addin-test-helpers/package.json
+++ b/packages/office-addin-test-helpers/package.json
@@ -23,8 +23,7 @@
     },
     "devDependencies": {
         "@types/es6-collections": "^0.5.31",
-        "@types/es6-promise": "0.0.32",
-        "@types/express": "^4.17.3",
+            "@types/express": "^4.17.3",
         "@types/isomorphic-fetch": "^0.0.35",
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",

--- a/packages/office-addin-test-helpers/package.json
+++ b/packages/office-addin-test-helpers/package.json
@@ -23,7 +23,7 @@
     },
     "devDependencies": {
         "@types/es6-collections": "^0.5.31",
-            "@types/express": "^4.17.3",
+        "@types/express": "^4.17.3",
         "@types/isomorphic-fetch": "^0.0.35",
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",

--- a/packages/office-addin-test-helpers/package.json
+++ b/packages/office-addin-test-helpers/package.json
@@ -18,7 +18,7 @@
         "Office Add-in"
     ],
     "dependencies": {
-            "isomorphic-fetch": "^3.0.0"
+        "isomorphic-fetch": "^3.0.0"
     },
     "devDependencies": {
         "@types/es6-collections": "^0.5.31",

--- a/packages/office-addin-test-helpers/package.json
+++ b/packages/office-addin-test-helpers/package.json
@@ -18,8 +18,7 @@
         "Office Add-in"
     ],
     "dependencies": {
-        "es6-promise": "^4.2.8",
-        "isomorphic-fetch": "^3.0.0"
+            "isomorphic-fetch": "^3.0.0"
     },
     "devDependencies": {
         "@types/es6-collections": "^0.5.31",

--- a/packages/office-addin-test-helpers/tsconfig.json
+++ b/packages/office-addin-test-helpers/tsconfig.json
@@ -12,7 +12,6 @@
         "noImplicitUseStrict": true,
         "types": [
             "node",
-            "es6-promise",
         ]
     },
     "include": [

--- a/packages/office-addin-test-server/package-lock.json
+++ b/packages/office-addin-test-server/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "commander": "^6.2.0",
                 "cors": "^2.8.5",
-                "es6-promise": "^4.2.8",
                 "express": "^4.17.1",
                 "office-addin-cli": "^1.3.2",
                 "office-addin-dev-certs": "^1.7.3"
@@ -1542,11 +1541,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -5820,11 +5814,6 @@
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
             }
-        },
-        "es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "escalade": {
             "version": "3.1.1",

--- a/packages/office-addin-test-server/package-lock.json
+++ b/packages/office-addin-test-server/package-lock.json
@@ -6,15 +6,15 @@
     "packages": {
         "": {
             "name": "office-addin-test-server",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "license": "MIT",
             "dependencies": {
                 "commander": "^6.2.0",
                 "cors": "^2.8.5",
                 "es6-promise": "^4.2.8",
                 "express": "^4.17.1",
-                "office-addin-cli": "^1.3.1",
-                "office-addin-dev-certs": "^1.7.1"
+                "office-addin-cli": "^1.3.2",
+                "office-addin-dev-certs": "^1.7.3"
             },
             "bin": {
                 "office-addin-test-server": "cli.js"
@@ -22,13 +22,12 @@
             "devDependencies": {
                 "@types/cors": "^2.8.6",
                 "@types/es6-collections": "^0.5.31",
-                "@types/es6-promise": "0.0.32",
                 "@types/express": "^4.17.3",
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^14.17.2",
                 "concurrently": "^6.3.0",
                 "mocha": "^9.1.1",
-                "office-addin-lint": "^1.4.1",
+                "office-addin-lint": "^1.4.3",
                 "rimraf": "^3.0.2",
                 "ts-node": "^10.1.0",
                 "typescript": "^4.3.5"
@@ -44,12 +43,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-            "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+            "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.15.6",
+                "@babel/types": "^7.16.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -67,50 +66,50 @@
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-            "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+            "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-get-function-arity": "^7.15.4",
-                "@babel/template": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/helper-get-function-arity": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-get-function-arity": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-            "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+            "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-            "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+            "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-            "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+            "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -126,12 +125,12 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+            "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -211,9 +210,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-            "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+            "version": "7.16.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+            "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -223,44 +222,44 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-            "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+            "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/code-frame": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template/node_modules/@babel/code-frame": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-            "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+            "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.14.5"
+                "@babel/highlight": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-            "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+            "version": "7.16.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+            "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/generator": "^7.15.4",
-                "@babel/helper-function-name": "^7.15.4",
-                "@babel/helper-hoist-variables": "^7.15.4",
-                "@babel/helper-split-export-declaration": "^7.15.4",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-function-name": "^7.16.0",
+                "@babel/helper-hoist-variables": "^7.16.0",
+                "@babel/helper-split-export-declaration": "^7.16.0",
+                "@babel/parser": "^7.16.3",
+                "@babel/types": "^7.16.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -269,12 +268,12 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-            "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+            "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.14.5"
+                "@babel/highlight": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -313,12 +312,12 @@
             "dev": true
         },
         "node_modules/@babel/types": {
-            "version": "7.15.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-            "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+            "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.14.9",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -533,12 +532,6 @@
             "version": "0.5.31",
             "resolved": "https://registry.npmjs.org/@types/es6-collections/-/es6-collections-0.5.31.tgz",
             "integrity": "sha512-djEvbdTH5Uw7V0WqdMQLG4NK3+iu/FMZy/ylyhWEFnW5xOsXEWpivo/dhP+cR43Az+ipytza7dTSnpsWCxKYAw==",
-            "dev": true
-        },
-        "node_modules/@types/es6-promise": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-            "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
             "dev": true
         },
         "node_modules/@types/express": {
@@ -1651,9 +1644,9 @@
             }
         },
         "node_modules/eslint-plugin-office-addins": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-            "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+            "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
             "dev": true,
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1664,7 +1657,7 @@
                 "eslint-plugin-prettier": "^4.0.0",
                 "eslint-plugin-react": "^7.25.1",
                 "eslint-plugin-react-native": "^3.11.0",
-                "office-addin-prettier-config": "^1.1.0",
+                "office-addin-prettier-config": "^1.1.1",
                 "prettier": "^2.4.0",
                 "requireindex": "~1.2.0",
                 "typescript": "^4.4.2"
@@ -1716,31 +1709,31 @@
             }
         },
         "node_modules/eslint-plugin-react": {
-            "version": "7.26.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-            "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+            "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
             "dev": true,
             "dependencies": {
-                "array-includes": "^3.1.3",
-                "array.prototype.flatmap": "^1.2.4",
+                "array-includes": "^3.1.4",
+                "array.prototype.flatmap": "^1.2.5",
                 "doctrine": "^2.1.0",
-                "estraverse": "^5.2.0",
+                "estraverse": "^5.3.0",
                 "jsx-ast-utils": "^2.4.1 || ^3.0.0",
                 "minimatch": "^3.0.4",
-                "object.entries": "^1.1.4",
-                "object.fromentries": "^2.0.4",
-                "object.hasown": "^1.0.0",
-                "object.values": "^1.1.4",
+                "object.entries": "^1.1.5",
+                "object.fromentries": "^2.0.5",
+                "object.hasown": "^1.1.0",
+                "object.values": "^1.1.5",
                 "prop-types": "^15.7.2",
                 "resolve": "^2.0.0-next.3",
                 "semver": "^6.3.0",
-                "string.prototype.matchall": "^4.0.5"
+                "string.prototype.matchall": "^4.0.6"
             },
             "engines": {
                 "node": ">=4"
             },
             "peerDependencies": {
-                "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
             }
         },
         "node_modules/eslint-plugin-react-native": {
@@ -2425,9 +2418,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+            "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -3417,9 +3410,9 @@
             }
         },
         "node_modules/office-addin-cli": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-            "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+            "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
             "dependencies": {
                 "commander": "^6.2.1",
                 "node-fetch": "^2.6.1",
@@ -3438,25 +3431,25 @@
             }
         },
         "node_modules/office-addin-dev-certs": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.1.tgz",
-            "integrity": "sha512-geCkk7S1SWCHwEil6+90HGj8xJc4hPRPlE5Z/Q6wIX6lAMRAEZOhZqC2fMayR7wvfhTA01eNyNT8jSVOhyH37g==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.3.tgz",
+            "integrity": "sha512-EGEHXWMOFNyT/kTth46tlJ1+0+yTy0CPFtrHV2qxCEECbrYetXwRVl4Iax+O9F4Xmr67eIOnh8/L1EBIwdySXQ==",
             "dependencies": {
                 "child_process": "^1.0.2",
                 "commander": "^6.2.0",
                 "fs-extra": "^7.0.1",
                 "mkcert": "^1.4.0",
-                "office-addin-cli": "^1.3.1",
-                "office-addin-usage-data": "^1.4.1"
+                "office-addin-cli": "^1.3.2",
+                "office-addin-usage-data": "^1.4.3"
             },
             "bin": {
                 "office-addin-dev-certs": "cli.js"
             }
         },
         "node_modules/office-addin-lint": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-            "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+            "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
             "dev": true,
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -3464,11 +3457,11 @@
                 "commander": "^6.2.0",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.1.0",
-                "eslint-plugin-office-addins": "^1.1.1",
+                "eslint-plugin-office-addins": "^1.1.2",
                 "eslint-plugin-prettier": "^3.3.1",
-                "office-addin-cli": "^1.3.1",
-                "office-addin-prettier-config": "^1.1.0",
-                "office-addin-usage-data": "^1.4.1",
+                "office-addin-cli": "^1.3.2",
+                "office-addin-prettier-config": "^1.1.1",
+                "office-addin-usage-data": "^1.4.3",
                 "prettier": "^2.2.1"
             },
             "bin": {
@@ -3476,19 +3469,19 @@
             }
         },
         "node_modules/office-addin-prettier-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-            "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+            "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
             "dev": true
         },
         "node_modules/office-addin-usage-data": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-            "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+            "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
             "dependencies": {
                 "applicationinsights": "^1.7.3",
                 "commander": "^6.2.0",
-                "office-addin-cli": "^1.3.1",
+                "office-addin-cli": "^1.3.2",
                 "readline-sync": "^1.4.9"
             },
             "bin": {
@@ -4678,12 +4671,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-            "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+            "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.6",
+                "@babel/types": "^7.16.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -4697,41 +4690,41 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-            "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+            "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.15.4",
-                "@babel/template": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/helper-get-function-arity": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-            "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+            "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-            "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+            "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-            "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+            "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -4741,12 +4734,12 @@
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+            "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -4810,57 +4803,57 @@
             }
         },
         "@babel/parser": {
-            "version": "7.15.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-            "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+            "version": "7.16.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+            "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
             "dev": true
         },
         "@babel/template": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-            "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+            "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/code-frame": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.15.8",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-                    "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+                    "version": "7.16.0",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+                    "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.14.5"
+                        "@babel/highlight": "^7.16.0"
                     }
                 }
             }
         },
         "@babel/traverse": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-            "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+            "version": "7.16.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+            "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/generator": "^7.15.4",
-                "@babel/helper-function-name": "^7.15.4",
-                "@babel/helper-hoist-variables": "^7.15.4",
-                "@babel/helper-split-export-declaration": "^7.15.4",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-function-name": "^7.16.0",
+                "@babel/helper-hoist-variables": "^7.16.0",
+                "@babel/helper-split-export-declaration": "^7.16.0",
+                "@babel/parser": "^7.16.3",
+                "@babel/types": "^7.16.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.15.8",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-                    "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+                    "version": "7.16.0",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+                    "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.14.5"
+                        "@babel/highlight": "^7.16.0"
                     }
                 },
                 "debug": {
@@ -4887,12 +4880,12 @@
             }
         },
         "@babel/types": {
-            "version": "7.15.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-            "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+            "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.14.9",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -5071,12 +5064,6 @@
             "version": "0.5.31",
             "resolved": "https://registry.npmjs.org/@types/es6-collections/-/es6-collections-0.5.31.tgz",
             "integrity": "sha512-djEvbdTH5Uw7V0WqdMQLG4NK3+iu/FMZy/ylyhWEFnW5xOsXEWpivo/dhP+cR43Az+ipytza7dTSnpsWCxKYAw==",
-            "dev": true
-        },
-        "@types/es6-promise": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-            "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
             "dev": true
         },
         "@types/express": {
@@ -5971,9 +5958,9 @@
             "requires": {}
         },
         "eslint-plugin-office-addins": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-            "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+            "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
             "dev": true,
             "requires": {
                 "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5984,7 +5971,7 @@
                 "eslint-plugin-prettier": "^4.0.0",
                 "eslint-plugin-react": "^7.25.1",
                 "eslint-plugin-react-native": "^3.11.0",
-                "office-addin-prettier-config": "^1.1.0",
+                "office-addin-prettier-config": "^1.1.1",
                 "prettier": "^2.4.0",
                 "requireindex": "~1.2.0",
                 "typescript": "^4.4.2"
@@ -6011,25 +5998,25 @@
             }
         },
         "eslint-plugin-react": {
-            "version": "7.26.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-            "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+            "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.1.3",
-                "array.prototype.flatmap": "^1.2.4",
+                "array-includes": "^3.1.4",
+                "array.prototype.flatmap": "^1.2.5",
                 "doctrine": "^2.1.0",
-                "estraverse": "^5.2.0",
+                "estraverse": "^5.3.0",
                 "jsx-ast-utils": "^2.4.1 || ^3.0.0",
                 "minimatch": "^3.0.4",
-                "object.entries": "^1.1.4",
-                "object.fromentries": "^2.0.4",
-                "object.hasown": "^1.0.0",
-                "object.values": "^1.1.4",
+                "object.entries": "^1.1.5",
+                "object.fromentries": "^2.0.5",
+                "object.hasown": "^1.1.0",
+                "object.values": "^1.1.5",
                 "prop-types": "^15.7.2",
                 "resolve": "^2.0.0-next.3",
                 "semver": "^6.3.0",
-                "string.prototype.matchall": "^4.0.5"
+                "string.prototype.matchall": "^4.0.6"
             },
             "dependencies": {
                 "doctrine": {
@@ -6487,9 +6474,9 @@
             }
         },
         "ignore": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+            "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
             "dev": true
         },
         "import-fresh": {
@@ -7191,9 +7178,9 @@
             }
         },
         "office-addin-cli": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-            "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+            "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
             "requires": {
                 "commander": "^6.2.1",
                 "node-fetch": "^2.6.1",
@@ -7208,22 +7195,22 @@
             }
         },
         "office-addin-dev-certs": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.1.tgz",
-            "integrity": "sha512-geCkk7S1SWCHwEil6+90HGj8xJc4hPRPlE5Z/Q6wIX6lAMRAEZOhZqC2fMayR7wvfhTA01eNyNT8jSVOhyH37g==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.7.3.tgz",
+            "integrity": "sha512-EGEHXWMOFNyT/kTth46tlJ1+0+yTy0CPFtrHV2qxCEECbrYetXwRVl4Iax+O9F4Xmr67eIOnh8/L1EBIwdySXQ==",
             "requires": {
                 "child_process": "^1.0.2",
                 "commander": "^6.2.0",
                 "fs-extra": "^7.0.1",
                 "mkcert": "^1.4.0",
-                "office-addin-cli": "^1.3.1",
-                "office-addin-usage-data": "^1.4.1"
+                "office-addin-cli": "^1.3.2",
+                "office-addin-usage-data": "^1.4.3"
             }
         },
         "office-addin-lint": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.1.tgz",
-            "integrity": "sha512-0CllDcqCJuRQdYIxyNaKbIcyiQq1Ncq+OnxUfQZgUdJHvvexmsAv4xTj6SDiFb5RSKV8OA00ay8jENG/CQjg+w==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-1.4.3.tgz",
+            "integrity": "sha512-AL0sGx8q5ny0i1h07xE71hpIGdcSU55+E2U2UcbjTEEYxICZqa8lbY/quaav/Ox6CfNdjkEnSThB1nIdLk65tg==",
             "dev": true,
             "requires": {
                 "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -7231,28 +7218,28 @@
                 "commander": "^6.2.0",
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^8.1.0",
-                "eslint-plugin-office-addins": "^1.1.1",
+                "eslint-plugin-office-addins": "^1.1.2",
                 "eslint-plugin-prettier": "^3.3.1",
-                "office-addin-cli": "^1.3.1",
-                "office-addin-prettier-config": "^1.1.0",
-                "office-addin-usage-data": "^1.4.1",
+                "office-addin-cli": "^1.3.2",
+                "office-addin-prettier-config": "^1.1.1",
+                "office-addin-usage-data": "^1.4.3",
                 "prettier": "^2.2.1"
             }
         },
         "office-addin-prettier-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-            "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+            "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
             "dev": true
         },
         "office-addin-usage-data": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.1.tgz",
-            "integrity": "sha512-IalrLZisa+PBj/SUn/UKwxkKEcYNcXRJGC4Csjwba+HC11E+C9NW7OjKNVxhIprZl9l8dIGv623rdaBB229ctQ==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.3.tgz",
+            "integrity": "sha512-LLeXZdG23ulXBkI/2bKhMqDiRvl+mDw0AxETsiwUYF7KHOH9QuLUlfuMthyMX0vnXM4xI8b2M8/dLwQbeBZSsA==",
             "requires": {
                 "applicationinsights": "^1.7.3",
                 "commander": "^6.2.0",
-                "office-addin-cli": "^1.3.1",
+                "office-addin-cli": "^1.3.2",
                 "readline-sync": "^1.4.9"
             }
         },

--- a/packages/office-addin-test-server/package.json
+++ b/packages/office-addin-test-server/package.json
@@ -24,14 +24,14 @@
     "dependencies": {
         "commander": "^6.2.0",
         "cors": "^2.8.5",
-            "express": "^4.17.1",
+        "express": "^4.17.1",
         "office-addin-cli": "^1.3.2",
         "office-addin-dev-certs": "^1.7.3"
     },
     "devDependencies": {
         "@types/cors": "^2.8.6",
         "@types/es6-collections": "^0.5.31",
-            "@types/express": "^4.17.3",
+        "@types/express": "^4.17.3",
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",
         "concurrently": "^6.3.0",

--- a/packages/office-addin-test-server/package.json
+++ b/packages/office-addin-test-server/package.json
@@ -24,8 +24,7 @@
     "dependencies": {
         "commander": "^6.2.0",
         "cors": "^2.8.5",
-        "es6-promise": "^4.2.8",
-        "express": "^4.17.1",
+            "express": "^4.17.1",
         "office-addin-cli": "^1.3.2",
         "office-addin-dev-certs": "^1.7.3"
     },

--- a/packages/office-addin-test-server/package.json
+++ b/packages/office-addin-test-server/package.json
@@ -32,8 +32,7 @@
     "devDependencies": {
         "@types/cors": "^2.8.6",
         "@types/es6-collections": "^0.5.31",
-        "@types/es6-promise": "0.0.32",
-        "@types/express": "^4.17.3",
+            "@types/express": "^4.17.3",
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",
         "concurrently": "^6.3.0",

--- a/packages/office-addin-test-server/tsconfig.json
+++ b/packages/office-addin-test-server/tsconfig.json
@@ -12,7 +12,6 @@
         "noImplicitUseStrict": true,
         "types": [
             "node",
-            "es6-promise",
             "express"
         ]
     },

--- a/packages/office-addin-usage-data/package-lock.json
+++ b/packages/office-addin-usage-data/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^14.17.2",
         "@typescript-eslint/eslint-plugin": "^4.26.0",
         "concurrently": "^6.0.2",
+        "es6-promise": "^4.2.8",
         "eslint": "7.32.0",
         "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.4.0",
@@ -1397,6 +1398,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5305,6 +5312,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-usage-data/package-lock.json
+++ b/packages/office-addin-usage-data/package-lock.json
@@ -6,29 +6,27 @@
   "packages": {
     "": {
       "name": "office-addin-usage-data",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
-        "office-addin-cli": "^1.3.1",
+        "office-addin-cli": "^1.3.2",
         "readline-sync": "^1.4.9"
       },
       "bin": {
         "office-addin-usage-data": "cli.js"
       },
       "devDependencies": {
-        "@types/applicationinsights": "^0.20.0",
-        "@types/es6-promise": "3.3.0",
         "@types/mocha": "^5.2.7",
         "@types/node": "^14.17.2",
         "@typescript-eslint/eslint-plugin": "^4.26.0",
         "concurrently": "^6.0.2",
         "eslint": "7.32.0",
-        "eslint-plugin-office-addins": "^1.1.1",
+        "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.4.0",
         "mocha": "^9.1.1",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "rimraf": "^3.0.2",
         "ts-node": "^10.1.0",
         "typescript": "^4.3.5"
@@ -387,26 +385,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
-    },
-    "node_modules/@types/applicationinsights": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@types/applicationinsights/-/applicationinsights-0.20.0.tgz",
-      "integrity": "sha512-dQ3Hb58ERe5YNKFVyvU9BrEvpgKeb6Ht9HkCyBvsOZxhx6yKSwF3e+xml3PJQ3JiVOvf6gM/PmE3MdWDl1L6aA==",
-      "deprecated": "This is a stub types definition for applicationinsights (https://github.com/Microsoft/ApplicationInsights-node.js). applicationinsights provides its own type definitions, so you don't need @types/applicationinsights installed!",
-      "dev": true,
-      "dependencies": {
-        "applicationinsights": "*"
-      }
-    },
-    "node_modules/@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "deprecated": "This is a stub types definition for es6-promise (https://github.com/jakearchibald/ES6-Promise). es6-promise provides its own type definitions, so you don't need @types/es6-promise installed!",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -1420,12 +1398,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1514,9 +1486,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1527,7 +1499,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -3134,9 +3106,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -3155,9 +3127,9 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "node_modules/once": {
@@ -4603,24 +4575,6 @@
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
     },
-    "@types/applicationinsights": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@types/applicationinsights/-/applicationinsights-0.20.0.tgz",
-      "integrity": "sha512-dQ3Hb58ERe5YNKFVyvU9BrEvpgKeb6Ht9HkCyBvsOZxhx6yKSwF3e+xml3PJQ3JiVOvf6gM/PmE3MdWDl1L6aA==",
-      "dev": true,
-      "requires": {
-        "applicationinsights": "*"
-      }
-    },
-    "@types/es6-promise": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-3.3.0.tgz",
-      "integrity": "sha512-ixCIAEkLUKv9movnHKCzx2rzAJgEnSALDXPrOSSwOjWwXFs0ssSZKan+O2e3FExPPCbX+DfA9NcKsbvLuyUlNA==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -5352,12 +5306,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -5507,9 +5455,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.1.tgz",
-      "integrity": "sha512-9C4JpKpCdAw/y/cmMAToQR0Yn741e8wL4A0Hc34i/YX2Hd+djVUDTUGm8ACAdsMmouowxbUJX/m3uRJ7vSZhtQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-1.1.2.tgz",
+      "integrity": "sha512-1aEN/9kaPao+Dbn93EtKFcXnU5yDnW/ZFYBb4iOwCdXPpLmLvFTEx5S3xKAAF0uEQtyS3cl8T1iE+XFd15GEAw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5520,7 +5468,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.0",
+        "office-addin-prettier-config": "^1.1.1",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -6605,9 +6553,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.1.tgz",
-      "integrity": "sha512-EoR3syk1wfyGfIRSbTVZNDx9do9RyWKDf54WUqun+ipKTB2yH9UCXquzXxSHz08A1PyjdXmL9CHwU40inhKVMg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.3.2.tgz",
+      "integrity": "sha512-UbteR6WEgUCRo83PPIHd8hWZ4pFNNjfhBJBGdJwSNYN+6Hu+QQvndY5asfCs91HVhpCNsIkgStjYGzHh7GhU5w==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -6622,9 +6570,9 @@
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.0.tgz",
-      "integrity": "sha512-tCv+FoL+oj5WpXcoKuqgqDIcdvHpEklRvksHD3zxT2eVKrDzgWd8BXsqrPkNIH85zsuPgpje3brobbOvbNqa6A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.1.tgz",
+      "integrity": "sha512-6WopN++t6nC3QU2AqbGOVuWWTR0fratf5DQRG6DOHtuSVGC95GNWE5vuoz3EGlwnd9GpQJvsA9gkUICqVFXSmQ==",
       "dev": true
     },
     "once": {

--- a/packages/office-addin-usage-data/package-lock.json
+++ b/packages/office-addin-usage-data/package-lock.json
@@ -22,7 +22,6 @@
         "@types/node": "^14.17.2",
         "@typescript-eslint/eslint-plugin": "^4.26.0",
         "concurrently": "^6.0.2",
-        "es6-promise": "^4.2.8",
         "eslint": "7.32.0",
         "eslint-plugin-office-addins": "^1.1.2",
         "eslint-plugin-prettier": "^3.4.0",
@@ -1398,12 +1397,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5312,12 +5305,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/packages/office-addin-usage-data/package.json
+++ b/packages/office-addin-usage-data/package.json
@@ -27,8 +27,6 @@
     "readline-sync": "^1.4.9"
   },
   "devDependencies": {
-    "@types/applicationinsights": "^0.20.0",
-    "@types/es6-promise": "3.3.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^14.17.2",
     "@typescript-eslint/eslint-plugin": "^4.26.0",

--- a/packages/office-addin-usage-data/package.json
+++ b/packages/office-addin-usage-data/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^14.17.2",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "concurrently": "^6.0.2",
+    "es6-promise": "^4.2.8",
     "eslint": "7.32.0",
     "eslint-plugin-office-addins": "^1.1.2",
     "eslint-plugin-prettier": "^3.4.0",

--- a/packages/office-addin-usage-data/package.json
+++ b/packages/office-addin-usage-data/package.json
@@ -31,7 +31,6 @@
     "@types/node": "^14.17.2",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "concurrently": "^6.0.2",
-    "es6-promise": "^4.2.8",
     "eslint": "7.32.0",
     "eslint-plugin-office-addins": "^1.1.2",
     "eslint-plugin-prettier": "^3.4.0",

--- a/packages/office-addin-usage-data/tsconfig.json
+++ b/packages/office-addin-usage-data/tsconfig.json
@@ -11,8 +11,7 @@
         "alwaysStrict": false,
         "noImplicitUseStrict": true,
         "types": [
-            "node",
-            "es6-promise"
+            "node"
         ]
         
     },


### PR DESCRIPTION
'npm install' was reporting that some @types packages were deprecated and un needed.  In order to compile a replacement packages was needed in most cases.