### PR TITLE
Removing file base path

### DIFF
--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -360,7 +360,7 @@ export async function sideloadAddIn(
         if (!isSideloadingSupportedForWebHost(app)) {
           throw new ExpectedError(`Sideload to the ${getOfficeAppName(app)} web app is not supported.`);
         }
-        const manifestFileName: string = path.basename(manifestPath);
+        const manifestFileName: string = manifestPath;
         sideloadFile = await generateSideloadUrl(manifestFileName, manifest, document, isTest);
         break;
       }


### PR DESCRIPTION
Sideload code was assuming the manifestPath served had always the same name from the one from the file, which isn't necessarily the case. 

There is no issue with this right now, but using `basename` didn't make sense, so I'm just removing it before it can become a problem.