### PR TITLE
Don't flag *OrNullObject as needing load calls

### DIFF
--- a/packages/eslint-plugin-office-addins/src/rules/load-object-before-read.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/load-object-before-read.ts
@@ -6,7 +6,7 @@ import {
 } from "@typescript-eslint/utils/dist/ts-eslint-scope";
 import { parseLoadArguments, isLoadFunction } from "../utils/load";
 import { findPropertiesRead } from "../utils/utils";
-import { isGetFunction } from "../utils/getFunction";
+import { isGetFunction, isGetOrNullObjectFunction } from "../utils/getFunction";
 
 export = {
   name: "load-object-before-read",
@@ -61,7 +61,11 @@ export = {
           ) {
             getFound = false; // In case of reassignment
 
-            if (node.parent.init && isGetFunction(node.parent.init)) {
+            if (
+              node.parent.init &&
+              isGetFunction(node.parent.init) &&
+              !isGetOrNullObjectFunction(node.parent.init)
+            ) {
               getFound = true;
               return;
             }
@@ -72,7 +76,10 @@ export = {
           ) {
             getFound = false; // In case of reassignment
 
-            if (isGetFunction(node.parent.right)) {
+            if (
+              isGetFunction(node.parent.right) &&
+              !isGetOrNullObjectFunction(node.parent.right)
+            ) {
               getFound = true;
               return;
             }

--- a/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
@@ -121,6 +121,15 @@ ruleTester.run('load-object-before-read', rule, {
         console.log(range.format.fill.color);
         console.log(range.address);`
     },
+    {
+      code: `
+        const range = context.workbook.getSelectedRange();
+        const first = range.getCell(0, 0);
+        const spillParent = first.getSpillParentOrNullObject();
+        await context.sync();
+        const cell = spillParent.isNullObject ? first : spillParent;
+        console.log(cell);`
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
A customer pointed out that the *OrNullObject calls don't require a "load()" call, but we are flagging them as needing it in our linter rules (https://github.com/OfficeDev/Office-Addin-Scripts/issues/671).  The removes those methods from the checking and adds a test to verify

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Added a test for it and tried it out in a template case.