### PR TITLE
[patch] Check for icon file path before zipping

### DIFF
--- a/packages/office-addin-manifest/src/export.ts
+++ b/packages/office-addin-manifest/src/export.ts
@@ -38,8 +38,13 @@ async function createZip(manifestPath: string = "manifest.json"): Promise<AdmZip
 function addIconFile(iconPath: string, zip: AdmZip) {
   if (iconPath && !iconPath.startsWith("https://")) {
     const filePath: string = path.resolve(iconPath);
+    const fileDir: string = path.dirname(iconPath);
     if (fs.existsSync(filePath)) {
-      zip.addLocalFile(iconPath, path.dirname(iconPath));
+      if (!!fileDir && fileDir != ".") {
+        zip.addLocalFile(iconPath, fileDir);
+      } else {
+        zip.addLocalFile(iconPath);
+      }
     } else {
       console.log(`Icon File ${filePath} does not exist`);
     }


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
Icons without a path weren't being zipped correctly.  Add a case to check for that and zip file w/out dir.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Linked to template code and test zip package as well and test with test json in the same project.  Ran tests.