### PR TITLE
[patch] Add optional chaining to manifest array objects.

### DIFF
--- a/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
+++ b/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
@@ -54,8 +54,8 @@ export class ManifestHandlerJson extends ManifestHandler {
     manifestInfo.highResolutionIconUrl = teamsAppManifest?.icons?.color;
     manifestInfo.hosts = extensionElement?.requirements?.scopes;
     manifestInfo.iconUrl = teamsAppManifest?.icons?.color;
-    manifestInfo.officeAppType = extensionElement?.requirements?.capabilities[0]?.name;
-    manifestInfo.permissions = teamsAppManifest?.authorization?.permissions?.resourceSpecific[0]?.name;
+    manifestInfo.officeAppType = extensionElement?.requirements?.capabilities?.[0]?.name;
+    manifestInfo.permissions = teamsAppManifest?.authorization?.permissions?.resourceSpecific?.[0]?.name;
     manifestInfo.providerName = teamsAppManifest?.developer?.name;
     manifestInfo.supportUrl = teamsAppManifest?.developer?.websiteUrl;
     manifestInfo.version = teamsAppManifest?.version;


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
Fix bug with trying to parse a json manifest that doesn't have an optional array property by using optional chaining check.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Tried it out with manifest from project manifest that was converted to json.  Also ran automated tests locally.