### PR TITLE
[minor] Improve generic type js streaming

### DIFF
--- a/packages/custom-functions-metadata/.vscode/launch.json
+++ b/packages/custom-functions-metadata/.vscode/launch.json
@@ -18,7 +18,7 @@
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
             "args": [
               "-u",
-              "tdd",
+              "bdd",
               "--timeout",
               "999999",
               "--colors",

--- a/packages/custom-functions-metadata/package-lock.json
+++ b/packages/custom-functions-metadata/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "custom-functions-metadata",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "MIT",
       "dependencies": {
         "assert": "^1.5.0",
         "commander": "^6.2.0",
         "nconf": "^0.12.0",
-        "office-addin-usage-data": "^1.4.8",
+        "office-addin-usage-data": "^1.4.9",
         "xregexp": "^4.3.0"
       },
       "bin": {
@@ -20,14 +20,14 @@
       },
       "devDependencies": {
         "@types/assert": "^1.4.6",
-        "@types/mocha": "^7.0.2",
+        "@types/mocha": "^9.1.1",
         "@types/node": "^14.17.2",
         "@types/node-fetch": "^2.5.10",
         "@types/xregexp": "^3.0.30",
         "concurrently": "^6.2.2",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^2.0.2",
-        "office-addin-prettier-config": "^1.1.6",
+        "office-addin-lint": "^2.0.3",
+        "office-addin-prettier-config": "^1.1.7",
         "rimraf": "^3.0.2",
         "ts-node": "^10.1.0",
         "typescript": "^4.3.5"
@@ -43,13 +43,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
-      "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.0.tgz",
+      "integrity": "sha512-81YO9gGx6voPXlvYdZBliFXAZU8vZ9AZ6z+CjlmcnaeOcYSFbMTpdeDUO9xD9dh/68Vq03I8ZspfUTPfitcDHg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.17.10",
-        "@jridgewell/gen-mapping": "^0.1.0",
+        "@babel/types": "^7.18.0",
+        "@jridgewell/gen-mapping": "^0.3.0",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
-      "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-AqDccGC+m5O/iUStSJy3DGRIUFu7WbY/CppZYwrEUB4N0tZlnI8CSTsgL7v5fHVFmUbRv2sd+yy27o8Ydt4MGg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -247,19 +247,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
-      "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.0.tgz",
+      "integrity": "sha512-oNOO4vaoIQoGjDQ84LgtF/IAlxlyqL4TUuoQ7xLkQETFaHkY1F7yazhB4Kt3VcZGL0ZF/jhrEpnXqUb0M7V3sw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.10",
+        "@babel/generator": "^7.18.0",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.17.9",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.10",
-        "@babel/types": "^7.17.10",
+        "@babel/parser": "^7.18.0",
+        "@babel/types": "^7.18.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
-      "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -373,14 +373,24 @@
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
+      "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -399,6 +409,16 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
       "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
       "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -472,9 +492,9 @@
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -1306,9 +1326,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
-      "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -1330,7 +1350,7 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.4.1",
+        "regexp.prototype.flags": "^1.4.3",
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
@@ -1458,9 +1478,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.0.2.tgz",
-      "integrity": "sha512-hTUn0L+47hrwL6iIXeF9NPtfI82eo0fRjASAuYMfXR+Ub2FMJVSyRY99nOyGbPo2mK4uNBIJLCUCEEzWXbMZrA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.0.3.tgz",
+      "integrity": "sha512-CnJ21LKaevYde3gc5T9j3HUOv/dCYmtcVanj3/arV5gLvqgMo5aNSGLri8/Nl9ThJe5+VwKh8eI9anvCFqMcXw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -1471,7 +1491,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.6",
+        "office-addin-prettier-config": "^1.1.7",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -1523,25 +1543,25 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.29.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
-      "integrity": "sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
+      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flatmap": "^1.2.5",
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.0",
+        "object.hasown": "^1.1.1",
         "object.values": "^1.1.5",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.6"
+        "string.prototype.matchall": "^4.0.7"
       },
       "engines": {
         "node": ">=4"
@@ -2794,9 +2814,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.1.tgz",
+      "integrity": "sha512-Y/jF6vnvEtOPGiKD1+q+X0CiUYRQtEHp89MLLUJ7TUivtH8Ugn2+3A7Rynqk7BRsAoqeOQWnFnjpDrKSxDgIGA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2891,9 +2911,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.0.2.tgz",
-      "integrity": "sha512-J7E0Roe1WKgxtJmIBR6AyCMy6PaD11YQQ5sqcmqoU0UIsO+VwoTr6tOEI3JWdwfxIXhinDfp+l4N7oV86iMWjg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.0.3.tgz",
+      "integrity": "sha512-IEHk9dxMq7vIMNErijYOmvK8q+z/BtTfSIFOut1GHBHf/Nfp1WZdtBN8BiQRIhi7jmJ94ESnGJElkhg++JcElw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -2901,10 +2921,10 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^2.0.2",
+        "eslint-plugin-office-addins": "^2.0.3",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-prettier-config": "^1.1.6",
-        "office-addin-usage-data": "^1.4.8",
+        "office-addin-prettier-config": "^1.1.7",
+        "office-addin-usage-data": "^1.4.9",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -2912,15 +2932,15 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.6.tgz",
-      "integrity": "sha512-y+3gbWK0Efmhn9hXP7hhegS2M1DYJ377FOCig2PKEulLvBX2VAMTyvX2jlBl5lD5p5HAT440LIUOYO6MHn/9Iw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.7.tgz",
+      "integrity": "sha512-fN7MdTscnJWaehL7hwwo4MMJOukeCNBf6hqrtPOcDAPFscKcAm0DVErQlPE4G8FaiXhTrPUXQvSuWmcWR889kg==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.8.tgz",
-      "integrity": "sha512-hxQwNuQ6f2D7/dSPsnp53g3sxJ4Ifmu4k9G2QLXzKYxsPFVvrFfEAJyryWaiTVNV1DVA2NryFHt/wlfZADjRcw==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.9.tgz",
+      "integrity": "sha512-pi9qDRl2xYzMILkAxd2wYVlDdifEn2x7IEsp8c/+2Ks4A5aZY42S2C0Omz7UVImR6bynVUuNbKV1y7LYXIDodQ==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
@@ -3945,13 +3965,13 @@
       }
     },
     "@babel/generator": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
-      "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.0.tgz",
+      "integrity": "sha512-81YO9gGx6voPXlvYdZBliFXAZU8vZ9AZ6z+CjlmcnaeOcYSFbMTpdeDUO9xD9dh/68Vq03I8ZspfUTPfitcDHg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.17.10",
-        "@jridgewell/gen-mapping": "^0.1.0",
+        "@babel/types": "^7.18.0",
+        "@jridgewell/gen-mapping": "^0.3.0",
         "jsesc": "^2.5.1"
       }
     },
@@ -4068,9 +4088,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
-      "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-AqDccGC+m5O/iUStSJy3DGRIUFu7WbY/CppZYwrEUB4N0tZlnI8CSTsgL7v5fHVFmUbRv2sd+yy27o8Ydt4MGg==",
       "dev": true
     },
     "@babel/runtime-corejs3": {
@@ -4105,19 +4125,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
-      "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.0.tgz",
+      "integrity": "sha512-oNOO4vaoIQoGjDQ84LgtF/IAlxlyqL4TUuoQ7xLkQETFaHkY1F7yazhB4Kt3VcZGL0ZF/jhrEpnXqUb0M7V3sw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.10",
+        "@babel/generator": "^7.18.0",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.17.9",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.10",
-        "@babel/types": "^7.17.10",
+        "@babel/parser": "^7.18.0",
+        "@babel/types": "^7.18.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -4140,9 +4160,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
-      "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -4211,14 +4231,21 @@
       "dev": true
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
+      "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
       "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.1",
@@ -4231,6 +4258,16 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
       "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
       "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4295,9 +4332,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "@types/node": {
@@ -4897,9 +4934,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
-      "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -4921,7 +4958,7 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.4.1",
+        "regexp.prototype.flags": "^1.4.3",
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
@@ -5058,9 +5095,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.0.2.tgz",
-      "integrity": "sha512-hTUn0L+47hrwL6iIXeF9NPtfI82eo0fRjASAuYMfXR+Ub2FMJVSyRY99nOyGbPo2mK4uNBIJLCUCEEzWXbMZrA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.0.3.tgz",
+      "integrity": "sha512-CnJ21LKaevYde3gc5T9j3HUOv/dCYmtcVanj3/arV5gLvqgMo5aNSGLri8/Nl9ThJe5+VwKh8eI9anvCFqMcXw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.31.0",
@@ -5071,7 +5108,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-native": "^3.11.0",
-        "office-addin-prettier-config": "^1.1.6",
+        "office-addin-prettier-config": "^1.1.7",
         "prettier": "^2.4.0",
         "requireindex": "~1.2.0",
         "typescript": "^4.4.2"
@@ -5098,25 +5135,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.29.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
-      "integrity": "sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
+      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flatmap": "^1.2.5",
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.0",
+        "object.hasown": "^1.1.1",
         "object.values": "^1.1.5",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.6"
+        "string.prototype.matchall": "^4.0.7"
       },
       "dependencies": {
         "doctrine": {
@@ -5979,9 +6016,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.1.tgz",
+      "integrity": "sha512-Y/jF6vnvEtOPGiKD1+q+X0CiUYRQtEHp89MLLUJ7TUivtH8Ugn2+3A7Rynqk7BRsAoqeOQWnFnjpDrKSxDgIGA==",
       "dev": true
     },
     "object-keys": {
@@ -6046,9 +6083,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.0.2.tgz",
-      "integrity": "sha512-J7E0Roe1WKgxtJmIBR6AyCMy6PaD11YQQ5sqcmqoU0UIsO+VwoTr6tOEI3JWdwfxIXhinDfp+l4N7oV86iMWjg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.0.3.tgz",
+      "integrity": "sha512-IEHk9dxMq7vIMNErijYOmvK8q+z/BtTfSIFOut1GHBHf/Nfp1WZdtBN8BiQRIhi7jmJ94ESnGJElkhg++JcElw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^4.20.0",
@@ -6056,23 +6093,23 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^2.0.2",
+        "eslint-plugin-office-addins": "^2.0.3",
         "eslint-plugin-prettier": "^3.3.1",
-        "office-addin-prettier-config": "^1.1.6",
-        "office-addin-usage-data": "^1.4.8",
+        "office-addin-prettier-config": "^1.1.7",
+        "office-addin-usage-data": "^1.4.9",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-prettier-config": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.6.tgz",
-      "integrity": "sha512-y+3gbWK0Efmhn9hXP7hhegS2M1DYJ377FOCig2PKEulLvBX2VAMTyvX2jlBl5lD5p5HAT440LIUOYO6MHn/9Iw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.1.7.tgz",
+      "integrity": "sha512-fN7MdTscnJWaehL7hwwo4MMJOukeCNBf6hqrtPOcDAPFscKcAm0DVErQlPE4G8FaiXhTrPUXQvSuWmcWR889kg==",
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.8.tgz",
-      "integrity": "sha512-hxQwNuQ6f2D7/dSPsnp53g3sxJ4Ifmu4k9G2QLXzKYxsPFVvrFfEAJyryWaiTVNV1DVA2NryFHt/wlfZADjRcw==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.4.9.tgz",
+      "integrity": "sha512-pi9qDRl2xYzMILkAxd2wYVlDdifEn2x7IEsp8c/+2Ks4A5aZY42S2C0Omz7UVImR6bynVUuNbKV1y7LYXIDodQ==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",

--- a/packages/custom-functions-metadata/package.json
+++ b/packages/custom-functions-metadata/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/assert": "^1.4.6",
-    "@types/mocha": "^7.0.2",
+    "@types/mocha": "^9.1.1",
     "@types/node": "^14.17.2",
     "@types/node-fetch": "^2.5.10",
     "@types/xregexp": "^3.0.30",

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/expected.json
@@ -1,0 +1,22 @@
+{
+    "functions": [
+        {
+            "description": "Test function for streaming type",
+            "id": "STREAMINGTEST",
+            "name": "STREAMINGTEST",
+            "options": {
+                "stream": true
+            },
+            "parameters": [
+                {
+                    "name": "x",
+                    "type": "string"
+                }
+            ],
+            "result": {
+                "dimensionality": "matrix",
+                "type": "string"
+            }
+        }
+    ]
+}

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/functions.js
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/functions.js
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test function for streaming type
+ * @param x {string}
+ * @param invocation {CustomFunctions.StreamingInvocation<string[][]>}
+ * @customfunction
+ */
+function streamingTest(x, invocation) {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/functions.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test function for streaming type
+ * @param x
+ * @param invocation
+ * @customfunction
+ */
+function streamingTest(x: string, invocation: CustomFunctions.StreamingInvocation<string[][]>) {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/expected.json
@@ -1,0 +1,21 @@
+{
+    "functions": [
+        {
+            "description": "Test function for streaming type",
+            "id": "STREAMINGTEST",
+            "name": "STREAMINGTEST",
+            "options": {
+                "stream": true
+            },
+            "parameters": [
+                {
+                    "name": "x",
+                    "type": "string"
+                }
+            ],
+            "result": {
+                "type": "string"
+            }
+        }
+    ]
+}

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/functions.js
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/functions.js
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test function for streaming type
+ * @param x {string}
+ * @param invocation {CustomFunctions.StreamingInvocation<string[]>}
+ * @customfunction
+ */
+function streamingTest(x, invocation) {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/functions.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test function for streaming type
+ * @param x
+ * @param invocation
+ * @customfunction
+ */
+function streamingTest(x: string, invocation: CustomFunctions.StreamingInvocation<string[]>) {
+    // Empty
+}


### PR DESCRIPTION
**Change Description**:

    The support for streaming function meta data was limited in the case of generics in js to a table of specific subtypes.  This adjusts the js comment parsing to look at the type string more to allow for the use of arrays in the type and adjust the lookup to find object properties instead of just simple types

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    No.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    No.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Tried it manually, used the debugger, ran the tests, and added two tests for the new specific cases.
