### PR TITLE
Renaming private variables of mock class

### DIFF
--- a/packages/office-addin-mock/test/officeMockObject.test.ts
+++ b/packages/office-addin-mock/test/officeMockObject.test.ts
@@ -46,6 +46,9 @@ const contextMockData = {
       return this.range;
     },
   },
+  properties: {
+    propsA: "propsA Value"
+  }
 };
 
 describe("Test OfficeMockObject class", function() {


### PR DESCRIPTION
Closes https://github.com/OfficeDev/Office-Addin-Scripts/issues/602

Some words couldn't be used as properties because they already existed for private use in the class. I am just changing the variables names from <varName> to <_varName> in order to free up the use of these words.