### PR TITLE
[minor] Allow for sideloading an existing json registration

### DIFF
--- a/packages/office-addin-dev-settings/src/cli.ts
+++ b/packages/office-addin-dev-settings/src/cli.ts
@@ -68,6 +68,7 @@ commander
   .description("Launch Office with the Office Add-in loaded.")
   .option("-a,--app <app>", `The Office app to launch. ("Excel", "Outlook", "PowerPoint", or "Word")`)
   .option("-d,--document <document>", `The file path or url of the Office document to open.`)
+  .option("--registration <registration>", `Id of the registered json add-in`)
   .action(commands.sideload)
   .on("--help", () => {
     console.log("\n[app-type] specifies the type of Office app::\n");

--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -375,8 +375,9 @@ export async function sideload(manifestPath: string, type: string | undefined, c
     const canPrompt = true;
     const document: string | undefined = command.document ? command.document : undefined;
     const appType: AppType | undefined = parseAppType(type || process.env.npm_package_config_app_platform_to_debug);
+    const registration: string = command.registration;
 
-    await sideloadAddIn(manifestPath, app, canPrompt, appType, document);
+    await sideloadAddIn(manifestPath, app, canPrompt, appType, document, registration);
     usageDataObject.reportSuccess("sideload");
   } catch (err: any) {
     usageDataObject.reportException("sideload", err);

--- a/packages/office-addin-dev-settings/src/dev-settings-windows.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-windows.ts
@@ -178,13 +178,15 @@ function isRegistryValueTrue(value?: registry.RegistryValue): boolean {
   return false;
 }
 
-export async function registerAddIn(manifestPath: string): Promise<void> {
+export async function registerAddIn(manifestPath: string, registration?: string): Promise<void> {
   const manifest: ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestPath);
 
   if (manifestPath.endsWith(".json")) {
-    const targetPath: string = fspath.join(process.env.TEMP as string, "manifest.zip");
-    const zipPath: string = await exportMetadataPackage(targetPath, manifestPath);
-    const registration = await registerWithTeams(zipPath);
+    if (!registration) {
+      const targetPath: string = fspath.join(process.env.TEMP as string, "manifest.zip");
+      const zipPath: string = await exportMetadataPackage(targetPath, manifestPath);
+      registration = await registerWithTeams(zipPath);
+    }
 
     const key = getDeveloperSettingsRegistryKey(OutlookSideloadManifestPath);
     await registry.addStringValue(key, TitleId, registration);

--- a/packages/office-addin-dev-settings/src/dev-settings-windows.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-windows.ts
@@ -27,6 +27,7 @@ const SourceBundleExtension: string = "SourceBundleExtension";
 const SourceBundleHost: string = "SourceBundleHost";
 const SourceBundlePath: string = "SourceBundlePath";
 const SourceBundlePort: string = "SourceBundlePort";
+const TitleId: string = "TitleId";
 const UseDirectDebugger: string = "UseDirectDebugger";
 const UseLiveReload: string = "UseLiveReload";
 const UseProxyDebugger: string = "UseWebDebugger";
@@ -178,14 +179,15 @@ function isRegistryValueTrue(value?: registry.RegistryValue): boolean {
 }
 
 export async function registerAddIn(manifestPath: string): Promise<void> {
-  let data = manifestPath; // xml will store the manifest path and json will store the titleId
   const manifest: ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestPath);
 
   if (manifestPath.endsWith(".json")) {
     const targetPath: string = fspath.join(process.env.TEMP as string, "manifest.zip");
     const zipPath: string = await exportMetadataPackage(targetPath, manifestPath);
+    const registration = await registerWithTeams(zipPath);
 
-    data = await registerWithTeams(zipPath);
+    const key = getDeveloperSettingsRegistryKey(OutlookSideloadManifestPath);
+    await registry.addStringValue(key, TitleId, registration);
   } else if (manifestPath.endsWith(".xml")) {
     const appsInManifest = getOfficeAppsForManifestHosts(manifest.hosts);
 
@@ -196,7 +198,7 @@ export async function registerAddIn(manifestPath: string): Promise<void> {
   const key = new registry.RegistryKey(`${DeveloperSettingsRegistryKey}`);
 
   await registry.deleteValue(key, manifestPath); // in case the manifest path was previously used as the key
-  return registry.addStringValue(key, manifest.id || "", data);
+  return registry.addStringValue(key, manifest.id || "", manifestPath);
 }
 
 export async function setSourceBundleUrl(addinId: string, components: SourceBundleUrlComponents): Promise<void> {
@@ -305,8 +307,13 @@ export async function unregisterAllAddIns(): Promise<void> {
 }
 
 async function unacquire(key: registry.RegistryKey, id: string) {
-  const regValue = await registry.getValue(key, id);
-  if (regValue != undefined && !regValue.data.endsWith(".xml")) {
-    unacquireWithTeams(regValue.data);
+  const manifest = await registry.getStringValue(key, id);
+  if (manifest != undefined && manifest.endsWith(".json")) {
+    const key = getDeveloperSettingsRegistryKey(OutlookSideloadManifestPath);
+    const registration = await registry.getStringValue(key, TitleId);
+    if (registration != undefined) {
+      unacquireWithTeams(registration);
+      registry.deleteValue(key, TitleId);
+    }
   }
 }

--- a/packages/office-addin-dev-settings/src/dev-settings.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings.ts
@@ -224,11 +224,11 @@ export async function isLiveReloadEnabled(addinId: string): Promise<boolean> {
   }
 }
 
-export async function registerAddIn(manifestPath: string): Promise<void> {
+export async function registerAddIn(manifestPath: string, registration?: string): Promise<void> {
   switch (process.platform) {
     case "win32": {
       const realManifestPath = fs.realpathSync(manifestPath);
-      return devSettingsWindows.registerAddIn(realManifestPath);
+      return devSettingsWindows.registerAddIn(realManifestPath, registration);
     }
     case "darwin":
       return devSettingsMac.registerAddIn(manifestPath);

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -301,7 +301,8 @@ export async function sideloadAddIn(
   app?: OfficeApp,
   canPrompt: boolean = false,
   appType?: AppType,
-  document?: string
+  document?: string,
+  registration?: string
 ): Promise<void> {
   try {
     if (appType === undefined) {
@@ -347,7 +348,7 @@ export async function sideloadAddIn(
 
     switch (appType) {
       case AppType.Desktop:
-        await registerAddIn(manifestPath);
+        await registerAddIn(manifestPath, registration);
         await launchDesktopApp(app, manifest, document);
         break;
       case AppType.Web: {

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -17,7 +17,6 @@ import open = require("open");
 import semver = require("semver");
 import * as os from "os";
 import * as path from "path";
-import * as util from "util";
 import { AppType } from "./appType";
 import { registerAddIn } from "./dev-settings";
 import { startDetachedProcess } from "./process";
@@ -26,9 +25,7 @@ import * as registry from "./registry";
 import { usageDataObject } from "./defaults";
 import { ExpectedError } from "office-addin-usage-data";
 
-/* global process, __dirname, URL, console */
-
-const readFileAsync = util.promisify(fs.readFile);
+/* global __dirname, Buffer, console, process, URL */
 
 /**
  * Create an Office document in the temporary files directory
@@ -117,14 +114,10 @@ export async function generateSideloadFile(app: OfficeApp, manifest: ManifestInf
 export async function generateSideloadUrl(
   manifestFileName: string,
   manifest: ManifestInfo,
-  documentUrl: string | undefined,
+  documentUrl: string,
   isTest: boolean = false
-): Promise<string | undefined> {
+): Promise<string> {
   const testQueryParam = "&wdaddintest=true";
-
-  if (documentUrl === undefined || documentUrl === "") {
-    return undefined;
-  }
 
   if (!manifest.id) {
     throw new ExpectedError("The manifest does not contain the id for the add-in.");
@@ -244,11 +237,15 @@ async function getOutlookVersion(): Promise<string | undefined> {
   }
 }
 
-async function getOutlookExePath(): Promise<string | undefined> {
+async function getOutlookExePath(): Promise<string> {
   try {
     const OutlookInstallPathRegistryKey: string = `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\OUTLOOK.EXE`;
     const key = new registry.RegistryKey(`${OutlookInstallPathRegistryKey}`);
     const outlookExePath: string | undefined = await registry.getStringValue(key, "");
+
+    if (!outlookExePath) {
+      throw new Error("Outlook.exe registry empty");
+    }
 
     return outlookExePath;
   } catch (err) {
@@ -324,7 +321,6 @@ export async function sideloadAddIn(
 
     const manifest: ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestPath);
     const appsInManifest: OfficeApp[] = getOfficeAppsForManifestHosts(manifest.hosts);
-    const isTest: boolean = process.env.WEB_SIDELOAD_TEST !== undefined;
 
     if (app) {
       if (appsInManifest.indexOf(app) < 0) {
@@ -349,55 +345,20 @@ export async function sideloadAddIn(
       throw new ExpectedError("Please specify the Office app.");
     }
 
-    let sideloadFile: string | undefined;
-
     switch (appType) {
       case AppType.Desktop:
-        if (!isSideloadingSupportedForDesktopHost(app)) {
-          throw new ExpectedError(`Sideload to the ${getOfficeAppName(app)} app is not supported.`);
-        }
-
-        // do the registration
         await registerAddIn(manifestPath);
-        // for Outlook, open Outlook.exe; for other Office apps, open the document
-        if (app == OfficeApp.Outlook) {
-          const version: string | undefined = await getOutlookVersion();
-          if (version && !hasOfficeVersion("16.0.13709", version)) {
-            throw new ExpectedError(
-              `The current version of Outlook does not support sideload. Please use version 16.0.13709 or greater.`
-            );
-          }
-          sideloadFile = await getOutlookExePath();
-        } else {
-          sideloadFile = await generateSideloadFile(app, manifest, document);
-        }
+        await launchDesktopApp(app, manifest, document);
         break;
       case AppType.Web: {
         if (!document) {
           throw new ExpectedError(`For sideload to web, you need to specify a document url.`);
         }
-        if (!isSideloadingSupportedForWebHost(app)) {
-          throw new ExpectedError(`Sideload to the ${getOfficeAppName(app)} web app is not supported.`);
-        }
-        const manifestFileName: string = path.basename(manifestPath);
-        sideloadFile = await generateSideloadUrl(manifestFileName, manifest, document, isTest);
+        await launchWebApp(app, manifestPath, manifest, document);
         break;
       }
       default:
         throw new ExpectedError("Sideload is not supported for the specified app type.");
-    }
-
-    if (sideloadFile) {
-      if (app === OfficeApp.Outlook) {
-        // put the Outlook.exe path in quotes if it contains spaces
-        if (sideloadFile.indexOf(" ") >= 0) {
-          sideloadFile = `"${sideloadFile}"`;
-        }
-
-        startDetachedProcess(sideloadFile);
-      } else {
-        await open(sideloadFile, { wait: false });
-      }
     }
     usageDataObject.reportSuccess("sideloadAddIn()");
   } catch (err: any) {
@@ -450,7 +411,7 @@ async function convertJsonToXmlManifest(manifestPath: string): Promise<string> {
   });
 }
 
-export default function stripBom(manifestPath: string) {
+function stripBom(manifestPath: string) {
   try {
     if (fs.existsSync(manifestPath)) {
       const fileData: string = fs.readFileSync(manifestPath, "utf8");
@@ -469,4 +430,48 @@ export default function stripBom(manifestPath: string) {
 
 function canSideloadJson(): boolean {
   return !!process.env.SIDELOADING_SERVICE_ENDPOINT && !!process.env.SIDELOADING_SERVICE_SCOPE;
+}
+
+async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document?: string) {
+  if (!isSideloadingSupportedForDesktopHost(app)) {
+    throw new ExpectedError(`Sideload to the ${getOfficeAppName(app)} app is not supported.`);
+  }
+
+  // for Outlook, open Outlook.exe; for other Office apps, open the document
+  if (app == OfficeApp.Outlook) {
+    const version: string | undefined = await getOutlookVersion();
+    if (version && !hasOfficeVersion("16.0.13709", version)) {
+      throw new ExpectedError(
+        `The current version of Outlook does not support sideload. Please use version 16.0.13709 or greater.`
+      );
+    }
+    await launchApp(app, await getOutlookExePath());
+  } else {
+    await launchApp(app, await generateSideloadFile(app, manifest, document));
+  }
+}
+
+async function launchWebApp(app: OfficeApp, manifestPath: string, manifest: ManifestInfo, document: string) {
+  if (!isSideloadingSupportedForWebHost(app)) {
+    throw new ExpectedError(`Sideload to the ${getOfficeAppName(app)} web app is not supported.`);
+  }
+  const manifestFileName: string = path.basename(manifestPath);
+  const isTest: boolean = process.env.WEB_SIDELOAD_TEST !== undefined;
+  await launchApp(app, await generateSideloadUrl(manifestFileName, manifest, document, isTest));
+}
+
+async function launchApp(app: OfficeApp, sideloadFile: string) {
+  console.log(`Launching ${app} via ${sideloadFile}`);
+  if (sideloadFile) {
+    if (app === OfficeApp.Outlook) {
+      // put the Outlook.exe path in quotes if it contains spaces
+      if (sideloadFile.indexOf(" ") >= 0) {
+        sideloadFile = `"${sideloadFile}"`;
+      }
+
+      startDetachedProcess(sideloadFile);
+    } else {
+      await open(sideloadFile, { wait: false });
+    }
+  }
 }


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
There will be times when we want to debug a json manifest project that has already been registered.  To allow for this I've refactored the code to separate add-in registration from host loading, updated the registry key that is used by outlook to determine sideloading, and added an argument that indicates the id of an existing registration.  When this is integrated into other tooling they will be able to provide the existing registration id and use our tooling to start localhost and the add-in host. 

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
Yes.  Added an option to provide a registration id

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
Maybe.  May want to document the new option.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran tests and used the debugger to verify code paths for registration.
