### PR TITLE
Adjust the date used to check cert validity

### DIFF
--- a/packages/office-addin-dev-certs/scripts/verify.ps1
+++ b/packages/office-addin-dev-certs/scripts/verify.ps1
@@ -4,9 +4,9 @@ if($args.Count -ne 1){
 
 $caCertificateName=$args[0]
 if(Get-Command -name Import-Certificate -ErrorAction SilentlyContinue){
-    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object Issuer -like "*CN=$caCertificateName*" | Where-Object { $_.NotAfter -gt [datetime]::today } | Format-List
+    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object Issuer -like "*CN=$caCertificateName*" | Where-Object { $_.NotAfter -gt [datetime]::today.AddDays(-1) } | Format-List
 }
 else{
     # Legacy system support
-    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object { $_.Subject -like "*CN=$caCertificateName*"} | Where-Object { $_.NotAfter -gt [datetime]::today } | Format-List
+    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object { $_.Subject -like "*CN=$caCertificateName*"} | Where-Object { $_.NotAfter -gt [datetime]::today.AddDays(-1) } | Format-List
 }


### PR DESCRIPTION
Customers have reported an error in the host taskpane saying no valid cert was found, but the tooling says the cert is valid.  We haven't been able to repro this . . . until yesterday when I encountered this.  I as investigated it became clear that my cert was expired at 2:30pm, but office-addin-dev-certs said it was still valid when checking against a time of 12AM on the same day (anything after is considered expired).