### PR TITLE
[Patch] yo Office is now responsible for data writting

### DIFF
--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -99,16 +99,6 @@ export class OfficeAddinUsageData {
         this.options.usageDataLevel = jsonData.readUsageDataLevel(this.options.groupName);
       }
 
-      // Generator-office will not raise a prompt because the yeoman generator creates the prompt.  If the projectName
-      // is defaults.generatorOffice and a office-addin-usage-data file hasn't been written yet, write one out.
-      if (
-        this.options.projectName === defaults.generatorOffice &&
-        this.options.instrumentationKey === defaults.instrumentationKeyForOfficeAddinCLITools &&
-        jsonData.needToPromptForUsageData(this.options.groupName)
-      ) {
-        jsonData.writeUsageDataJsonData(this.options.groupName, this.options.usageDataLevel);
-      }
-
       if (
         !this.options.isForTesting &&
         this.options.raisePrompt &&


### PR DESCRIPTION
Usage data was wrongfully always setting usage-data for yo-office to "no" and not asking the client what they prefer.
Now, the responsibility of writing the usage-data level is on Generator Office and it will not be a special case in `office-addin-usage-data`.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    No


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    No

**Validation/testing performed**:
Tested and validated that Yo-Office now asks and raises data when accepted by the customer. Yo Office now asks if it can collect data and it doesn't assume it is a no.
