### PR TITLE
[patch] Improve dev server startup

### DIFF
--- a/packages/office-addin-debugging/src/port.ts
+++ b/packages/office-addin-debugging/src/port.ts
@@ -54,7 +54,7 @@ export function getProcessIdsForPort(port: number): Promise<number[]> {
   return new Promise((resolve, reject) => {
     const isWin32 = process.platform === "win32";
     const isLinux = process.platform === "linux";
-    const command = isWin32 ? `netstat -ano` : isLinux ? `netstat -tlpna | grep :${port}` : `lsof -n -i:${port}`;
+    const command = isWin32 ? `netstat -ano | findstr :${port}` : isLinux ? `netstat -tlpna | grep :${port}` : `lsof -n -i:${port}`;
 
     childProcess.exec(command, (error, stdout) => {
       if (error) {
@@ -71,7 +71,7 @@ export function getProcessIdsForPort(port: number): Promise<number[]> {
           lines.forEach((line) => {
             /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             const [protocol, localAddress, foreignAddress, status, processId] = line.split(" ").filter((text) => text);
-            if (processId !== undefined) {
+            if (processId !== undefined && processId !== '0') {
               const localAddressPort = parsePort(localAddress);
               if (localAddressPort === port) {
                 processIds.add(parseInt(processId, 10));

--- a/packages/office-addin-debugging/src/port.ts
+++ b/packages/office-addin-debugging/src/port.ts
@@ -54,7 +54,11 @@ export function getProcessIdsForPort(port: number): Promise<number[]> {
   return new Promise((resolve, reject) => {
     const isWin32 = process.platform === "win32";
     const isLinux = process.platform === "linux";
-    const command = isWin32 ? `netstat -ano | findstr :${port}` : isLinux ? `netstat -tlpna | grep :${port}` : `lsof -n -i:${port}`;
+    const command = isWin32
+      ? `netstat -ano | findstr :${port}`
+      : isLinux
+      ? `netstat -tlpna | grep :${port}`
+      : `lsof -n -i:${port}`;
 
     childProcess.exec(command, (error, stdout) => {
       if (error) {


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
When 'npm start' is run we check if the required port is already being used (bound to) and assume the dev server is already running if it is.  However it turns out that when an add-in is run in the host a whole bunch of port bindings to the same port are made and when the host is closed some of those bindings linger attached to pid 0 (the idle process) before finally getting cleaned up.  This has the effect of blocking 'npm start' while these bindings are waiting to be cleaned up.  It seems safe to ignore these bindings on pid 0 and allow 'npm start' to re-setup the dev server without having to wait so long.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Ran test suit.
