### PR TITLE
[minor] Fix validate endpoint error message when site is down

### DIFF
--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -148,7 +148,9 @@ export async function validate(
   try {
     const verifyProduction: boolean = command.production;
     const validation: ManifestValidation = await validateManifest(manifestPath, verifyProduction);
-    if (validation.report) {
+    if (validation.status && validation.status != 200) {
+      console.log(`Unable to validate the manifest.\n${validation.status}`);
+    } else if (validation.report) {
       logManifestValidationInfos(validation.report.notes);
       logManifestValidationErrors(validation.report.errors);
       logManifestValidationWarnings(validation.report.warnings);

--- a/packages/office-addin-manifest/src/commands.ts
+++ b/packages/office-addin-manifest/src/commands.ts
@@ -149,7 +149,7 @@ export async function validate(
     const verifyProduction: boolean = command.production;
     const validation: ManifestValidation = await validateManifest(manifestPath, verifyProduction);
     if (validation.status && validation.status != 200) {
-      console.log(`Unable to validate the manifest.\n${validation.status}`);
+      console.log(`Unable to validate the manifest.\n${validation.status}\n${validation.statusText}`);
     } else if (validation.report) {
       logManifestValidationInfos(validation.report.notes);
       logManifestValidationErrors(validation.report.errors);

--- a/packages/office-addin-manifest/src/validate.ts
+++ b/packages/office-addin-manifest/src/validate.ts
@@ -56,6 +56,7 @@ export class ManifestValidation {
   public isValid: boolean;
   public report?: ManifestValidationReport;
   public status?: number;
+  public statusText?: string;
 
   constructor() {
     this.isValid = false;
@@ -108,6 +109,7 @@ export async function validateManifest(
       }
 
       validation.status = response.status;
+      validation.statusText = response.statusText
 
       const text = await response.text();
 

--- a/packages/office-addin-manifest/src/validate.ts
+++ b/packages/office-addin-manifest/src/validate.ts
@@ -109,7 +109,7 @@ export async function validateManifest(
       }
 
       validation.status = response.status;
-      validation.statusText = response.statusText
+      validation.statusText = response.statusText;
 
       const text = await response.text();
 

--- a/packages/office-addin-manifest/src/validate.ts
+++ b/packages/office-addin-manifest/src/validate.ts
@@ -107,13 +107,16 @@ export async function validateManifest(
         throw new Error(`Unable to contact the manifest validation service.\n${err}`);
       }
 
-      const text = await response.text();
-      const json = JSON.parse(text.trim());
+      validation.status = response.status;
 
-      if (json) {
-        validation.report = json;
-        validation.status = response.status;
-      }
+      const text = await response.text();
+
+      try {
+        const json = JSON.parse(text.trim());
+        if (json) {
+          validation.report = json;
+        }
+      } catch {} // eslint-disable-line no-empty
 
       if (validation.report) {
         const result = validation.report.status;


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
If the validation endpoint is unreachable (status other then 200) then we error with a json parsing error which is confusing to customers.  This will capture the status and message, not throw on a json parsing error, and then log the error to the customer to say the site is unreachable.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
ran validation tests.