### PR TITLE
Update number of prod failure messages reported

### DIFF
--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -632,7 +632,7 @@ describe("Unit Tests", function() {
         const validation = await validateManifest("test/manifests/TaskPane.manifest.xml", true);
         assert.strictEqual(validation.isValid, false);
         assert.strictEqual(validation.status, 200);
-        assert.strictEqual(validation.report!.errors!.length, 2);
+        assert.strictEqual(validation.report!.errors!.length, 4);
         assert.strictEqual(validation.report!.notes!.length > 0, true);
         assert.strictEqual(validation.report!.warnings!.length, 0);
         assert.strictEqual(validation.report!.addInDetails!.supportedProducts!.length > 0, true);


### PR DESCRIPTION
Looks like the number of errors reported by the validation service (valid change and no change on us is necessary) has changed for production and the test needs to be updated to match.