### PR TITLE
[Patch] Deleting old .xml manifest

### DIFF
--- a/packages/office-addin-project/src/convert.ts
+++ b/packages/office-addin-project/src/convert.ts
@@ -40,7 +40,7 @@ export async function convertProject(
   try {
     await convert(manifestPath, outputPath, false, false);
     updatePackages();
-    await updateManifestXmlReferences();
+    await updateManifestXmlReferences(manifestPath);
   } catch (err: any) {
     console.log(`Error in conversion. Restoring project initial state.`);
     await restoreBackup(backupPath);
@@ -116,7 +116,9 @@ function updatePackages(): void {
   execSync(command);
 }
 
-async function updateManifestXmlReferences(): Promise<void> {
+async function updateManifestXmlReferences(
+  manifestPath: string
+): Promise<void> {
   const packageJson = `./package.json`;
   const readFileAsync = util.promisify(fs.readFile);
   const data = await readFileAsync(packageJson, "utf8");
@@ -132,4 +134,5 @@ async function updateManifestXmlReferences(): Promise<void> {
   // write updated json to file
   const writeFileAsync = util.promisify(fs.writeFile);
   await writeFileAsync(packageJson, JSON.stringify(content, null, 2));
+  fs.unlinkSync(manifestPath);
 }

--- a/packages/office-addin-project/src/convert.ts
+++ b/packages/office-addin-project/src/convert.ts
@@ -40,7 +40,8 @@ export async function convertProject(
   try {
     await convert(manifestPath, outputPath, false, false);
     updatePackages();
-    await updateManifestXmlReferences(manifestPath);
+    await updateManifestXmlReferences();
+    fs.unlinkSync(manifestPath);
   } catch (err: any) {
     console.log(`Error in conversion. Restoring project initial state.`);
     await restoreBackup(backupPath);
@@ -116,9 +117,7 @@ function updatePackages(): void {
   execSync(command);
 }
 
-async function updateManifestXmlReferences(
-  manifestPath: string
-): Promise<void> {
+async function updateManifestXmlReferences(): Promise<void> {
   const packageJson = `./package.json`;
   const readFileAsync = util.promisify(fs.readFile);
   const data = await readFileAsync(packageJson, "utf8");
@@ -134,5 +133,4 @@ async function updateManifestXmlReferences(
   // write updated json to file
   const writeFileAsync = util.promisify(fs.writeFile);
   await writeFileAsync(packageJson, JSON.stringify(content, null, 2));
-  fs.unlinkSync(manifestPath);
 }


### PR DESCRIPTION
Deleting the `.xml` manifest after the main conversion is done.

---

**Change Description**:

    Describe what the PR is about. 

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Testing conversion of the project and notice the `.xml` manifest is removed even if is not in the root of the project.
