### PR TITLE
upgrade[patch]: @microsoft/teamsfx-cli to v1.2.1

### DIFF
--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -22,7 +22,7 @@
     "Office Add-in"
   ],
   "dependencies": {
-    "@microsoft/teamsfx-cli": "1.1.5",
+    "@microsoft/teamsfx-cli": "1.2.1",
     "adm-zip": "^0.5.9",
     "commander": "^6.2.0",
     "fs-extra": "^9.0.1",

--- a/packages/office-addin-sso/package.json
+++ b/packages/office-addin-sso/package.json
@@ -31,7 +31,7 @@
     "form-urlencoded": "3.0.0",
     "http-errors": "~1.6.3",
     "jquery": "^3.5.1",
-    "jsonwebtoken": "8.5.1",
+    "jsonwebtoken": "9.0.0",
     "jwks-rsa": "2.1.4",
     "morgan": "1.9.1",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
resolves security vulnerability from jsonwebtoken package < 9.0.0

**Change Description**:

package upgrade which also resolves security vulnerability from an older version of the jsonwebtoken package.

I am unsure what to do with the lock files? 

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

I ran test suite
