### PR TITLE
Removing sideffects from maskFilePaths telemetry function

### DIFF
--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -284,10 +284,10 @@ export class OfficeAddinUsageData {
    */
   public maskFilePaths(err: Error): Error {
     try {
-      const regexRemoveUserFilePaths = /[/\\](.*[/\\]+)*(.+\.)+/gim;
+      const regexRemoveUserFilePaths = /(\w:)*[/\\](.*[/\\]+)*(.+\.)+[a-zA-Z]+/gim;
 
-      err.message = err.message.replace(regexRemoveUserFilePaths, "\\.");
-      err.stack = err.stack.replace(regexRemoveUserFilePaths, "\\.");
+      err.message = err.message.replace(regexRemoveUserFilePaths, '""');
+      err.stack = err.stack.replace(regexRemoveUserFilePaths, '""');
 
       return err;
     } catch (err) {

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -352,7 +352,7 @@ export class OfficeAddinUsageData {
   public reportExpectedException(method: string, err: Error | string, data: object = {}) {
     let error = err instanceof Error ? Object.create(err) : new Error(`${this.options.projectName} error: ${err}`);
     error.name = this.getEventName();
-    error = this.maskFilePaths(error);
+    this.maskFilePaths(error);
     const errorMessage = error instanceof Error ? error.message : error;
 
     this.sendUsageDataEvent({

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -282,13 +282,14 @@ export class OfficeAddinUsageData {
    */
   public maskFilePaths(err: Error): Error {
     try {
+      const error: Error = err;
       const regexRemoveUserFilePaths = /[\/\\](.*)[\/\\]/gim; /* eslint-disable-line no-useless-escape */
       const regexRemoveAbsoluteUserFilePathsFromStack = /\w:\\(?:[^\\\s]+\\)+/gim;
       const regexRemoveFirstFilePathFromStack = /\\(.*)\./i;
-      err.message = err.message.replace(regexRemoveUserFilePaths, "\\");
-      err.stack = err.stack.replace(regexRemoveFirstFilePathFromStack, "\\.");
-      err.stack = err.stack.replace(regexRemoveAbsoluteUserFilePathsFromStack, "");
-      return err;
+      error.message = error.message.replace(regexRemoveUserFilePaths, "\\");
+      error.stack = error.stack.replace(regexRemoveFirstFilePathFromStack, "\\.");
+      error.stack = error.stack.replace(regexRemoveAbsoluteUserFilePathsFromStack, "");
+      return error;
     } catch (err) {
       this.reportError("maskFilePaths", err);
       throw new Error(err);

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -184,7 +184,7 @@ export class OfficeAddinUsageData {
     if (this.getUsageDataLevel() === UsageDataLevel.on) {
       let error = Object.create(err);
 
-      err.name = this.options.isForTesting ? `${errorName}-test` : errorName;
+      error.name = this.options.isForTesting ? `${errorName}-test` : errorName;
       this.usageDataClient.trackException({
         exception: this.maskFilePaths(error),
       });

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -285,9 +285,10 @@ export class OfficeAddinUsageData {
   public maskFilePaths(err: Error): Error {
     try {
       const regexRemoveUserFilePaths = /(\w:)*[/\\](.*[/\\]+)*(.+\.)+[a-zA-Z]+/gim;
+      const maskToken: string = "<filepath>";
 
-      err.message = err.message.replace(regexRemoveUserFilePaths, '""');
-      err.stack = err.stack.replace(regexRemoveUserFilePaths, '""');
+      err.message = err.message.replace(regexRemoveUserFilePaths, maskToken);
+      err.stack = err.stack.replace(regexRemoveUserFilePaths, maskToken);
 
       return err;
     } catch (err) {

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -352,7 +352,7 @@ export class OfficeAddinUsageData {
   public reportExpectedException(method: string, err: Error | string, data: object = {}) {
     let error = err instanceof Error ? err : new Error(`${this.options.projectName} error: ${err}`);
     error.name = this.getEventName();
-    this.maskFilePaths(error);
+    error = this.maskFilePaths(error);
     const errorMessage = error instanceof Error ? error.message : error;
 
     this.sendUsageDataEvent({

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -284,10 +284,10 @@ export class OfficeAddinUsageData {
    */
   public maskFilePaths(err: Error): Error {
     try {
-      const regexRemoveUserFilePaths = /\w:[\/\\](?:[^\\\s]+[\/\\])+/gmi;
+      const regexRemoveUserFilePaths = /[/\\](.*[/\\]+)*(.+\.)+/gim;
 
-      err.message = err.message.replace(regexRemoveUserFilePaths, "");
-      err.stack = err.stack.replace(regexRemoveUserFilePaths, "");
+      err.message = err.message.replace(regexRemoveUserFilePaths, "\\.");
+      err.stack = err.stack.replace(regexRemoveUserFilePaths, "\\.");
 
       return err;
     } catch (err) {

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -166,19 +166,21 @@ describe("Test office-addin-usage data-package", function() {
       compareError.message = "this error contains a file path:C:\\index.js";
       // may throw error if change any part of the top of the test file
       compareError.stack = "this error contains a file path:C:\\.js";
-      addInUsageData.maskFilePaths(err);
-      assert.equal(compareError.name, err.name);
-      assert.equal(compareError.message, err.message);
-      assert.equal(err.stack.includes(compareError.stack), true);
+      const returnedError = addInUsageData.maskFilePaths(err);
+
+      assert.strictEqual(compareError.name, returnedError.name);
+      assert.strictEqual(compareError.message, returnedError.message);
+      assert.strictEqual(returnedError.stack.includes(compareError.stack), true);
     });
     it("should parse error file paths with backslashs", () => {
       addInUsageData.setUsageDataOff();
       const compareErrorWithBackslash = new Error();
       compareErrorWithBackslash.message = "this error contains a file path:C:\\excel file .xlsx";
       compareErrorWithBackslash.stack = "this error contains a file path:C:\\.xlsx";;
-      addInUsageData.maskFilePaths(errWithBackslash);
-      assert.equal(compareErrorWithBackslash.message, errWithBackslash.message);
-      assert.equal(errWithBackslash.stack.includes(compareErrorWithBackslash.stack), true);
+      const returnedError = addInUsageData.maskFilePaths(errWithBackslash);
+
+      assert.strictEqual(compareErrorWithBackslash.message, returnedError.message);
+      assert.strictEqual(returnedError.stack.includes(compareErrorWithBackslash.stack), true);
     });
   });
 

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -11,8 +11,7 @@ import * as officeAddinUsageData from "../src/usageData";
 import * as jsonData from "../src/usageDataSettings";
 
 let addInUsageData: officeAddinUsageData.OfficeAddinUsageData;
-const err = new Error(`this error contains a file path:C:/${os.homedir()}/AppData/Roaming/npm/node_modules//alanced-match/index.js`);
-const errWithBackslash = new Error(`this error contains a file path:C:\\Users\\admin\\AppData\\Local\Temp\\excel file .xlsx`);
+const err = new Error(`this error contains a file path:C:/Users/admin/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
 let usageData: string;
 const usageDataObject: officeAddinUsageData.IUsageDataOptions = {
   groupName: "office-addin-usage-data",
@@ -162,25 +161,29 @@ describe("Test office-addin-usage data-package", function() {
     it("should parse error file paths with slashs", () => {
       addInUsageData.setUsageDataOff();
       const compareError = new Error();
-      compareError.name = "TestData-test";
-      compareError.message = "this error contains a file path:C:\\index.js";
+      compareError.name = "Error";
+      compareError.message = "this error contains a file path:index.js";
       // may throw error if change any part of the top of the test file
-      compareError.stack = "this error contains a file path:C:\\.js";
-      const returnedError = addInUsageData.maskFilePaths(err);
+      compareError.stack = "this error contains a file path:index.js";
+      const error = new Error(`this error contains a file path:C:/Users/admin/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
 
-      assert.strictEqual(compareError.name, returnedError.name);
-      assert.strictEqual(compareError.message, returnedError.message);
-      assert.strictEqual(returnedError.stack.includes(compareError.stack), true);
+      addInUsageData.maskFilePaths(error);
+
+      assert.strictEqual(compareError.name, error.name);
+      assert.strictEqual(compareError.message, error.message);
+      assert.strictEqual(error.stack.includes(compareError.stack), true);
     });
     it("should parse error file paths with backslashs", () => {
       addInUsageData.setUsageDataOff();
       const compareErrorWithBackslash = new Error();
-      compareErrorWithBackslash.message = "this error contains a file path:C:\\excel file .xlsx";
-      compareErrorWithBackslash.stack = "this error contains a file path:C:\\.xlsx";;
-      const returnedError = addInUsageData.maskFilePaths(errWithBackslash);
+      compareErrorWithBackslash.message = "this error contains a file path:excel file .xlsx";
+      compareErrorWithBackslash.stack = "this error contains a file path:excel file .xlsx";;
+      const errWithBackslash = new Error(`this error contains a file path:C:\\Users\\admin\\AppData\\Local\Temp\\excel file .xlsx`);
+      
+      addInUsageData.maskFilePaths(errWithBackslash);
 
-      assert.strictEqual(compareErrorWithBackslash.message, returnedError.message);
-      assert.strictEqual(returnedError.stack.includes(compareErrorWithBackslash.stack), true);
+      assert.strictEqual(compareErrorWithBackslash.message, errWithBackslash.message);
+      assert.strictEqual(errWithBackslash.stack.includes(compareErrorWithBackslash.stack), true);
     });
   });
 

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -163,9 +163,9 @@ describe("Test office-addin-usage data-package", function() {
       const error = new Error(`this error contains a file path: C:/${os.homedir()}/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
       const compareError = new Error();
       compareError.name = "Error";
-      compareError.message = "this error contains a file path: \"\"";
+      compareError.message = "this error contains a file path: <filepath>";
       // may throw error if change any part of the top of the test file
-      compareError.stack = "this error contains a file path: \"\"";
+      compareError.stack = "this error contains a file path: <filepath>";
 
       addInUsageData.maskFilePaths(error);
 
@@ -177,8 +177,8 @@ describe("Test office-addin-usage data-package", function() {
       addInUsageData.setUsageDataOff();
       const errWithBackslash = new Error(`this error contains a file path: C:\\Users\\admin\\AppData\\Local\\Temp\\excel file .xlsx`);
       const compareErrorWithBackslash = new Error();
-      compareErrorWithBackslash.message = "this error contains a file path: \"\"";
-      compareErrorWithBackslash.stack = "this error contains a file path: \"\"";
+      compareErrorWithBackslash.message = "this error contains a file path: <filepath>";
+      compareErrorWithBackslash.stack = "this error contains a file path: <filepath>";
       
       addInUsageData.maskFilePaths(errWithBackslash);
 
@@ -189,8 +189,8 @@ describe("Test office-addin-usage data-package", function() {
       addInUsageData.setUsageDataOff();
       const error = new Error(`this error contains a file path: C:\\Users/\\admin\\AppData\\Local//Temp\\excel_file .xlsx`);
       const compareError = new Error();
-      compareError.message = "this error contains a file path: \"\"";
-      compareError.stack = "this error contains a file path: \"\"";
+      compareError.message = "this error contains a file path: <filepath>";
+      compareError.stack = "this error contains a file path: <filepath>";
       
       addInUsageData.maskFilePaths(error);
 
@@ -201,8 +201,8 @@ describe("Test office-addin-usage data-package", function() {
       addInUsageData.setUsageDataOff();
       const error = new Error(`file path: /this is a file path/path/manifestName.xml`);
       const compareError = new Error();
-      compareError.message = "file path: \"\"";
-      compareError.stack = "file path: \"\"";
+      compareError.message = "file path: <filepath>";
+      compareError.stack = "file path: <filepath>";
       
       addInUsageData.maskFilePaths(error);
 

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -11,7 +11,7 @@ import * as officeAddinUsageData from "../src/usageData";
 import * as jsonData from "../src/usageDataSettings";
 
 let addInUsageData: officeAddinUsageData.OfficeAddinUsageData;
-const err = new Error(`this error contains a file path:C:/Users/admin/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
+const err = new Error(`this error contains a file path:C:/${os.homedir()}/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
 let usageData: string;
 const usageDataObject: officeAddinUsageData.IUsageDataOptions = {
   groupName: "office-addin-usage-data",
@@ -160,7 +160,7 @@ describe("Test office-addin-usage data-package", function() {
   describe("Test maskFilePaths method", () => {
     it("should parse error file paths with slashs", () => {
       addInUsageData.setUsageDataOff();
-      const error = new Error(`this error contains a file path:C:/Users/admin/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
+      const error = new Error(`this error contains a file path:C:/${os.homedir()}/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
       const compareError = new Error();
       compareError.name = "Error";
       compareError.message = "this error contains a file path:C:\\.js";

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -160,12 +160,12 @@ describe("Test office-addin-usage data-package", function() {
   describe("Test maskFilePaths method", () => {
     it("should parse error file paths with slashs", () => {
       addInUsageData.setUsageDataOff();
+      const error = new Error(`this error contains a file path:C:/Users/admin/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
       const compareError = new Error();
       compareError.name = "Error";
-      compareError.message = "this error contains a file path:index.js";
+      compareError.message = "this error contains a file path:C:\\.js";
       // may throw error if change any part of the top of the test file
-      compareError.stack = "this error contains a file path:index.js";
-      const error = new Error(`this error contains a file path:C:/Users/admin/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
+      compareError.stack = "this error contains a file path:C:\\.js";
 
       addInUsageData.maskFilePaths(error);
 
@@ -175,15 +175,39 @@ describe("Test office-addin-usage data-package", function() {
     });
     it("should parse error file paths with backslashs", () => {
       addInUsageData.setUsageDataOff();
+      const errWithBackslash = new Error(`this error contains a file path:C:\\Users\\admin\\AppData\\Local\\Temp\\excel file .xlsx`);
       const compareErrorWithBackslash = new Error();
-      compareErrorWithBackslash.message = "this error contains a file path:excel file .xlsx";
-      compareErrorWithBackslash.stack = "this error contains a file path:excel file .xlsx";;
-      const errWithBackslash = new Error(`this error contains a file path:C:\\Users\\admin\\AppData\\Local\Temp\\excel file .xlsx`);
+      compareErrorWithBackslash.message = "this error contains a file path:C:\\.xlsx";
+      compareErrorWithBackslash.stack = "this error contains a file path:C:\\.xlsx";
       
       addInUsageData.maskFilePaths(errWithBackslash);
 
       assert.strictEqual(compareErrorWithBackslash.message, errWithBackslash.message);
       assert.strictEqual(errWithBackslash.stack.includes(compareErrorWithBackslash.stack), true);
+    });
+    it("should parse error file paths with slashs and backslashs", () => {
+      addInUsageData.setUsageDataOff();
+      const error = new Error(`this error contains a file path:C:\\Users/\\admin\\AppData\\Local//Temp\\excel_file .xlsx`);
+      const compareError = new Error();
+      compareError.message = "this error contains a file path:C:\\.xlsx";
+      compareError.stack = "this error contains a file path:C:\\.xlsx";;
+      
+      addInUsageData.maskFilePaths(error);
+
+      assert.strictEqual(compareError.message, error.message);
+      assert.strictEqual(error.stack.includes(compareError.stack), true);
+    });
+    it("should handle relative paths", () => {
+      addInUsageData.setUsageDataOff();
+      const error = new Error(`file path: /this is a file path/path/manifestName.xml`);
+      const compareError = new Error();
+      compareError.message = "file path: \\.xml";
+      compareError.stack = "file path: \\.xml";
+      
+      addInUsageData.maskFilePaths(error);
+
+      assert.strictEqual(compareError.message, error.message);
+      assert.strictEqual(error.stack.includes(compareError.stack), true);
     });
   });
 

--- a/packages/office-addin-usage-data/test/test.ts
+++ b/packages/office-addin-usage-data/test/test.ts
@@ -160,12 +160,12 @@ describe("Test office-addin-usage data-package", function() {
   describe("Test maskFilePaths method", () => {
     it("should parse error file paths with slashs", () => {
       addInUsageData.setUsageDataOff();
-      const error = new Error(`this error contains a file path:C:/${os.homedir()}/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
+      const error = new Error(`this error contains a file path: C:/${os.homedir()}/AppData/Roaming/npm/node_modules/alanced-match/index.js`);
       const compareError = new Error();
       compareError.name = "Error";
-      compareError.message = "this error contains a file path:C:\\.js";
+      compareError.message = "this error contains a file path: \"\"";
       // may throw error if change any part of the top of the test file
-      compareError.stack = "this error contains a file path:C:\\.js";
+      compareError.stack = "this error contains a file path: \"\"";
 
       addInUsageData.maskFilePaths(error);
 
@@ -175,10 +175,10 @@ describe("Test office-addin-usage data-package", function() {
     });
     it("should parse error file paths with backslashs", () => {
       addInUsageData.setUsageDataOff();
-      const errWithBackslash = new Error(`this error contains a file path:C:\\Users\\admin\\AppData\\Local\\Temp\\excel file .xlsx`);
+      const errWithBackslash = new Error(`this error contains a file path: C:\\Users\\admin\\AppData\\Local\\Temp\\excel file .xlsx`);
       const compareErrorWithBackslash = new Error();
-      compareErrorWithBackslash.message = "this error contains a file path:C:\\.xlsx";
-      compareErrorWithBackslash.stack = "this error contains a file path:C:\\.xlsx";
+      compareErrorWithBackslash.message = "this error contains a file path: \"\"";
+      compareErrorWithBackslash.stack = "this error contains a file path: \"\"";
       
       addInUsageData.maskFilePaths(errWithBackslash);
 
@@ -187,10 +187,10 @@ describe("Test office-addin-usage data-package", function() {
     });
     it("should parse error file paths with slashs and backslashs", () => {
       addInUsageData.setUsageDataOff();
-      const error = new Error(`this error contains a file path:C:\\Users/\\admin\\AppData\\Local//Temp\\excel_file .xlsx`);
+      const error = new Error(`this error contains a file path: C:\\Users/\\admin\\AppData\\Local//Temp\\excel_file .xlsx`);
       const compareError = new Error();
-      compareError.message = "this error contains a file path:C:\\.xlsx";
-      compareError.stack = "this error contains a file path:C:\\.xlsx";;
+      compareError.message = "this error contains a file path: \"\"";
+      compareError.stack = "this error contains a file path: \"\"";
       
       addInUsageData.maskFilePaths(error);
 
@@ -201,8 +201,8 @@ describe("Test office-addin-usage data-package", function() {
       addInUsageData.setUsageDataOff();
       const error = new Error(`file path: /this is a file path/path/manifestName.xml`);
       const compareError = new Error();
-      compareError.message = "file path: \\.xml";
-      compareError.stack = "file path: \\.xml";
+      compareError.message = "file path: \"\"";
+      compareError.stack = "file path: \"\"";
       
       addInUsageData.maskFilePaths(error);
 


### PR DESCRIPTION
The function `maskFilePaths ` was having a side effect of modifying the value passed to it.
This would lead to unwanted behavior in the function `reportExpectedException` for example, in which calling it would have side effects on the parameter.