### PR TITLE
fixes 718 for OSX

### DIFF
--- a/packages/office-addin-dev-certs/src/install.ts
+++ b/packages/office-addin-dev-certs/src/install.ts
@@ -21,7 +21,9 @@ function getInstallCommand(caCertificatePath: string, machine: boolean = false):
       } "${caCertificatePath}"`;
     }
     case "darwin": // macOS
-      return `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain '${caCertificatePath}'`;
+      const prefix = machine ? "sudo " : ""
+      const keychainFile = machine ? "/Library/Keychains/System.keychain" : "~/Library/Keychains/login.keychain-db"
+      return `${prefix}security add-trusted-cert -d -r trustRoot -k ${keychainFile} '${caCertificatePath}'`;
     case "linux":
       return `sudo mkdir -p /usr/local/share/ca-certificates/office-addin-dev-certs && sudo cp ${caCertificatePath} /usr/local/share/ca-certificates/office-addin-dev-certs && sudo /usr/sbin/update-ca-certificates`;
     default:


### PR DESCRIPTION
**Change Description**:

This is a fix for issue #718 that works on OSX. It should still be fixed for Linux, but I'm not able currently to test it thoroughly.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
   No impact on the command syntax, but it will make the `use-machine` flag more effective.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    Probably, it should be now described that `use-machine` will impact the certificates installed, not sure though.

**Validation/testing performed**:

Tested on dummy local repository and on actual add-in I'm working on currently.