### PR TITLE
Fix mac dev cert script verify and uninstall

### DIFF
--- a/packages/office-addin-dev-certs/src/uninstall.ts
+++ b/packages/office-addin-dev-certs/src/uninstall.ts
@@ -22,7 +22,7 @@ function getUninstallCommand(machine: boolean = false): string {
     case "darwin": {
       // macOS
       const script = path.resolve(__dirname, "../scripts/uninstall.sh");
-      return `sudo sh ${script} '${defaults.certificateName}'`;
+      return `sudo sh '${script}' '${defaults.certificateName}'`;
     }
     case "linux":
       return `sudo rm -r /usr/local/share/ca-certificates/office-addin-dev-certs/${defaults.caCertificateFileName} && sudo /usr/sbin/update-ca-certificates --fresh`;

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -20,7 +20,7 @@ function getVerifyCommand(): string {
     case "darwin": {
       // macOS
       const script = path.resolve(__dirname, "../scripts/verify.sh");
-      return `sh ${script} '${defaults.certificateName}'`;
+      return `sh '${script}' '${defaults.certificateName}'`;
     }
     case "linux":
       return `[ -f /usr/local/share/ca-certificates/office-addin-dev-certs/${defaults.caCertificateFileName} ] && openssl x509 -in /usr/local/share/ca-certificates/office-addin-dev-certs/${defaults.caCertificateFileName} -checkend 86400 -noout`;


### PR DESCRIPTION
When there is a space in the path the script fails to get called.  Add quote around script path.