### PR TITLE
Fixed powershell compatibility and robustness issues

### DIFF
--- a/packages/office-addin-dev-certs/scripts/install.ps1
+++ b/packages/office-addin-dev-certs/scripts/install.ps1
@@ -2,9 +2,17 @@ if($args.Count -ne 2){
     throw "Usage: install.ps1 <LocalMachine | CurrentUser> <CA-certificate-path>"
 }
 
+# Without this, the script always succeeds (exit code = 0)
+$ErrorActionPreference = 'Stop'
+
 $machine = $args[0]
 $caCertificatePath=$args[1]
 if(Get-Command -name Import-Certificate -ErrorAction SilentlyContinue){
+    if ($PSVersionTable.PSVersion.Major -le 5) {
+        # The following line is required in case pwsh is one of the parent callers
+        # because the changes it makes to PSModulePath are not backward compatible with Windows powershell.
+        $env:PSModulePath = [Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
+    }
     Import-Certificate -CertStoreLocation cert:\\$machine\\Root ${caCertificatePath}
 }
 else{

--- a/packages/office-addin-dev-certs/scripts/uninstall.ps1
+++ b/packages/office-addin-dev-certs/scripts/uninstall.ps1
@@ -2,9 +2,17 @@ if($args.Count -ne 2){
     throw "Usage: uninstall.ps1 <LocalMachine | CurrentUser> <CA-certficate-name>"
 }
 
+# Without this, the script always succeeds (exit code = 0)
+$ErrorActionPreference = 'Stop'
+
 $machine = $args[0]
 $caCertificateName=$args[1]
 if(Get-Command -name Import-Certificate -ErrorAction SilentlyContinue){
+    if ($PSVersionTable.PSVersion.Major -le 5) {
+        # The following line is required in case pwsh is one of the parent callers
+        # because the changes it makes to PSModulePath are not backward compatible with Windows powershell.
+        $env:PSModulePath = [Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
+    }
     Get-ChildItem  cert:\\$machine\\Root | Where-Object { $_.IssuerName.Name -like "*CN=$caCertificateName*" } |  Remove-Item
 }
 else{

--- a/packages/office-addin-dev-certs/scripts/verify.ps1
+++ b/packages/office-addin-dev-certs/scripts/verify.ps1
@@ -1,12 +1,63 @@
-if($args.Count -ne 1){
-    throw "Usage: verify.ps1 <CA-certficate-name>"
+Param (
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $CaCertificateName,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $CaCertificatePath,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $LocalhostCertificatePath,
+
+    [switch]
+    $ReturnInvalidCertificate
+)
+
+# Without this, the script always succeeds (exit code = 0)
+$ErrorActionPreference = 'Stop'
+
+if ($PSVersionTable.PSVersion.Major -le 5) {
+    # The following line is required in case pwsh is one of the parent callers
+    # because the changes it makes to PSModulePath are not backward compatible with Windows powershell.
+    $env:PSModulePath = [Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
 }
 
-$caCertificateName=$args[0]
 if(Get-Command -name Import-Certificate -ErrorAction SilentlyContinue){
-    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object Issuer -like "*CN=$caCertificateName*" | Where-Object { $_.NotAfter -gt [datetime]::today.AddDays(-1) } | Format-List
+    $result = Get-ChildItem cert:\\CurrentUser\\Root | Where-Object Issuer -like "*CN=$CaCertificateName*"
+    if (!$ReturnInvalidCertificate) {
+        $result = $result | Where-Object { $_.NotAfter -gt [datetime]::today.AddDays(-1) }
+        if ($result -and ($result.Length -eq 1) -and (Test-Path $CaCertificatePath) -and (Test-Path $LocalhostCertificatePath)) {
+            # Check that CA certificate in store is the same as ca.crt
+            $caCert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CaCertificatePath)
+            $caThumbprint = $caCert.Thumbprint
+
+            $result = $result | Where-Object Thumbprint -eq $caThumbprint
+
+            if ($result) {
+                # Check that it matches the issuer of localhost.crt
+                $localhostCert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($LocalhostCertificatePath)
+
+                $localhostChain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+                $localhostChain.Build($localhostCert) | Out-Null
+                $localhostTrustedIssuer = $localhostChain.ChainElements.Certificate | Where-Object { $_.Subject -eq $localhostCert.Issuer -and $_.Thumbprint -eq $caThumbprint }
+                if (!$localhostTrustedIssuer) {
+                    $result = $null
+                }
+            }
+        }
+        else {
+            $result = $null
+        }
+    }
+
+    $result | Format-List
 }
 else{
     # Legacy system support
-    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object { $_.Subject -like "*CN=$caCertificateName*"} | Where-Object { $_.NotAfter -gt [datetime]::today.AddDays(-1) } | Format-List
+    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object { $_.Subject -like "*CN=$CaCertificateName*"} | Where-Object { $_.NotAfter -gt [datetime]::today.AddDays(-1) } | Format-List
 }

--- a/packages/office-addin-dev-certs/src/uninstall.ts
+++ b/packages/office-addin-dev-certs/src/uninstall.ts
@@ -45,7 +45,7 @@ export function deleteCertificateFiles(certificateDirectory: string = defaults.c
 }
 
 export async function uninstallCaCertificate(machine: boolean = false, verbose: boolean = true) {
-  if (isCaCertificateInstalled()) {
+  if (isCaCertificateInstalled(/* returnInvalidCertificate */ true)) {
     const command = getUninstallCommand(machine);
 
     try {

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -16,9 +16,9 @@ function getVerifyCommand(returnInvalidCertificate: boolean): string {
     case "win32": {
       const script = path.resolve(__dirname, "..\\scripts\\verify.ps1");
       const defaultCommand = `powershell -ExecutionPolicy Bypass -File "${script}" -CaCertificateName "${defaults.certificateName}" -CaCertificatePath "${defaults.caCertificatePath}" -LocalhostCertificatePath "${defaults.localhostCertificatePath}"`;
-			if (returnInvalidCertificate) {
-				return defaultCommand + ` -ReturnInvalidCertificate`
-			}
+      if (returnInvalidCertificate) {
+        return defaultCommand + ` -ReturnInvalidCertificate`
+      }
       return defaultCommand;
     }
     case "darwin": {

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -11,11 +11,15 @@ import { ExpectedError } from "office-addin-usage-data";
 
 /* global process, Buffer, __dirname */
 
-function getVerifyCommand(): string {
+function getVerifyCommand(returnInvalidCertificate: boolean): string {
   switch (process.platform) {
     case "win32": {
       const script = path.resolve(__dirname, "..\\scripts\\verify.ps1");
-      return `powershell -ExecutionPolicy Bypass -File "${script}" "${defaults.certificateName}"`;
+      const defaultCommand = `powershell -ExecutionPolicy Bypass -File "${script}" -CaCertificateName "${defaults.certificateName}" -CaCertificatePath "${defaults.caCertificatePath}" -LocalhostCertificatePath "${defaults.localhostCertificatePath}"`;
+			if (returnInvalidCertificate) {
+				return defaultCommand + ` -ReturnInvalidCertificate`
+			}
+      return defaultCommand;
     }
     case "darwin": {
       // macOS
@@ -29,8 +33,8 @@ function getVerifyCommand(): string {
   }
 }
 
-export function isCaCertificateInstalled(): boolean {
-  const command = getVerifyCommand();
+export function isCaCertificateInstalled(returnInvalidCertificate: boolean = false): boolean {
+  const command = getVerifyCommand(returnInvalidCertificate);
 
   try {
     const output = execSync(command, { stdio: "pipe" }).toString();


### PR DESCRIPTION
Change Description:

Let's start with robustness issues: no error handling was implemented in powershell scripts. There are executed through execSync, which throws if the error code is not 0. We want execSync to fail if the script fails. See
https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.3#erroractionpreference

CA certificate validation was only checking expiration date, which is not enough to prevent dev environment corruption (certificate mismatch, duplication, ...). The following checkings have been added:
- CA certificate in store must match ca.crt
- This certificate must match the issuer of localhost.crt

There was also an issue in clean-up logic. Both verify and uninstall are relying on isCaCertificateInstalled. Since this function only returned valid certificates, uninstall was never triggered.

Do these changes impact *command syntax* of any of the packages? (e.g., add/remove command, add/remove a command parameter, or update required parameters)

No.


Do these changes impact *documentation*? (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)

No.

Validation/testing performed:

Tested from cmd, powershell (Windows powershell) and pwsh (Powershell 7).
