### PR TITLE
[Minor] Creating an isOutlook option for the object

### DIFF
--- a/packages/office-addin-mock/README.md
+++ b/packages/office-addin-mock/README.md
@@ -115,9 +115,23 @@ Represents a mock Office object.
 #### Constructor
 
 The object parameter provides initial values for the mock object. (Optional)
+The host parameter identifies the host of the tests. (Optional)
 
 ```
-constructor(object?: Object); 
+constructor(object?: Object, host?: Host); 
+```
+
+Host can be any of the following:
+
+```Javascript
+Host {
+  excel = "excel",
+  outlook = "outlook",
+  powerpoint = "powerpoint",
+  word = "word",
+  other = "other",
+  notFound = "notFound",
+}
 ```
 
 #### Methods

--- a/packages/office-addin-mock/README.md
+++ b/packages/office-addin-mock/README.md
@@ -126,11 +126,13 @@ Host can be any of the following:
 ```Javascript
 Host {
   excel = "excel",
+  onenote = "onenote",
   outlook = "outlook",
   powerpoint = "powerpoint",
+  project = "project",
+  visio = "visio",
   word = "word",
-  other = "other",
-  notFound = "notFound",
+  unknow = "unknow",
 }
 ```
 

--- a/packages/office-addin-mock/README.md
+++ b/packages/office-addin-mock/README.md
@@ -118,21 +118,19 @@ The object parameter provides initial values for the mock object. (Optional)
 The host parameter identifies the host of the tests. (Optional)
 
 ```
-constructor(object?: Object, host?: Host); 
+constructor(object?: Object, host?: OfficeApp | undefined); 
 ```
 
 Host can be any of the following:
 
 ```Javascript
-Host {
-  excel = "excel",
-  onenote = "onenote",
-  outlook = "outlook",
-  powerpoint = "powerpoint",
-  project = "project",
-  visio = "visio",
-  word = "word",
-  unknow = "unknow",
+OfficeApp {
+  Excel = "excel",
+  OneNote = "onenote",
+  Outlook = "outlook",
+  PowerPoint = "powerpoint",
+  Project = "project",
+  Word = "word",
 }
 ```
 

--- a/packages/office-addin-mock/package-lock.json
+++ b/packages/office-addin-mock/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "office-addin-manifest": "^1.7.7",
         "office-addin-usage-data": "^1.4.6"
       },
       "devDependencies": {
@@ -661,7 +662,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -1011,7 +1011,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -1019,8 +1018,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/commander": {
       "version": "6.2.1",
@@ -1091,6 +1089,11 @@
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2006,7 +2009,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2062,6 +2064,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2100,8 +2107,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -2422,6 +2428,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2489,6 +2500,17 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2500,6 +2522,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -2966,6 +2996,46 @@
         "office-addin-lint": "lib/cli.js"
       }
     },
+    "node_modules/office-addin-manifest": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.7.tgz",
+      "integrity": "sha512-wBkDBiNTAaJew/69J8GJ89IOp+bBQyVFts29HKIJ8XohxNGelkoMXJDZ9onL9qO85V/hOFQJmAzWC19ZumRbPQ==",
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "commander": "^6.2.0",
+        "jszip": "^3.7.1",
+        "node-fetch": "^2.6.1",
+        "office-addin-cli": "^1.3.5",
+        "office-addin-usage-data": "^1.4.6",
+        "path": "^0.12.7",
+        "uuid": "^8.3.2",
+        "xml2js": "^0.4.23"
+      },
+      "bin": {
+        "office-addin-manifest": "cli.js"
+      }
+    },
+    "node_modules/office-addin-manifest/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/office-addin-manifest/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/office-addin-prettier-config": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.4.tgz",
@@ -3042,6 +3112,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3070,6 +3145,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
       }
     },
     "node_modules/path-exists": {
@@ -3112,6 +3196,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "node_modules/path/node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
       }
     },
     "node_modules/picomatch": {
@@ -3158,6 +3255,19 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -3258,6 +3368,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -3436,6 +3565,11 @@
         }
       ]
     },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -3451,6 +3585,14 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/shebang-command": {
@@ -3610,6 +3752,19 @@
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
       "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3697,7 +3852,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -3946,6 +4100,19 @@
         "which-typed-array": "^1.1.2"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -4097,6 +4264,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -4643,7 +4830,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -4906,7 +5092,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -4914,8 +5099,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "commander": {
       "version": "6.2.1",
@@ -4970,6 +5154,11 @@
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
       }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "create-require": {
       "version": "1.1.1",
@@ -5647,8 +5836,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -5683,6 +5871,11 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5712,8 +5905,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -5923,6 +6115,11 @@
         "call-bind": "^1.0.0"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5978,6 +6175,17 @@
         "object.assign": "^4.1.2"
       }
     },
+    "jszip": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5986,6 +6194,14 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -6335,6 +6551,39 @@
         "prettier": "^2.2.1"
       }
     },
+    "office-addin-manifest": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.7.7.tgz",
+      "integrity": "sha512-wBkDBiNTAaJew/69J8GJ89IOp+bBQyVFts29HKIJ8XohxNGelkoMXJDZ9onL9qO85V/hOFQJmAzWC19ZumRbPQ==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "commander": "^6.2.0",
+        "jszip": "^3.7.1",
+        "node-fetch": "^2.6.1",
+        "office-addin-cli": "^1.3.5",
+        "office-addin-usage-data": "^1.4.6",
+        "path": "^0.12.7",
+        "uuid": "^8.3.2",
+        "xml2js": "^0.4.23"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        }
+      }
+    },
     "office-addin-prettier-config": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.4.tgz",
@@ -6393,6 +6642,11 @@
         "p-limit": "^3.0.2"
       }
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6412,6 +6666,30 @@
         "error-ex": "^1.3.1",
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "util": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+          "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        }
       }
     },
     "path-exists": {
@@ -6470,6 +6748,16 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -6541,6 +6829,27 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
           "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
           "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -6647,6 +6956,11 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -6660,6 +6974,11 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -6790,6 +7109,21 @@
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
       "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6856,7 +7190,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -7032,6 +7365,16 @@
         "which-typed-array": "^1.1.2"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -7152,6 +7495,20 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/packages/office-addin-mock/package.json
+++ b/packages/office-addin-mock/package.json
@@ -15,6 +15,7 @@
     "office-js"
   ],
   "dependencies": {
+    "office-addin-manifest": "^1.7.7",
     "office-addin-usage-data": "^1.4.6"
   },
   "devDependencies": {

--- a/packages/office-addin-mock/src/host.ts
+++ b/packages/office-addin-mock/src/host.ts
@@ -2,22 +2,23 @@ import { ObjectData } from "./objectData";
 
 export enum Host {
   excel = "excel",
+  onenote = "onenote",
   outlook = "outlook",
   powerpoint = "powerpoint",
+  project = "project",
+  visio = "visio",
   word = "word",
-  other = "other",
-  notFound = "notFound",
+  unknow = "unknow",
 }
 
 export function getHostType(object: ObjectData | undefined): Host {
+  let validHost = Host.unknow;
   if (object && object["host"]) {
-    let validHost = Host.other;
     Object.values(Host).forEach((host: string) => {
       if (object["host"] === host) {
         validHost = object["host"];
       }
     });
-    return validHost;
   }
-  return Host.notFound;
+  return validHost;
 }

--- a/packages/office-addin-mock/src/host.ts
+++ b/packages/office-addin-mock/src/host.ts
@@ -1,0 +1,23 @@
+import { ObjectData } from "./objectData";
+
+export enum Host {
+  excel = "excel",
+  outlook = "outlook",
+  powerpoint = "powerpoint",
+  word = "word",
+  other = "other",
+  notFound = "notFound",
+}
+
+export function getHostType(object: ObjectData | undefined): Host {
+  if (object && object["host"]) {
+    let validHost = Host.other;
+    Object.values(Host).forEach((host: string) => {
+      if (object["host"] === host) {
+        validHost = object["host"];
+      }
+    });
+    return validHost;
+  }
+  return Host.notFound;
+}

--- a/packages/office-addin-mock/src/host.ts
+++ b/packages/office-addin-mock/src/host.ts
@@ -1,20 +1,12 @@
+import { OfficeApp } from "office-addin-manifest";
 import { ObjectData } from "./objectData";
 
-export enum Host {
-  excel = "excel",
-  onenote = "onenote",
-  outlook = "outlook",
-  powerpoint = "powerpoint",
-  project = "project",
-  visio = "visio",
-  word = "word",
-  unknow = "unknow",
-}
-
-export function getHostType(object: ObjectData | undefined): Host {
-  let validHost = Host.unknow;
+export function getHostType(
+  object: ObjectData | undefined
+): OfficeApp | undefined {
+  let validHost = undefined;
   if (object && object["host"]) {
-    Object.values(Host).forEach((host: string) => {
+    Object.values(OfficeApp).forEach((host: string) => {
       if (object["host"] === host) {
         validHost = object["host"];
       }

--- a/packages/office-addin-mock/src/objectData.ts
+++ b/packages/office-addin-mock/src/objectData.ts
@@ -1,0 +1,5 @@
+// Represents the Object to be used when populating Office JS with data.
+export class ObjectData {
+  /* eslint-disable-next-line */
+    [key: string]: any;
+}

--- a/packages/office-addin-mock/src/officeMockObject.ts
+++ b/packages/office-addin-mock/src/officeMockObject.ts
@@ -5,6 +5,7 @@ import { ObjectData } from "./objectData";
 /**
  * Creates an office-js mockable object
  * @param object Object structure to provide initial values for the mock object (Optional)
+ * @param host Host tested by the object (Optional)
  */
 export class OfficeMockObject {
   constructor(object?: ObjectData, host?: Host) {

--- a/packages/office-addin-mock/src/officeMockObject.ts
+++ b/packages/office-addin-mock/src/officeMockObject.ts
@@ -1,14 +1,20 @@
+import { getHostType, Host } from "./host";
 import { isValidError, PossibleErrors } from "./possibleErrors";
+import { ObjectData } from "./objectData";
 
 /**
  * Creates an office-js mockable object
  * @param object Object structure to provide initial values for the mock object (Optional)
  */
 export class OfficeMockObject {
-  constructor(object?: ObjectData, isOutlook: boolean = false) {
+  constructor(object?: ObjectData, host?: Host) {
     this.properties = new Map<string, OfficeMockObject>();
     this.loaded = false;
-    this.isOutlook = isOutlook;
+    if (host) {
+      this.host = host;
+    } else {
+      this.host = getHostType(object);
+    }
     this.resetValue(undefined);
     if (object) {
       this.populate(object);
@@ -20,7 +26,7 @@ export class OfficeMockObject {
    * @param propertyArgument Argument of the load call. Will load any properties in the argument
    */
   load(propertyArgument: string | string[] | ObjectData) {
-    if (this.isOutlook) {
+    if (this.host === Host.outlook) {
       return;
     }
     let properties: string[] = [];
@@ -60,7 +66,7 @@ export class OfficeMockObject {
       throw new Error("Mock object already exists");
     }
 
-    const officeMockObject = new OfficeMockObject(undefined, this.isOutlook);
+    const officeMockObject = new OfficeMockObject(undefined, this.host);
     officeMockObject.isObject = true;
     this.properties.set(objectName, officeMockObject);
     this[objectName] = this.properties.get(objectName);
@@ -179,7 +185,7 @@ export class OfficeMockObject {
   }
 
   private resetValue(value: unknown) {
-    if (this.isOutlook) {
+    if (this.host === Host.outlook) {
       this.value = value;
     } else {
       this.value = PossibleErrors.notLoaded;
@@ -198,10 +204,7 @@ export class OfficeMockObject {
       this[propertyName] = value;
     } else {
       if (!this.properties.has(propertyName)) {
-        const officeMockObject = new OfficeMockObject(
-          undefined,
-          this.isOutlook
-        );
+        const officeMockObject = new OfficeMockObject(undefined, this.host);
         officeMockObject.isObject = false;
         this.properties.set(propertyName, officeMockObject);
       }
@@ -224,13 +227,7 @@ export class OfficeMockObject {
   private value: unknown;
   private valueBeforeLoaded: unknown;
   private isObject: boolean | undefined;
-  private isOutlook: boolean;
-  /* eslint-disable-next-line */
-  [key: string]: any;
-}
-
-// Represents the Object to be used when populating Office JS with data.
-class ObjectData {
+  private host: Host;
   /* eslint-disable-next-line */
   [key: string]: any;
 }

--- a/packages/office-addin-mock/src/officeMockObject.ts
+++ b/packages/office-addin-mock/src/officeMockObject.ts
@@ -1,4 +1,5 @@
-import { getHostType, Host } from "./host";
+import { OfficeApp } from "office-addin-manifest";
+import { getHostType } from "./host";
 import { isValidError, PossibleErrors } from "./possibleErrors";
 import { ObjectData } from "./objectData";
 
@@ -8,7 +9,7 @@ import { ObjectData } from "./objectData";
  * @param host Host tested by the object (Optional)
  */
 export class OfficeMockObject {
-  constructor(object?: ObjectData, host?: Host) {
+  constructor(object?: ObjectData, host?: OfficeApp | undefined) {
     this.properties = new Map<string, OfficeMockObject>();
     this.loaded = false;
     if (host) {
@@ -27,7 +28,7 @@ export class OfficeMockObject {
    * @param propertyArgument Argument of the load call. Will load any properties in the argument
    */
   load(propertyArgument: string | string[] | ObjectData) {
-    if (this.host === Host.outlook) {
+    if (this.host === OfficeApp.Outlook) {
       return;
     }
     let properties: string[] = [];
@@ -186,7 +187,7 @@ export class OfficeMockObject {
   }
 
   private resetValue(value: unknown) {
-    if (this.host === Host.outlook) {
+    if (this.host === OfficeApp.Outlook) {
       this.value = value;
     } else {
       this.value = PossibleErrors.notLoaded;
@@ -228,7 +229,7 @@ export class OfficeMockObject {
   private value: unknown;
   private valueBeforeLoaded: unknown;
   private isObject: boolean | undefined;
-  private host: Host;
+  private host: OfficeApp | undefined;
   /* eslint-disable-next-line */
   [key: string]: any;
 }

--- a/packages/office-addin-mock/src/officeMockObject.ts
+++ b/packages/office-addin-mock/src/officeMockObject.ts
@@ -5,9 +5,10 @@ import { isValidError, PossibleErrors } from "./possibleErrors";
  * @param object Object structure to provide initial values for the mock object (Optional)
  */
 export class OfficeMockObject {
-  constructor(object?: ObjectData) {
+  constructor(object?: ObjectData, isOutlook: boolean = false) {
     this.properties = new Map<string, OfficeMockObject>();
     this.loaded = false;
+    this.isOutlook = isOutlook;
     this.resetValue(undefined);
     if (object) {
       this.populate(object);
@@ -34,7 +35,7 @@ export class OfficeMockObject {
       throw new Error("Mock object already exists");
     }
 
-    const officeMockObject = new OfficeMockObject();
+    const officeMockObject = new OfficeMockObject(undefined, this.isOutlook);
     officeMockObject.isObject = true;
     this.properties.set(objectName, officeMockObject);
     this[objectName] = this.properties.get(objectName);
@@ -45,6 +46,9 @@ export class OfficeMockObject {
    * @param propertyArgument Argument of the load call. Will load any properties in the argument
    */
   load(propertyArgument: string | string[] | ObjectData) {
+    if (this.isOutlook) {
+      return;
+    }
     let properties: string[] = [];
 
     if (typeof propertyArgument === "string") {
@@ -68,7 +72,7 @@ export class OfficeMockObject {
    */
   setMock(propertyName: string, value: unknown) {
     if (!this.properties.has(propertyName)) {
-      const officeMockObject = new OfficeMockObject();
+      const officeMockObject = new OfficeMockObject(undefined, this.isOutlook);
       officeMockObject.isObject = false;
       this.properties.set(propertyName, officeMockObject);
     }
@@ -202,9 +206,13 @@ export class OfficeMockObject {
   }
 
   private resetValue(value: unknown) {
-    this.value = PossibleErrors.notLoaded;
-    this.valueBeforeLoaded = value;
-    this.loaded = false;
+    if (this.isOutlook) {
+      this.value = value;
+    } else {
+      this.value = PossibleErrors.notLoaded;
+      this.valueBeforeLoaded = value;
+      this.loaded = false;
+    }
   }
 
   /**
@@ -217,7 +225,10 @@ export class OfficeMockObject {
       this[propertyName] = value;
     } else {
       if (!this.properties.has(propertyName)) {
-        const officeMockObject = new OfficeMockObject();
+        const officeMockObject = new OfficeMockObject(
+          undefined,
+          this.isOutlook
+        );
         officeMockObject.isObject = false;
         this.properties.set(propertyName, officeMockObject);
       }
@@ -240,6 +251,7 @@ export class OfficeMockObject {
   private value: unknown;
   private valueBeforeLoaded: unknown;
   private isObject: boolean | undefined;
+  private isOutlook: boolean;
   /* eslint-disable-next-line */
   [key: string]: any;
 }

--- a/packages/office-addin-mock/test/host.test.ts
+++ b/packages/office-addin-mock/test/host.test.ts
@@ -14,12 +14,33 @@ describe("Test Host file", function() {
       };
       assert.strictEqual(getHostType(object), "excel");
     });
+    it("OneNote", async function() {
+      const object = {
+        context: {},
+        host: "onenote"
+      };
+      assert.strictEqual(getHostType(object), "onenote");
+    });
     it("PowerPoint", async function() {
       const object = {
         context: {},
         host: "powerpoint"
       };
       assert.strictEqual(getHostType(object), "powerpoint");
+    });
+    it("Project", async function() {
+      const object = {
+        context: {},
+        host: "project"
+      };
+      assert.strictEqual(getHostType(object), "project");
+    });
+    it("Visio", async function() {
+      const object = {
+        context: {},
+        host: "visio"
+      };
+      assert.strictEqual(getHostType(object), "visio");
     });
     it("Word", async function() {
       const object = {
@@ -39,7 +60,7 @@ describe("Test Host file", function() {
       const outlookObject = {
         context: {},
       };
-      assert.strictEqual(getHostType(outlookObject), "notFound");
+      assert.strictEqual(getHostType(outlookObject), "unknow");
     });
     it("Other", async function() {
       const object = {
@@ -47,7 +68,7 @@ describe("Test Host file", function() {
         host: "not a host"
 
       };
-      assert.strictEqual(getHostType(object), "other");
+      assert.strictEqual(getHostType(object), "unknow");
     });
   });
 });

--- a/packages/office-addin-mock/test/host.test.ts
+++ b/packages/office-addin-mock/test/host.test.ts
@@ -3,7 +3,7 @@
 
 import * as assert from "assert";
 import * as mocha from "mocha";
-import { getHostType, Host } from "../src/host";
+import { getHostType } from "../src/host";
 
 describe("Test Host file", function() {
   describe("Works on differt hosts", function() {
@@ -35,13 +35,6 @@ describe("Test Host file", function() {
       };
       assert.strictEqual(getHostType(object), "project");
     });
-    it("Visio", async function() {
-      const object = {
-        context: {},
-        host: "visio"
-      };
-      assert.strictEqual(getHostType(object), "visio");
-    });
     it("Word", async function() {
       const object = {
         context: {},
@@ -60,7 +53,7 @@ describe("Test Host file", function() {
       const outlookObject = {
         context: {},
       };
-      assert.strictEqual(getHostType(outlookObject), "unknow");
+      assert.strictEqual(getHostType(outlookObject), undefined);
     });
     it("Other", async function() {
       const object = {
@@ -68,7 +61,7 @@ describe("Test Host file", function() {
         host: "not a host"
 
       };
-      assert.strictEqual(getHostType(object), "unknow");
+      assert.strictEqual(getHostType(object), undefined);
     });
   });
 });

--- a/packages/office-addin-mock/test/host.test.ts
+++ b/packages/office-addin-mock/test/host.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import * as mocha from "mocha";
+import { getHostType, Host } from "../src/host";
+
+describe("Test Host file", function() {
+  describe("Works on differt hosts", function() {
+    it("Excel", async function() {
+      const object = {
+        context: {},
+        host: "excel"
+      };
+      assert.strictEqual(getHostType(object), "excel");
+    });
+    it("PowerPoint", async function() {
+      const object = {
+        context: {},
+        host: "powerpoint"
+      };
+      assert.strictEqual(getHostType(object), "powerpoint");
+    });
+    it("Word", async function() {
+      const object = {
+        context: {},
+        host: "word"
+      };
+      assert.strictEqual(getHostType(object), "word");
+    });
+    it("Outlook", async function() {
+      const object = {
+        context: {},
+        host: "outlook"
+      };
+      assert.strictEqual(getHostType(object), "outlook");
+    });
+    it("Not defined", async function() {
+      const outlookObject = {
+        context: {},
+      };
+      assert.strictEqual(getHostType(outlookObject), "notFound");
+    });
+    it("Other", async function() {
+      const object = {
+        context: {},
+        host: "not a host"
+
+      };
+      assert.strictEqual(getHostType(object), "other");
+    });
+  });
+});

--- a/packages/office-addin-mock/test/officeMockObject.test.ts
+++ b/packages/office-addin-mock/test/officeMockObject.test.ts
@@ -18,6 +18,20 @@ const testObject = {
   },
 }
 
+const testObjectOutlook = {
+  range: {
+    color: "blue",
+    getColor: function() {
+      return this.color;
+    },
+    font: {
+      size: 12,
+      type: "arial"
+    }
+  },
+  host: "outlook",
+}
+
 const contextMockData = {
   workbook: {
     range: {
@@ -226,7 +240,7 @@ describe("Test OfficeMockObject class", function() {
 
   describe("Works on Outlook", function() {
     it("Object construction", async function() {
-      const officeMock = new OfficeMockObject(testObject, true);
+      const officeMock = new OfficeMockObject(testObjectOutlook);
       officeMock.load("range");
       officeMock.sync();
       assert.strictEqual(officeMock.range.color, "blue");
@@ -234,13 +248,13 @@ describe("Test OfficeMockObject class", function() {
       assert.strictEqual(officeMock.range.getColor(), "blue");
     });
     it("Invalid load calls", async function() {
-      const officeMock = new OfficeMockObject(testObject, true);
+      const officeMock = new OfficeMockObject(testObjectOutlook);
       officeMock.range.load("color");
       assert.strictEqual(officeMock.range.getColor(), "blue");
       assert.strictEqual(officeMock.range.color, "blue");
     });
     it("Invalid sync calls", async function() {
-      const officeMock = new OfficeMockObject(testObject, true);
+      const officeMock = new OfficeMockObject(testObjectOutlook);
       officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "blue");
       assert.strictEqual(officeMock.range.color, "blue");

--- a/packages/office-addin-mock/test/officeMockObject.test.ts
+++ b/packages/office-addin-mock/test/officeMockObject.test.ts
@@ -223,4 +223,27 @@ describe("Test OfficeMockObject class", function() {
       assert.strictEqual(context.items[1].text2, "B");
     });
   });
+
+  describe("Works on Outlook", function() {
+    it("Object construction", async function() {
+      const officeMock = new OfficeMockObject(testObject, true);
+      officeMock.load("range");
+      officeMock.sync();
+      assert.strictEqual(officeMock.range.color, "blue");
+      assert.strictEqual(officeMock.range.font.size, 12);
+      assert.strictEqual(officeMock.range.getColor(), "blue");
+    });
+    it("Invalid load calls", async function() {
+      const officeMock = new OfficeMockObject(testObject, true);
+      officeMock.range.load("color");
+      assert.strictEqual(officeMock.range.getColor(), "blue");
+      assert.strictEqual(officeMock.range.color, "blue");
+    });
+    it("Invalid sync calls", async function() {
+      const officeMock = new OfficeMockObject(testObject, true);
+      officeMock.sync();
+      assert.strictEqual(officeMock.range.getColor(), "blue");
+      assert.strictEqual(officeMock.range.color, "blue");
+    });
+  });
 });


### PR DESCRIPTION
Creating an outlook flag to pass to the mocking object in order to bypass the need for a property wait for load and sync calls.
Previous to this commit, a property assigned in the constructor of `OfficeAddinMock` would always require a `load` call, which is not needed for Outlook.

Solves this issue: https://github.com/OfficeDev/Office-Addin-Scripts/issues/587