### PR TITLE
[minor] Update name of manifest file in zip to always be "manifest.json"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       },
       "engines": {
         "node": ">=16 <19",
-        "npm": ">=6 <9"
+        "npm": ">=6 <=9"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/packages/office-addin-manifest/src/export.ts
+++ b/packages/office-addin-manifest/src/export.ts
@@ -23,7 +23,7 @@ async function createZip(manifestPath: string = "manifest.json"): Promise<AdmZip
   const zip: AdmZip = new AdmZip();
 
   if (fs.existsSync(manifestPath)) {
-    zip.addLocalFile(manifestPath);
+    zip.addLocalFile(manifestPath, "", "manifest.json");
   } else {
     throw new Error(`The file '${manifestPath}' does not exist`);
   }

--- a/packages/office-addin-manifest/test/manifests/manifest.local.json
+++ b/packages/office-addin-manifest/test/manifests/manifest.local.json
@@ -1,0 +1,545 @@
+{
+  "$schema": "http://zlatkom2:32080/metaos/schema/metaos.public.schema.json#",
+  "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  "version": "1.0.0",
+  "manifestVersion": "m365DevPreview",
+  "name": {
+    "short": "Contoso Task Pane Add-in",
+    "full": "Contoso Task Pane Add-in"
+  },
+  "description": {
+    "short": "A template to get started.",
+    "full": "This is the template to get started."
+  },
+  "developer": {
+    "name": "Contoso",
+    "websiteUrl": "https://www.contoso.com",
+    "privacyUrl": "https://www.contoso.com/privacy",
+    "termsOfUseUrl": "https://www.contoso.com/servicesagreement"
+  },
+  "icons": {
+    "outline": "test/assets/icon-64.png",
+    "color": "test/assets/icon-128.png"
+  },
+  "accentColor": "#230201",
+  "localizationInfo": {
+    "defaultLanguageTag": "en-us",
+    "additionalLanguages": []
+  },
+  "authorization": {
+    "permissions": {
+      "resourceSpecific": [
+        {
+          "name": "Mailbox.ReadWrite",
+          "type": "Delegated"
+        }
+      ]
+    }
+  },
+  "validDomains": ["contoso.com"],
+  "extensions": [
+    {
+      "requirements": {
+        "scopes": ["mail"],
+        "capabilities": [
+          { "name": "AddinCommands", "minVersion": "1.1" },
+          { "name": "Mailbox", "minVersion": "1.10" }
+        ]
+      },
+      "getStartedMessages": [
+        {
+          "requirements": {
+            "formFactors": ["desktop"]
+          },
+          "title": "Get Started",
+          "description": "Your sample add-in loaded succesfully. Click the buttons to get started.",
+          "learnMoreUrl": "https://www.contoso.com/learnmore"
+        }
+      ],
+      "runtimes": [
+        {
+          "requirements": {
+            "capabilities": [{ "name": "MailBox", "minVersion": "1.10" }]
+          },
+          "id": "mail",
+          "type": "general",
+          "code": {
+            "page": "https://localhost:3000/taskpane.html",
+            "script": "https://localhost:3000/taskpane.js"
+          },
+          "lifetime": "short",
+          "actions": [
+            {
+              "id": "mail.onMessageSending",
+              "type": "executeFunction"
+            },
+            {
+              "id": "mail.onNewMessageComposeCreated",
+              "type": "executeFunction"
+            }
+          ]
+        },
+        {
+          "id": "ShowTaskpane",
+          "type": "general",
+          "code": {
+            "page": "https://localhost:3000/taskpane.html"
+          },
+          "lifetime": "short",
+          "actions": [
+            {
+              "id": "ShowTaskpane.show",
+              "type": "openPage",
+              "view": "",
+              "pinnable": false
+            }
+          ]
+        }
+      ],
+      "contextMenus": [
+        {
+          "menus": [
+            {
+              "type": "cell",
+              "controls": [
+                {
+                  "id": "menuForCell",
+                  "type": "menu",
+                  "label": "Menu",
+                  "icons": [
+                    { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                    { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                    { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                  ],
+                  "supertip": {
+                    "title": "Change text case",
+                    "description": "This allow you to change text to lowercase or uppercase."
+                  },
+                  "items": [
+                    {
+                      "id": "menu.uppercase",
+                      "type": "menuItem",
+                      "label": "To uppercase",
+                      "supertip": {
+                        "title": "Change text to uppercase",
+                        "description": "This will change the text to uppercase."
+                      },
+                      "actionId": "mail.toUppercase"
+                    },
+                    {
+                      "id": "menu.lowercase",
+                      "type": "menuItem",
+                      "label": "To lowercase",
+                      "supertip": {
+                        "title": "Change text to lowercase",
+                        "description": "This will change the text to lowercase."
+                      },
+                      "actionId": "mail.toLowercase"
+                    }
+                  ]
+                },
+                {
+                  "id": "showDashboard",
+                  "type": "button",
+                  "label": "Show dashboard",
+                  "icons": [
+                    { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                    { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                    { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                  ],
+                  "supertip": {
+                    "title": "Show dashboard",
+                    "description": "click to open dashboard"
+                  },
+                  "actionId": "mail.showDashboard"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "controls": [
+                {
+                  "id": "menuForText",
+                  "type": "menu",
+                  "label": "Menu",
+                  "icons": [
+                    { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                    { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                    { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                  ],
+                  "supertip": {
+                    "title": "Change text case",
+                    "description": "This allow you to change text to lowercase or uppercase."
+                  },
+                  "items": [
+                    {
+                      "id": "menu.uppercase",
+                      "type": "menuItem",
+                      "label": "To uppercase",
+                      "supertip": {
+                        "title": "Change text to uppercase",
+                        "description": "This will change the text to uppercase."
+                      },
+                      "actionId": "mail.toUppercase"
+                    },
+                    {
+                      "id": "menu.lowercase",
+                      "type": "menuItem",
+                      "label": "To lowercase",
+                      "supertip": {
+                        "title": "Change text to lowercase",
+                        "description": "This will change the text to lowercase."
+                      },
+                      "actionId": "mail.toLowercase"
+                    }
+                  ]
+                },
+                {
+                  "id": "showDashboard",
+                  "type": "button",
+                  "label": "Show dashboard",
+                  "icons": [
+                    { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                    { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                    { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                  ],
+                  "supertip": {
+                    "title": "Show dashboard",
+                    "description": "click to open dashboard"
+                  },
+                  "actionId": "mail.showDashboard"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "ribbons": [
+        {
+          "contexts": ["default"],
+          "tabs": [
+            {
+              "builtInTabId": "TabDefault",
+              "groups": [
+                {
+                  "id": "dashboard",
+                  "label": "Controls",
+                  "icons": [
+                    { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                    { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                    { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                  ],
+                  "controls": [
+                    {
+                      "id": "uppercase",
+                      "type": "button",
+                      "label": "To uppercase",
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Change text to uppercase",
+                        "description": "This will change the text to uppercase."
+                      },
+                      "actionId": "mail.toUppercase"
+                    },
+                    {
+                      "id": "lowercase",
+                      "type": "button",
+                      "label": "To lowercase",
+                      "enabled": false,
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Change text to lowercase",
+                        "description": "This will change the text to lowercase."
+                      },
+                      "actionId": "mail.toLowercase"
+                    },
+                    {
+                      "id": "menu",
+                      "type": "menu",
+                      "label": "Menu",
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Change text case",
+                        "description": "This allow you to change text to lowercase or uppercase."
+                      },
+                      "items": [
+                        {
+                          "id": "menu.uppercase",
+                          "type": "menuItem",
+                          "label": "To uppercase",
+                          "enabled": false,
+                          "icons": [
+                            { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                            { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                            { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                          ],
+                          "supertip": {
+                            "title": "Change text to uppercase",
+                            "description": "This will change the text to uppercase."
+                          },
+                          "actionId": "mail.toUppercase"
+                        },
+                        {
+                          "id": "menu.lowercase",
+                          "type": "menuItem",
+                          "label": "To lowercase",
+                          "supertip": {
+                            "title": "Change text to lowercase",
+                            "description": "This will change the text to lowercase."
+                          },
+                          "actionId": "mail.toLowercase",
+                          "overriddenByRibbonApi": true
+                        }
+                      ]
+                    },
+                    {
+                      "id": "showDashboard",
+                      "type": "button",
+                      "label": "Show dashboard",
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Show dashboard",
+                        "description": "click to open dashboard"
+                      },
+                      "actionId": "mail.showDashboard",
+                      "overriddenByRibbonApi": true
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "contexts": ["mailCompose"],
+          "tabs": [
+            {
+              "builtInTabId": "TabDefault",
+              "groups": [
+                {
+                  "id": "dashboard",
+                  "label": "Controls",
+                  "controls": [
+                    {
+                      "id": "uppercase",
+                      "type": "button",
+                      "label": "To uppercase",
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Change text to uppercase",
+                        "description": "This will change the text to uppercase."
+                      },
+                      "actionId": "mail.toUppercase"
+                    },
+                    {
+                      "id": "lowercase",
+                      "type": "button",
+                      "label": "To lowercase",
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Change text to lowercase",
+                        "description": "This will change the text to lowercase."
+                      },
+                      "actionId": "mail.toLowercase"
+                    },
+                    {
+                      "id": "menu",
+                      "type": "menu",
+                      "label": "Menu",
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Change text case",
+                        "description": "This allow you to change text to lowercase or uppercase."
+                      },
+                      "items": [
+                        {
+                          "id": "menu.uppercase",
+                          "type": "menuItem",
+                          "label": "To uppercase",
+                          "supertip": {
+                            "title": "Change text to uppercase",
+                            "description": "This will change the text to uppercase."
+                          },
+                          "actionId": "mail.toUppercase"
+                        },
+                        {
+                          "id": "menu.lowercase",
+                          "type": "menuItem",
+                          "label": "To lowercase",
+                          "icons": [
+                            { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                            { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                            { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                          ],
+                          "supertip": {
+                            "title": "Change text to lowercase",
+                            "description": "This will change the text to lowercase."
+                          },
+                          "actionId": "mail.toLowercase"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "showDashboard",
+                      "type": "button",
+                      "label": "Show dashboard",
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Show dashboard",
+                        "description": "click to open dashboard"
+                      },
+                      "actionId": "mail.showDashboard"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "contexts": ["mailRead"],
+          "tabs": [
+            {
+              "builtInTabId": "TabDefault",
+              "groups": [
+                {
+                  "id": "dashboard",
+                  "label": "Controls",
+                  "controls": [
+                    {
+                      "id": "showDashboard",
+                      "type": "button",
+                      "label": "Show dashboard",
+                      "icons": [
+                        { "size": 16, "file": "https://localhost:3000/assets/icon-16.png" },
+                        { "size": 32, "file": "https://localhost:3000/assets/icon-32.png" },
+                        { "size": 80, "file": "https://localhost:3000/assets/icon-80.png" }
+                      ],
+                      "supertip": {
+                        "title": "Show dashboard",
+                        "description": "click to open dashboard"
+                      },
+                      "actionId": "mail.showDashboard"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "keyboards": [
+        {
+          "requirements": {
+            "capabilities": [{ "name": "SharedRuntime", "minVersion": "1.1" }],
+            "platforms": ["windows", "web"]
+          },
+          "shortcuts": [
+            {
+              "key": "Ctrl+Shift+U",
+              "actionId": "mail.toUppercase"
+            },
+            {
+              "key": "Ctrl+Shift+L",
+              "actionId": "mail.toLowercase"
+            },
+            {
+              "key": "Ctrl+Shift+Up",
+              "actionId": "mail.showDashboard"
+            }
+          ]
+        },
+        {
+          "requirements": {
+            "capabilities": [{ "name": "SharedRuntime", "minVersion": "1.1" }],
+            "platforms": ["mac"]
+          },
+          "shortcuts": [
+            {
+              "key": "Command+Shift+U",
+              "actionId": "mail.toUppercase"
+            },
+            {
+              "key": "Command+Shift+L",
+              "actionId": "mail.toLowercase"
+            },
+            {
+              "key": "Command+Shift+Up",
+              "actionId": "mail.showDashboard"
+            }
+          ]
+        }
+      ],
+      "autoRunEvents": [
+        {
+          "requirements": {
+            "capabilities": [{ "name": "MailBox", "minVersion": "1.10" }]
+          },
+          "events": [
+            {
+              "type": "newMessageComposeCreated",
+              "actionId": "mail.onNewMessageComposeCreated"
+            },
+            {
+              "type":"messageSending",
+              "actionId": "mail.onMessageSending",
+              "options": {
+                "sendMode": "promptUser"
+              }
+            }
+          ]
+        }
+      ],
+      "alternates": [
+        {
+          "requirements": {
+            "scopes": ["mail"]
+          },
+          "prefer": {
+            "comAddin": {
+              "progId": "ContosoExtension"
+            }
+          },
+          "hide": {
+            "storeOfficeAddin": {
+              "officeAddinId": "fca2794d-4aa5-4023-a84b-c60a3cbd33d4",
+              "assetId": "WA129485"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as AdmZip from "adm-zip";
 import * as assert from "assert";
 import * as fs from "fs";
 import * as mocha from "mocha";
@@ -828,6 +829,20 @@ describe("Unit Tests", function() {
         assert.strictEqual(outputFile, expectedOutput, "Output path \'" + outputFile + "\' should match the default \'" + expectedOutput + "\'");
         assert.strictEqual(fs.existsSync(outputFile), true, "Output file \'" + outputFile + "\' should exist");
         
+        // Cleanup
+        fs.unlinkSync(outputFile);
+      });
+      it("export manifest with different name", async function() {
+        this.timeout(6000);
+        const manifestPath = path.normalize("test/manifests/manifest.local.json");
+        const expectedOutput = path.join(path.dirname(path.resolve(manifestPath)), "manifest.zip");
+        const outputFile = await exportMetadataPackage("", manifestPath);
+        assert.strictEqual(outputFile, expectedOutput, "Output path \'" + outputFile + "\' should match the default \'" + expectedOutput + "\'");
+        assert.strictEqual(fs.existsSync(outputFile), true, "Output file \'" + outputFile + "\' should exist");
+
+        const zip: AdmZip = new AdmZip(outputFile);
+        const entries = zip.getEntries().filter((entry) => { return entry.name == "manifest.json"});
+        assert.strictEqual(entries.length, 1, "Found manifest.json in zip file");
         // Cleanup
         fs.unlinkSync(outputFile);
       });


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
The export of a json manifest to a zip file was preserving the file name, but it turns out the service we send it to always expects "manifest.json" so changing the zip file creation to rename the manifest to "manifest.json".

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran automated tests and added a new test that looks for the specific name of the manifest file.