### PR TITLE
Sideload desktop existing file

### DIFF
--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -88,7 +88,16 @@ export async function generateSideloadFile(app: OfficeApp, manifest: ManifestInf
     zip.file(webExtensionPath, webExtensionXml);
   }
 
-  return await writeZipFile(zip, pathToWrite);
+  // Write the file
+  await new Promise((resolve, reject) => {
+    zip
+      .generateNodeStream({ type: "nodebuffer", streamFiles: true })
+      .pipe(fs.createWriteStream(pathToWrite))
+      .on("error", reject)
+      .on("finish", resolve);
+  });
+
+  return pathToWrite;
 }
 
 /**
@@ -376,17 +385,4 @@ export async function sideloadAddIn(
     usageDataObject.reportException("sideloadAddIn()", err);
     throw err;
   }
-}
-
-async function writeZipFile(zip: jszip, pathToWrite: string): Promise<string> {
-  // Write the file
-  await new Promise((resolve, reject) => {
-    zip
-      .generateNodeStream({ type: "nodebuffer", streamFiles: true })
-      .pipe(fs.createWriteStream(pathToWrite))
-      .on("error", reject)
-      .on("finish", resolve);
-  });
-
-  return pathToWrite;
 }

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -66,7 +66,10 @@ export async function generateSideloadFile(app: OfficeApp, manifest: ManifestInf
 
   const appName = getOfficeAppName(app);
   const extension = path.extname(templatePath);
-  const pathToWrite: string = makePathUnique(path.join(os.tmpdir(), `${appName} add-in ${manifest.id}${extension}`), true);
+  const pathToWrite: string = makePathUnique(
+    path.join(os.tmpdir(), `${appName} add-in ${manifest.id}${extension}`),
+    true
+  );
 
   if (documentWasProvided) {
     return await writeZipFile(zip, pathToWrite);
@@ -378,14 +381,14 @@ export async function sideloadAddIn(
 }
 
 async function writeZipFile(zip: jszip, pathToWrite: string): Promise<string> {
-    // Write the file
-    await new Promise((resolve, reject) => {
-      zip
-        .generateNodeStream({ type: "nodebuffer", streamFiles: true })
-        .pipe(fs.createWriteStream(pathToWrite))
-        .on("error", reject)
-        .on("finish", resolve);
-    });
+  // Write the file
+  await new Promise((resolve, reject) => {
+    zip
+      .generateNodeStream({ type: "nodebuffer", streamFiles: true })
+      .pipe(fs.createWriteStream(pathToWrite))
+      .on("error", reject)
+      .on("finish", resolve);
+  });
 
-    return pathToWrite;
+  return pathToWrite;
 }

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -71,24 +71,22 @@ export async function generateSideloadFile(app: OfficeApp, manifest: ManifestInf
     true
   );
 
-  if (documentWasProvided) {
-    return await writeZipFile(zip, pathToWrite);
-  }
+  if (!documentWasProvided) {
+    const webExtensionPath = getWebExtensionPath(app, addInType);
+    if (!webExtensionPath) {
+      throw new ExpectedError("Don't know the webextension path.");
+    }
 
-  const webExtensionPath = getWebExtensionPath(app, addInType);
-  if (!webExtensionPath) {
-    throw new ExpectedError("Don't know the webextension path.");
+    // replace the placeholder id and version
+    const zipFile = zip.file(webExtensionPath);
+    if (!zipFile) {
+      throw new ExpectedError("webextension was not found.");
+    }
+    const webExtensionXml = (await zipFile.async("text"))
+      .replace(/00000000-0000-0000-0000-000000000000/g, manifest.id)
+      .replace(/1.0.0.0/g, manifest.version);
+    zip.file(webExtensionPath, webExtensionXml);
   }
-
-  // replace the placeholder id and version
-  const zipFile = zip.file(webExtensionPath);
-  if (!zipFile) {
-    throw new ExpectedError("webextension was not found.");
-  }
-  const webExtensionXml = (await zipFile.async("text"))
-    .replace(/00000000-0000-0000-0000-000000000000/g, manifest.id)
-    .replace(/1.0.0.0/g, manifest.version);
-  zip.file(webExtensionPath, webExtensionXml);
 
   return await writeZipFile(zip, pathToWrite);
 }


### PR DESCRIPTION
Making code accepts existing documents for sideloading on desktop.
Fixes in part: https://github.com/OfficeDev/Office-Addin-Scripts/issues/500 and https://github.com/OfficeDev/Office-Addin-Scripts/pull/564

This will make the CLI for `office-addin-debugging` work for documents created using our tooling and referenced later.
This won't fix the problem of making the tool work with any document, because editing them would cause the client to detect a corruption issue.