### PR TITLE
[patch] Fix project convert to update webpack

### DIFF
--- a/packages/office-addin-project/src/convert.ts
+++ b/packages/office-addin-project/src/convert.ts
@@ -118,6 +118,11 @@ function updatePackages(): void {
 }
 
 async function updateManifestXmlReferences(): Promise<void> {
+  await updatePackageJson();
+  await updateWebpackConfig();
+}
+
+async function updatePackageJson(): Promise<void> {
   const packageJson = `./package.json`;
   const readFileAsync = util.promisify(fs.readFile);
   const data = await readFileAsync(packageJson, "utf8");
@@ -130,7 +135,21 @@ async function updateManifestXmlReferences(): Promise<void> {
       `manifest.json`
     );
   });
+
   // write updated json to file
   const writeFileAsync = util.promisify(fs.writeFile);
   await writeFileAsync(packageJson, JSON.stringify(content, null, 2));
+}
+
+async function updateWebpackConfig(): Promise<void> {
+  const weppackConfig = `./webpack.config.js`;
+  const readFileAsync = util.promisify(fs.readFile);
+  const data = await readFileAsync(weppackConfig, "utf8");
+
+  // switching to json extension is the easy fix.
+  // TODO: update to remove the manifest copy plugin since it's not needed in webpack
+  let content = data.replace(/"(manifest\*\.)xml"/gi, "\"$1json\"");
+
+  const writeFileAsync = util.promisify(fs.writeFile);
+  await writeFileAsync(weppackConfig, content);
 }


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
The code to convert a project from xml manifest to json manifest deletes the xml manifest at the end, but webpack.config is still trying to copy it during debugging, and this throws an error.  This will do a simple fix to webpack.config to change the copy to do the json manifest instead.  A better fix would be to remove that part of the webpack config, but that is far more complex and we need a simple solution now.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
ran automated tests.  Also tried converting a sample project created with current 'yo office' command.