### PR TITLE
Fix OfficeMockObject not supporting dates. [patch] 

### DIFF
--- a/packages/office-addin-mock/src/officeMockObject.ts
+++ b/packages/office-addin-mock/src/officeMockObject.ts
@@ -50,10 +50,12 @@ export class OfficeMockObject {
    * Mock replacement for the sync method in the Office.js API
    */
   async sync() {
-    this._properties.forEach(async (property: OfficeMockObject, key: string) => {
-      await property.sync();
-      this.updatePropertyCall(key);
-    });
+    this._properties.forEach(
+      async (property: OfficeMockObject, key: string) => {
+        await property.sync();
+        this.updatePropertyCall(key);
+      }
+    );
     if (this._loaded) {
       this._value = this._valueBeforeLoaded;
     }
@@ -177,7 +179,11 @@ export class OfficeMockObject {
       const property = objectData[propertyName];
       const dataType: string = typeof property;
 
-      if (dataType === "object" && !Array.isArray(property)) {
+      if (
+        dataType === "object" &&
+        !Array.isArray(property) &&
+        !(property instanceof Date)
+      ) {
         this.addMock(propertyName);
         this[propertyName].populate(property);
       } else {

--- a/packages/office-addin-mock/test/officeMockObject.test.ts
+++ b/packages/office-addin-mock/test/officeMockObject.test.ts
@@ -27,7 +27,8 @@ const testObjectOutlook = {
     font: {
       size: 12,
       type: "arial"
-    }
+    },
+    date: new Date("2022-06-29T11:32:11.447Z"),
   },
   host: "outlook",
 }
@@ -121,7 +122,7 @@ describe("Test OfficeMockObject class", function() {
 
       officeMock.range.address = "C2";
       assert.strictEqual(officeMock.range.address, "C2");
-  
+
       officeMock.range.font.color = "blue";
       assert.strictEqual(officeMock.range.font.color, "blue");
     });
@@ -174,7 +175,7 @@ describe("Test OfficeMockObject class", function() {
       officeMock.load("range/font/size");
       await officeMock.sync();
       assert.strictEqual(officeMock.range.font.size, 12);
-  
+
       assert.throws(() => officeMock.load("range/notANavigational/size"));
       assert.throws(() => officeMock.load("notANavigational/font/size"));
     });
@@ -231,7 +232,7 @@ describe("Test OfficeMockObject class", function() {
       const ContextMockData = {
         items: [ { text: 'A' }, {text2: 'B' } ],
       };
-  
+
       const context = new OfficeMockObject(ContextMockData) as any;
       context.load( { items: [ { text: 'A' }, { text2: 'B' } ] } );
       await context.sync();
@@ -249,6 +250,11 @@ describe("Test OfficeMockObject class", function() {
       assert.strictEqual(officeMock.range.color, "blue");
       assert.strictEqual(officeMock.range.font.size, 12);
       assert.strictEqual(officeMock.range.getColor(), "blue");
+      assert.strictEqual(
+        officeMock.range.date.getTime(),
+        new Date("2022-06-29T11:32:11.447Z").getTime()
+      );
+
     });
     it("Invalid load calls", async function() {
       const officeMock = new OfficeMockObject(testObjectOutlook);


### PR DESCRIPTION
**Description**:

    Currently OfficeMockObject has no support for dates. It would treat a Date as an object to traverse, adding a OfficeMockObject in place of the date.
    I found this issue while working in a Outlook add-in, trying to stub a date in `context.mailbox.item.dateTimeCreated`

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    If Yes, briefly describe what is impacted.

```
It has no impacts.
```

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.

```
It has no impacts.
```

**Validation/testing performed**:

    I have added a unit test to validate correct behaviour.
    I have confirmed this works in the Outlook add-in I'm working on using a stub object like:
    
```javascript
const stub = {
    context: {
      mailbox: {
        item: {
          dateTimeCreated: new Date('2022-06-29T08:58:44.769Z'),
        },
      },
    },
  };
```