### PR TITLE
Additional parameters in JSON metadata file

### DIFF
--- a/packages/custom-functions-metadata-plugin/README.md
+++ b/packages/custom-functions-metadata-plugin/README.md
@@ -5,13 +5,18 @@ A WebPack plugin which generates the metadata for custom functions.
 
 # Webpack example (webpack.config.js)
 
+```
 const CustomFunctionsPlugin = require("custom-functions-metadata-plugin");
 
 plugins: [
       new CustomFunctionsPlugin({
         input: './src/functions/functions.ts',
-        output: 'functions.json'})
+        output: 'functions.json',
+        options: {
+            allowErrorForDataTypeAny: true
+        })
     ]
+```
 
 # Contributing
 

--- a/packages/custom-functions-metadata-plugin/package.json
+++ b/packages/custom-functions-metadata-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-functions-metadata-plugin",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "author": "Office Dev",
   "bugs": {
     "url": "https://github.com/OfficeDev/Office-Addin-Scripts/issues"
@@ -26,7 +26,7 @@
     "watch": "tsc -p tsconfig.json -w"
   },
   "dependencies": {
-    "custom-functions-metadata": "^1.2.7",
+    "custom-functions-metadata": "^1.2.8",
     "loader-utils": "^2.0.0",
     "webpack": "^5.24.4"
   },

--- a/packages/custom-functions-metadata-plugin/src/customfunctionsplugin.ts
+++ b/packages/custom-functions-metadata-plugin/src/customfunctionsplugin.ts
@@ -4,6 +4,7 @@
 import {
   generateCustomFunctionsMetadata,
   IGenerateResult,
+  MetadataOptions
 } from "custom-functions-metadata";
 import * as path from "path";
 import { Compiler, sources, WebpackError, NormalModule } from "webpack";
@@ -12,7 +13,7 @@ import { Compiler, sources, WebpackError, NormalModule } from "webpack";
 
 const pluginName = "CustomFunctionsMetadataPlugin";
 
-type Options = { input: string; output: string };
+type Options = { input: string; output: string; options?: MetadataOptions };
 
 class CustomFunctionsMetadataPlugin {
   private options: Options;
@@ -30,7 +31,8 @@ class CustomFunctionsMetadataPlugin {
     compiler.hooks.beforeCompile.tapPromise(pluginName, async () => {
       generateResult = await generateCustomFunctionsMetadata(
         inputFilePath,
-        true
+        true,
+        this.options.options
       );
     });
 

--- a/packages/custom-functions-metadata/README.md
+++ b/packages/custom-functions-metadata/README.md
@@ -12,8 +12,14 @@ Generates metadata for custom functions from source code.
 
 Syntax:
 
-`custom-functions-metadata generate <sourceFile> [outputFile]`
+`custom-functions-metadata generate <sourceFile> [outputFile] [options]`
 
 `sourceFile`: path to the source file (.ts or .js).
+
 `outputFile`: If specified, the metadata is written to the file. Otherwise, it is written to the console.
 
+Options:
+
+`--allow-error-for-data-type-any`
+
+Allow a custom function to process errors as input values.

--- a/packages/custom-functions-metadata/package.json
+++ b/packages/custom-functions-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-functions-metadata",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Generate metadata for Excel Custom Functions.",
   "main": "./lib/main.js",
   "scripts": {

--- a/packages/custom-functions-metadata/src/cli.ts
+++ b/packages/custom-functions-metadata/src/cli.ts
@@ -14,6 +14,7 @@ commander.version(process.env.npm_package_version || "(version not available)");
 
 commander
   .command("generate <source-file> [output-file]")
+  .option("--allow-error-for-data-type-any", "Allow a custom function to process errors as input values.")
   .description("Generate the metadata for the custom functions from the source code.")
   .action(commands.generate);
 

--- a/packages/custom-functions-metadata/src/commands.ts
+++ b/packages/custom-functions-metadata/src/commands.ts
@@ -1,18 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as commander from "commander";
 import { writeFileSync } from "fs";
 import { logErrorMessage } from "office-addin-usage-data";
-import { generateCustomFunctionsMetadata } from "./generate";
+import { generateCustomFunctionsMetadata, MetadataOptions } from "./generate";
 
 /* global console */
 
-export async function generate(inputPath: string, outputPath: string) {
+export async function generate(inputPath: string, outputPath: string, command: commander.Command) {
   try {
     if (!inputPath) {
       throw new Error("You need to provide the path to the source file for custom functions.");
     }
-    const results = await generateCustomFunctionsMetadata(inputPath);
+    const additionalOptions: MetadataOptions | null =
+      command.allowErrorForDataTypeAny != null ? { allowErrorForDataTypeAny: command.allowErrorForDataTypeAny } : null;
+    const results = await generateCustomFunctionsMetadata(inputPath, false, additionalOptions);
     if (results.errors.length > 0) {
       console.error("Errors found:");
       results.errors.forEach((err) => console.log(err));

--- a/packages/custom-functions-metadata/src/generate.ts
+++ b/packages/custom-functions-metadata/src/generate.ts
@@ -8,6 +8,7 @@ import XRegExp = require("xregexp");
 /* global console */
 
 export interface ICustomFunctionsMetadata {
+  allowErrorForDataTypeAny?: boolean;
   functions: IFunction[];
 }
 
@@ -134,14 +135,18 @@ const TYPE_CUSTOM_FUNCTION_INVOCATION = "customfunctions.invocation";
 
 type CustomFunctionsSchemaDimensionality = "invalid" | "scalar" | "matrix";
 
+export type MetadataOptions = { allowErrorForDataTypeAny: boolean };
+
 /**
  * Generate the metadata of the custom functions
  * @param inputFile - File that contains the custom functions
  * @param outputFileName - Name of the file to create (i.e functions.json)
+ * @param metadataOptions - Additional properties like allowErrorForDataTypeAny
  */
 export async function generateCustomFunctionsMetadata(
   inputFile: string,
-  wantConsoleOutput: boolean = false
+  wantConsoleOutput: boolean = false,
+  metadataOptions?: MetadataOptions | null
 ): Promise<IGenerateResult> {
   const generateResults: IGenerateResult = {
     metadataJson: "",
@@ -160,7 +165,13 @@ export async function generateCustomFunctionsMetadata(
         generateResults.errors.forEach((err) => console.error(err));
       }
     } else {
-      generateResults.metadataJson = JSON.stringify({ functions: parseTreeResult.functions }, null, 4);
+      const customFunctionsMetadata: ICustomFunctionsMetadata = {
+        functions: parseTreeResult.functions,
+      };
+      if (metadataOptions?.allowErrorForDataTypeAny != null)
+        customFunctionsMetadata.allowErrorForDataTypeAny = metadataOptions.allowErrorForDataTypeAny;
+
+      generateResults.metadataJson = JSON.stringify(customFunctionsMetadata, null, 4);
       generateResults.associate = [...parseTreeResult.associate];
     }
   } else {

--- a/packages/custom-functions-metadata/test/src/test.ts
+++ b/packages/custom-functions-metadata/test/src/test.ts
@@ -63,9 +63,10 @@ describe("test javascript file as input", function() {
     describe("js test", function() {
         it("basic test", async function() {
             const inputFile = "./test/javascript/testjs.js";
-            const results = await generateCustomFunctionsMetadata(inputFile, true);
+            const results = await generateCustomFunctionsMetadata(inputFile, true, { allowErrorForDataTypeAny: true });
             const j = JSON.parse(results.metadataJson);
 
+            assert.strictEqual(j.allowErrorForDataTypeAny, true, "additional parameter not created properly");
             assert.strictEqual(j.functions[0].id, "TESTADD", "id not created properly");
             assert.strictEqual(j.functions[0].name, "TESTADD", "name not created properly");
             assert.strictEqual(j.functions[0].description, "This function is testing add", "description not created properly");


### PR DESCRIPTION
We should be able to set up [additional properties](https://docs.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-json#metadata-reference) (like `allowErrorForDataTypeAny`) in the JSON metadata file using `custom-functions-metadata-plugin`.
Soon we could also add `allowCustomDataForDataTypeAny` (the property is currently available in public preview).