### PR TITLE
Update validation url

### DIFF
--- a/packages/office-addin-manifest/.vscode/launch.json
+++ b/packages/office-addin-manifest/.vscode/launch.json
@@ -35,7 +35,7 @@
       "program": "${workspaceFolder}/lib/cli.js",
       "args": [
         "validate",
-        "${workspaceFolder}/../../../office-addin-validator/manifest-to-test/valid_excel.xml"
+        "${workspaceFolder}\\test\\manifests\\TaskPane.manifest.xml"
       ]
     },
     {

--- a/packages/office-addin-manifest/src/cli.ts
+++ b/packages/office-addin-manifest/src/cli.ts
@@ -20,7 +20,10 @@ commander
   .option("-d, --displayName <name>", "Change the display name.")
   .action(commands.modify);
 
-commander.command("validate <manifest-path>").action(commands.validate);
+commander
+  .command("validate <manifest-path>")
+  .option("-p, --production", "Verify the manifest for production environment")
+  .action(commands.validate);
 
 commander
   .command("export")

--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -143,7 +143,8 @@ export async function validate(
   command: commander.Command /* eslint-disable-line no-unused-vars */
 ) {
   try {
-    const validation: ManifestValidation = await validateManifest(manifestPath);
+    const verifyProduction: boolean = command.production;
+    const validation: ManifestValidation = await validateManifest(manifestPath, verifyProduction);
 
     if (validation.isValid) {
       console.log("The manifest is valid.");

--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -60,8 +60,9 @@ function logManifestValidationErrors(errors: ManifestValidationIssue[] | undefin
   if (errors) {
     let errorNumber = 1;
     for (const currentError of errors) {
-      console.log(chalk.bold.red(`\nError # ${errorNumber}: `));
+      console.log(chalk.bold.red(`Error #${errorNumber}: `));
       logManifestValidationIssue(currentError);
+      console.log();
       ++errorNumber;
     }
   }
@@ -69,7 +70,7 @@ function logManifestValidationErrors(errors: ManifestValidationIssue[] | undefin
 
 function logManifestValidationInfos(infos: ManifestValidationIssue[] | undefined) {
   if (infos) {
-    console.log(chalk.bold.blue(`\nAdditional information: `));
+    console.log(chalk.bold.blue(`Validation Information: `));
     for (const currentInfo of infos) {
       logManifestValidationIssue(currentInfo);
       console.log();
@@ -81,8 +82,9 @@ function logManifestValidationWarnings(warnings: ManifestValidationIssue[] | und
   if (warnings) {
     let warningNumber = 1;
     for (const currentWarning of warnings) {
-      console.log(chalk.bold.yellow(`\nWarning # ${warningNumber}: `));
+      console.log(chalk.bold.yellow(`Warning #${warningNumber}: `));
       logManifestValidationIssue(currentWarning);
+      console.log();
       ++warningNumber;
     }
   }
@@ -146,22 +148,19 @@ export async function validate(
     const verifyProduction: boolean = command.production;
     const validation: ManifestValidation = await validateManifest(manifestPath, verifyProduction);
 
-    if (validation.isValid) {
-      console.log(chalk.bold.green("The manifest is valid."));
-    } else {
-      console.log(chalk.bold.red("The manifest is not valid."));
-    }
-    console.log();
-
     if (validation.report) {
+      logManifestValidationInfos(validation.report.notes);
       logManifestValidationErrors(validation.report.errors);
       logManifestValidationWarnings(validation.report.warnings);
-      logManifestValidationInfos(validation.report.notes);
 
       if (validation.isValid) {
         if (validation.report.addInDetails) {
           logManifestValidationSupportedProducts(validation.report.addInDetails.supportedProducts);
+          console.log();
         }
+        console.log(chalk.bold.green("The manifest is valid.\n"));
+      } else {
+        console.log(chalk.bold.red("The manifest is not valid.\n"));
       }
     }
 

--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -147,9 +147,9 @@ export async function validate(
     const validation: ManifestValidation = await validateManifest(manifestPath, verifyProduction);
 
     if (validation.isValid) {
-      console.log("The manifest is valid.");
+      console.log(chalk.bold.green("The manifest is valid."));
     } else {
-      console.log("The manifest is not valid.");
+      console.log(chalk.bold.red("The manifest is not valid."));
     }
     console.log();
 

--- a/packages/office-addin-manifest/src/validate.ts
+++ b/packages/office-addin-manifest/src/validate.ts
@@ -61,9 +61,13 @@ export class ManifestValidation {
   }
 }
 
-export async function validateManifest(manifestPath: string): Promise<ManifestValidation> {
+export async function validateManifest(
+  manifestPath: string,
+  verifyProduction: boolean = false
+): Promise<ManifestValidation> {
   try {
     const validation: ManifestValidation = new ManifestValidation();
+    const clientId: string = verifyProduction ? "Default" : "devx";
 
     // read the manifest file to ensure the file path is valid
     await OfficeAddinManifest.readManifestFile(manifestPath);
@@ -72,16 +76,13 @@ export async function validateManifest(manifestPath: string): Promise<ManifestVa
     let response;
 
     try {
-      response = await fetch(
-        "https://validationgateway.omex.office.net/package/api/check?gates=DisableIconDimensionValidation",
-        {
-          body: stream,
-          headers: {
-            "Content-Type": "application/xml",
-          },
-          method: "POST",
-        }
-      );
+      response = await fetch(`https://validationgateway.omex.office.net/package/api/check?clientId=${clientId}`, {
+        body: stream,
+        headers: {
+          "Content-Type": "application/xml",
+        },
+        method: "POST",
+      });
     } catch (err) {
       throw new Error(`Unable to contact the manifest validation service.\n${err}`);
     }

--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -552,6 +552,16 @@ describe("Unit Tests", function() {
         assert.strictEqual(validation.report!.warnings!.length, 0);
         assert.strictEqual(validation.report!.addInDetails!.supportedProducts!.length > 0, true);
       });
+      it("valid manifest prod (fail)", async function() {
+        this.timeout(6000);
+        const validation = await validateManifest("test/manifests/TaskPane.manifest.xml", true);
+        assert.strictEqual(validation.isValid, false);
+        assert.strictEqual(validation.status, 200);
+        assert.strictEqual(validation.report!.errors!.length, 2);
+        assert.strictEqual(validation.report!.notes!.length > 0, true);
+        assert.strictEqual(validation.report!.warnings!.length, 0);
+        assert.strictEqual(validation.report!.addInDetails!.supportedProducts!.length > 0, true);
+      });
       it("invalid manifest path", async function() {
         this.timeout(6000);
         let result: string = "";


### PR DESCRIPTION
The OMEX teams has asked that we change from a gate to a url param for indicating our manifest validation comes from a dev environment.  I have also added a command argument that allows the validation to be done for a production environment.