### PR TITLE
[minor] office-addin-dev-certs: add --domains option to install

### DIFF
--- a/packages/office-addin-dev-certs/src/cli.ts
+++ b/packages/office-addin-dev-certs/src/cli.ts
@@ -20,6 +20,7 @@ commander
     "--days <days>",
     `Specifies the validity of CA certificate in days. Default: ${defaults.daysUntilCertificateExpires}`
   )
+  .option("--domains <domains>", "List of IP address and domains separated by commas.")
   .description(`Generate an SSL certificate for "localhost" issued by a CA certificate which is installed.`)
   .action(commands.install);
 

--- a/packages/office-addin-dev-certs/src/generate.ts
+++ b/packages/office-addin-dev-certs/src/generate.ts
@@ -17,7 +17,8 @@ export async function generateCertificates(
   caCertificatePath: string = defaults.caCertificatePath,
   localhostCertificatePath: string = defaults.localhostCertificatePath,
   localhostKeyPath: string = defaults.localhostKeyPath,
-  daysUntilCertificateExpires: number = defaults.daysUntilCertificateExpires
+  daysUntilCertificateExpires: number = defaults.daysUntilCertificateExpires,
+  domains: string[] = defaults.domain
 ) {
   try {
     fsExtra.ensureDirSync(path.dirname(caCertificatePath));
@@ -44,7 +45,7 @@ export async function generateCertificates(
   const localhostCertificateInfo: mkcert.CertificateInfo = {
     caCert: caCertificate.cert,
     caKey: caCertificate.key,
-    domains: defaults.domain,
+    domains,
     validityDays: daysUntilCertificateExpires,
   };
   let localhostCertificate: mkcert.Certificate;

--- a/packages/office-addin-dev-certs/src/install.ts
+++ b/packages/office-addin-dev-certs/src/install.ts
@@ -31,6 +31,7 @@ function getInstallCommand(caCertificatePath: string, machine: boolean = false):
 
 export async function ensureCertificatesAreInstalled(
   daysUntilCertificateExpires: number = defaults.daysUntilCertificateExpires,
+  domains: string[] = defaults.domain,
   machine: boolean = false
 ) {
   try {
@@ -47,7 +48,8 @@ export async function ensureCertificatesAreInstalled(
         defaults.caCertificatePath,
         defaults.localhostCertificatePath,
         defaults.localhostKeyPath,
-        daysUntilCertificateExpires
+        daysUntilCertificateExpires,
+        domains
       );
       await installCaCertificate(defaults.caCertificatePath, machine);
     }


### PR DESCRIPTION
This adds --domains as an option to the office-addin-dev-certs install command.

This allows the set of domains to be customized if needed. By default, the domains are "127.0.0.1" and "localhost".

An example where customization is useful is if "localhost" is not allowed as a domain name. You can map a different name to the local port, but the SSL certificate needs to have that name listed.

For example, on Windows, the hosts file can map "dev-host" to 127.0.0.1 (IPv4) and ::1 (IPv6) by adding these lines to %systemroot%\system32\drivers\etc\hosts:

127.0.0.1 	dev-host
::1		dev-host

Then, use the --domains option to specify the IP addresses and host names:

office-addin-dev-certs install --domains 127.0.0.1,::1,localhost,dev-host

Opening the browser to https://dev-host will show that the SSL certificate is valid.


1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
Yes, 


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

1. I validated the default behavior of "office-addin-dev-certs install" is unchanged. 
2. I validated that with the --domains option added, the SSL certificate has those domains listed. 
    For example: office-addin-dev-certs install --domains 127.0.0.1.::1,localhost,dev-host
3. I also validated the browser shows the url https://dev-host contains a valid SSL certificate and is trusted.
