### PR TITLE
Force .sh to use LF instead of CRLF

### DIFF
--- a/packages/office-addin-dev-certs/.gitattributes
+++ b/packages/office-addin-dev-certs/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf


### PR DESCRIPTION
Somehow the package coming from npm has the .sh script files with CRLF endings which breaks the scripts.  This should force those files to use LF as their endings.