### PR TITLE
[patch] Fix mock empty load

### DIFF
--- a/packages/office-addin-mock/src/officeMockObject.ts
+++ b/packages/office-addin-mock/src/officeMockObject.ts
@@ -33,7 +33,10 @@ export class OfficeMockObject {
     }
     let properties: string[] = [];
 
-    if (typeof propertyArgument === "string") {
+    if (propertyArgument === undefined) { 
+      // an empty load call mean load all properties
+      properties = ["*"];
+    } else if (typeof propertyArgument === "string") {
       properties = Array(propertyArgument);
     } else if (Array.isArray(propertyArgument)) {
       properties = propertyArgument;

--- a/packages/office-addin-mock/test/officeMockObject.test.ts
+++ b/packages/office-addin-mock/test/officeMockObject.test.ts
@@ -200,6 +200,12 @@ describe("Test OfficeMockObject class", function() {
       await officeMock.sync();
       assert.strictEqual(officeMock.range.getColor(), "blue");
     });
+    it("Load with no arguments", async function() {
+      const officeMock = new OfficeMockObject(testObject);
+      officeMock.range.load();
+      await officeMock.sync();
+      assert.strictEqual(officeMock.range.getColor(), "blue");
+    });
     it("Load navigational property", async function() {
       const contextMock = new OfficeMockObject(contextMockData);
       contextMock.workbook.range.load("format/fill");


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
The mock doesn't handle calls to the load method that doesn't have any arguments.  This should be the same as a call to load with a "*" as an argument.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Tried it out on a test project.  Added and automated test.  Ran automated tests.