### PR TITLE
[Minor] Handle zipped manifests

### DIFF
--- a/packages/office-addin-debugging/package-lock.json
+++ b/packages/office-addin-debugging/package-lock.json
@@ -9,19 +9,21 @@
       "version": "4.6.7",
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.9",
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-cli": "^1.5.3",
-        "office-addin-dev-certs": "^1.11.0",
-        "office-addin-dev-settings": "^1.15.0",
-        "office-addin-manifest": "^1.11.0",
-        "office-addin-node-debugger": "^0.8.3",
-        "office-addin-usage-data": "^1.6.3"
+        "office-addin-cli": "^1.5.4",
+        "office-addin-dev-certs": "^1.11.1",
+        "office-addin-dev-settings": "^1.15.1",
+        "office-addin-manifest": "^1.12.0",
+        "office-addin-node-debugger": "^0.8.4",
+        "office-addin-usage-data": "^1.6.4"
       },
       "bin": {
         "office-addin-debugging": "cli.js"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.0",
         "@types/express": "^4.17.13",
         "@types/mocha": "^5.2.5",
         "@types/node": "^14.17.2",
@@ -30,7 +32,7 @@
         "concurrently": "^6.2.2",
         "express": "^4.17.3",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^2.2.3",
+        "office-addin-lint": "^2.2.4",
         "rimraf": "^2.7.1",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4",
@@ -812,12 +814,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.3.tgz",
-      "integrity": "sha512-Wl5ilw2UD1+ZYprHVprxHZJCFeBWlzZYOovE4SDYLZnqCOD11j+0QzNeEWKLLTWM7nixrZEh7vNIyb76MyJg3A==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -975,9 +977,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
+      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -998,14 +1000,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1024,19 +1026,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
+        "@babel/generator": "^7.20.7",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
+        "@babel/parser": "^7.20.13",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1089,9 +1091,9 @@
       "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -2215,6 +2217,15 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+      "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -2410,14 +2421,14 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
-      "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.49.0.tgz",
+      "integrity": "sha512-IhxabIpcf++TBaBa1h7jtOWyon80SXPRLDq0dVz5SLFC/eW6tofkw/O7Ar3lkx5z5U6wzbKDrl2larprp5kk5Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/type-utils": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/type-utils": "5.49.0",
+        "@typescript-eslint/utils": "5.49.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -2466,14 +2477,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
-      "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
+      "integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2516,13 +2527,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
-      "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
+      "integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1"
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2533,13 +2544,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
-      "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.49.0.tgz",
+      "integrity": "sha512-eUgLTYq0tR0FGU5g1YHm4rt5H/+V2IPVkP0cBmbhRyEmyGe4XvJ2YJ6sYTmONfjmdMqyMLad7SB8GvblbeESZA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/typescript-estree": "5.49.0",
+        "@typescript-eslint/utils": "5.49.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2583,9 +2594,9 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
-      "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
+      "integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2596,13 +2607,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
-      "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
+      "integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2646,16 +2657,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
-      "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
+      "integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -2672,12 +2683,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
-      "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
+      "integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
+        "@typescript-eslint/types": "5.49.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -3049,15 +3060,15 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -3097,6 +3108,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "node_modules/asap": {
@@ -4551,9 +4575,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -4563,9 +4587,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.3.tgz",
-      "integrity": "sha512-gBZoVOjU2tjSPBmwZE4xIIkkbBBsZAToKALE0LBYR6IgK4g4a/4+S8aFbqsE5W9quSHn8FyaT1DT4NFOhm5A1A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.4.tgz",
+      "integrity": "sha512-fs7qHWVirBJ23HQf07juSDz8csDyGChM2GnOZw9nuxhdPQdIB+zMTuHd1NKwL6kMvo/lCL1fy27pJBWYjag/cQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -4628,25 +4652,26 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.31.10",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz",
-      "integrity": "sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==",
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.1.tgz",
+      "integrity": "sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.5",
-        "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
-        "object.values": "^1.1.5",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.3",
+        "resolve": "^2.0.0-next.4",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
+        "string.prototype.matchall": "^4.0.8"
       },
       "engines": {
         "node": ">=4"
@@ -5096,9 +5121,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -7847,9 +7872,9 @@
       }
     },
     "node_modules/office-addin-cli": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.5.3.tgz",
-      "integrity": "sha512-GSTxPe8PP/8Q1HqQGT1D2cCb+MA95QPPoVVUluExVuO8kxVaRc0ZFvl7j3ehKJlKKUDJElsZ9OjiEQ0xCK7OBA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.5.4.tgz",
+      "integrity": "sha512-HRFV7/sjiSz6FKNSd1XNkXl/UUXh5CqbR5dCLdv9OuG7j95OOvMWE4g7AMwkSHIkKzY/7okWxQr/cEf1hBDGiw==",
       "dependencies": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -7860,24 +7885,24 @@
       }
     },
     "node_modules/office-addin-dev-certs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.11.0.tgz",
-      "integrity": "sha512-+A8fgx0bYLshcb6S3UMF6z2lv4YolvP6i1DdX9eEOsvuP27D3l8eLHTXK/O7FntahqFN4j8Y+IjK9Wg3Tr3RMA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.11.1.tgz",
+      "integrity": "sha512-nq38SYYqBtGyavgBx/WLvpBOWQTtbJUq0HsgXX9ofF3ac6UROGaZcs1pdePbvi25hjJqRGjdU2qC09MpJhkcwA==",
       "dependencies": {
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "mkcert": "^1.4.0",
-        "office-addin-cli": "^1.5.3",
-        "office-addin-usage-data": "^1.6.3"
+        "office-addin-cli": "^1.5.4",
+        "office-addin-usage-data": "^1.6.4"
       },
       "bin": {
         "office-addin-dev-certs": "cli.js"
       }
     },
     "node_modules/office-addin-dev-settings": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.15.0.tgz",
-      "integrity": "sha512-Q9aJKC0FzBi6AAxvBlO5tVXr2jxrK2KldiulyOyoSRxrsZjMVWvelZyXSF201nljC8dZiRdh4Lt/cDy6omqfiA==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.15.1.tgz",
+      "integrity": "sha512-6UluzPow4wxifMEx2XmKuF75SyOE7oqCSHWXafa3MlfeqKpl0B7S9sONh5A3PG0D2+Qrgky8JcrIm1eAOQXajQ==",
       "dependencies": {
         "@microsoft/teamsfx-cli": "1.1.5",
         "adm-zip": "^0.5.9",
@@ -7885,8 +7910,8 @@
         "fs-extra": "^9.0.1",
         "inquirer": "^7.3.3",
         "junk": "^3.1.0",
-        "office-addin-manifest": "^1.11.0",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-manifest": "^1.12.0",
+        "office-addin-usage-data": "^1.6.4",
         "open": "^6.4.0",
         "string_decoder": "1.3.0",
         "whatwg-url": "^7.1.0",
@@ -7953,9 +7978,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.3.tgz",
-      "integrity": "sha512-TIglSHkMTMNWtzWH/w6wlct03eZoxyMM4gY3CXqOAE6mfJTCdCO0L1NDoUjmpbmcIvLF90brMRs87DrQ5rO9hg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.4.tgz",
+      "integrity": "sha512-FO5kI12+1uRuTLQtcc5IE07hA/Mybo+9pehb9SMA06UoVq8Pw1sjwHq9kC0/BFe8PAx+0qoFBVn2fTlc8wDC2A==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -7963,10 +7988,10 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^2.1.3",
+        "eslint-plugin-office-addins": "^2.1.4",
         "eslint-plugin-prettier": "^3.3.1",
         "office-addin-prettier-config": "^1.2.0",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -7974,9 +7999,9 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.11.0.tgz",
-      "integrity": "sha512-XYRENsYqLJkgvVzvVfwDpPcNgZtN7jL+oezQb+ASb/npVO0UEefz9PzCxPM6l+qwErmVw5Uh+yGh+WaWA/ftXw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.0.tgz",
+      "integrity": "sha512-9FwCqGX1tj/6kH6qhtMQC+emTiETkN/pbIqBaSnQyszbN834uERbFnJHfvd8jvvNpGnDqgNnRTnV93LifGeDLg==",
       "dependencies": {
         "@microsoft/teams-manifest": "^0.0.7",
         "adm-zip": "^0.5.9",
@@ -7984,7 +8009,7 @@
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -8102,13 +8127,13 @@
       }
     },
     "node_modules/office-addin-node-debugger": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.8.3.tgz",
-      "integrity": "sha512-RSv4VX7Lfl9es9K/ypbDvLBIMxb75Riyx44VDb4Hs0JdRADI0oqzFWuBhh5mPcPhFHasgGMwra7eO5xYeHNrMQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.8.4.tgz",
+      "integrity": "sha512-dRTS3ZkFe4iFfjOWgDzYm2RutqcyFmX7pN8fZ3jh4XUmd6HNOMA2dNZbyq0C13SHEFGFNz/Fe3dbpHBZ5f9WgA==",
       "dependencies": {
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "ws": "^7.4.6"
       },
       "bin": {
@@ -8122,9 +8147,9 @@
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.3.tgz",
-      "integrity": "sha512-KXg3Wa1lm4D1KmAjShXpAZReeF+Psu96JTAFv09KWa+gIRvQQcA6kuzP1ie7DPn+ILRPhRzRthpWw2h4L15xZA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.4.tgz",
+      "integrity": "sha512-h6L2lMuQHoc9dACWlB/j55YmXix/k0UmQiXtzoORAirSVX8Y2WM2eLhHuOiYJ/Zk1l7kntj4dJnJx3+cNEfmWg==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
@@ -9369,18 +9394,18 @@
       }
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
-      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.1",
+        "regexp.prototype.flags": "^1.4.3",
         "side-channel": "^1.0.4"
       },
       "funding": {
@@ -11105,12 +11130,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.3.tgz",
-      "integrity": "sha512-Wl5ilw2UD1+ZYprHVprxHZJCFeBWlzZYOovE4SDYLZnqCOD11j+0QzNeEWKLLTWM7nixrZEh7vNIyb76MyJg3A==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       }
@@ -11231,9 +11256,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
+      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
       "dev": true
     },
     "@babel/runtime": {
@@ -11245,14 +11270,14 @@
       }
     },
     "@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -11267,19 +11292,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
+        "@babel/generator": "^7.20.7",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
+        "@babel/parser": "^7.20.13",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -11317,9 +11342,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -12242,6 +12267,15 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "@types/adm-zip": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+      "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -12436,14 +12470,14 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
-      "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.49.0.tgz",
+      "integrity": "sha512-IhxabIpcf++TBaBa1h7jtOWyon80SXPRLDq0dVz5SLFC/eW6tofkw/O7Ar3lkx5z5U6wzbKDrl2larprp5kk5Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/type-utils": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/type-utils": "5.49.0",
+        "@typescript-eslint/utils": "5.49.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -12470,14 +12504,14 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
-      "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
+      "integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "debug": "^4.3.4"
       },
       "dependencies": {
@@ -12499,23 +12533,23 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
-      "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
+      "integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1"
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
-      "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.49.0.tgz",
+      "integrity": "sha512-eUgLTYq0tR0FGU5g1YHm4rt5H/+V2IPVkP0cBmbhRyEmyGe4XvJ2YJ6sYTmONfjmdMqyMLad7SB8GvblbeESZA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/typescript-estree": "5.49.0",
+        "@typescript-eslint/utils": "5.49.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -12538,19 +12572,19 @@
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
-      "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
+      "integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
-      "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
+      "integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -12576,28 +12610,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
-      "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
+      "integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
-      "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
+      "integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
+        "@typescript-eslint/types": "5.49.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -12876,15 +12910,15 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       }
     },
@@ -12909,6 +12943,19 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "asap": {
@@ -14123,16 +14170,16 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
       "dev": true,
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.3.tgz",
-      "integrity": "sha512-gBZoVOjU2tjSPBmwZE4xIIkkbBBsZAToKALE0LBYR6IgK4g4a/4+S8aFbqsE5W9quSHn8FyaT1DT4NFOhm5A1A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.4.tgz",
+      "integrity": "sha512-fs7qHWVirBJ23HQf07juSDz8csDyGChM2GnOZw9nuxhdPQdIB+zMTuHd1NKwL6kMvo/lCL1fy27pJBWYjag/cQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -14170,25 +14217,26 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.31.10",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz",
-      "integrity": "sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==",
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.1.tgz",
+      "integrity": "sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.5",
-        "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
-        "object.values": "^1.1.5",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.3",
+        "resolve": "^2.0.0-next.4",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
+        "string.prototype.matchall": "^4.0.8"
       },
       "dependencies": {
         "doctrine": {
@@ -14434,9 +14482,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -16482,9 +16530,9 @@
       }
     },
     "office-addin-cli": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.5.3.tgz",
-      "integrity": "sha512-GSTxPe8PP/8Q1HqQGT1D2cCb+MA95QPPoVVUluExVuO8kxVaRc0ZFvl7j3ehKJlKKUDJElsZ9OjiEQ0xCK7OBA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/office-addin-cli/-/office-addin-cli-1.5.4.tgz",
+      "integrity": "sha512-HRFV7/sjiSz6FKNSd1XNkXl/UUXh5CqbR5dCLdv9OuG7j95OOvMWE4g7AMwkSHIkKzY/7okWxQr/cEf1hBDGiw==",
       "requires": {
         "commander": "^6.2.1",
         "node-fetch": "^2.6.1",
@@ -16492,21 +16540,21 @@
       }
     },
     "office-addin-dev-certs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.11.0.tgz",
-      "integrity": "sha512-+A8fgx0bYLshcb6S3UMF6z2lv4YolvP6i1DdX9eEOsvuP27D3l8eLHTXK/O7FntahqFN4j8Y+IjK9Wg3Tr3RMA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-certs/-/office-addin-dev-certs-1.11.1.tgz",
+      "integrity": "sha512-nq38SYYqBtGyavgBx/WLvpBOWQTtbJUq0HsgXX9ofF3ac6UROGaZcs1pdePbvi25hjJqRGjdU2qC09MpJhkcwA==",
       "requires": {
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "mkcert": "^1.4.0",
-        "office-addin-cli": "^1.5.3",
-        "office-addin-usage-data": "^1.6.3"
+        "office-addin-cli": "^1.5.4",
+        "office-addin-usage-data": "^1.6.4"
       }
     },
     "office-addin-dev-settings": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.15.0.tgz",
-      "integrity": "sha512-Q9aJKC0FzBi6AAxvBlO5tVXr2jxrK2KldiulyOyoSRxrsZjMVWvelZyXSF201nljC8dZiRdh4Lt/cDy6omqfiA==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.15.1.tgz",
+      "integrity": "sha512-6UluzPow4wxifMEx2XmKuF75SyOE7oqCSHWXafa3MlfeqKpl0B7S9sONh5A3PG0D2+Qrgky8JcrIm1eAOQXajQ==",
       "requires": {
         "@microsoft/teamsfx-cli": "1.1.5",
         "adm-zip": "^0.5.9",
@@ -16514,8 +16562,8 @@
         "fs-extra": "^9.0.1",
         "inquirer": "^7.3.3",
         "junk": "^3.1.0",
-        "office-addin-manifest": "^1.11.0",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-manifest": "^1.12.0",
+        "office-addin-usage-data": "^1.6.4",
         "open": "^6.4.0",
         "string_decoder": "1.3.0",
         "whatwg-url": "^7.1.0",
@@ -16573,9 +16621,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.3.tgz",
-      "integrity": "sha512-TIglSHkMTMNWtzWH/w6wlct03eZoxyMM4gY3CXqOAE6mfJTCdCO0L1NDoUjmpbmcIvLF90brMRs87DrQ5rO9hg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.4.tgz",
+      "integrity": "sha512-FO5kI12+1uRuTLQtcc5IE07hA/Mybo+9pehb9SMA06UoVq8Pw1sjwHq9kC0/BFe8PAx+0qoFBVn2fTlc8wDC2A==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -16583,17 +16631,17 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^2.1.3",
+        "eslint-plugin-office-addins": "^2.1.4",
         "eslint-plugin-prettier": "^3.3.1",
         "office-addin-prettier-config": "^1.2.0",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-manifest": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.11.0.tgz",
-      "integrity": "sha512-XYRENsYqLJkgvVzvVfwDpPcNgZtN7jL+oezQb+ASb/npVO0UEefz9PzCxPM6l+qwErmVw5Uh+yGh+WaWA/ftXw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.0.tgz",
+      "integrity": "sha512-9FwCqGX1tj/6kH6qhtMQC+emTiETkN/pbIqBaSnQyszbN834uERbFnJHfvd8jvvNpGnDqgNnRTnV93LifGeDLg==",
       "requires": {
         "@microsoft/teams-manifest": "^0.0.7",
         "adm-zip": "^0.5.9",
@@ -16601,7 +16649,7 @@
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -16697,13 +16745,13 @@
       }
     },
     "office-addin-node-debugger": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.8.3.tgz",
-      "integrity": "sha512-RSv4VX7Lfl9es9K/ypbDvLBIMxb75Riyx44VDb4Hs0JdRADI0oqzFWuBhh5mPcPhFHasgGMwra7eO5xYeHNrMQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.8.4.tgz",
+      "integrity": "sha512-dRTS3ZkFe4iFfjOWgDzYm2RutqcyFmX7pN8fZ3jh4XUmd6HNOMA2dNZbyq0C13SHEFGFNz/Fe3dbpHBZ5f9WgA==",
       "requires": {
         "commander": "^6.2.0",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "ws": "^7.4.6"
       }
     },
@@ -16714,9 +16762,9 @@
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.3.tgz",
-      "integrity": "sha512-KXg3Wa1lm4D1KmAjShXpAZReeF+Psu96JTAFv09KWa+gIRvQQcA6kuzP1ie7DPn+ILRPhRzRthpWw2h4L15xZA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.4.tgz",
+      "integrity": "sha512-h6L2lMuQHoc9dACWlB/j55YmXix/k0UmQiXtzoORAirSVX8Y2WM2eLhHuOiYJ/Zk1l7kntj4dJnJx3+cNEfmWg==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
@@ -17598,18 +17646,18 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
-      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.1",
+        "regexp.prototype.flags": "^1.4.3",
         "side-channel": "^1.0.4"
       }
     },

--- a/packages/office-addin-debugging/package.json
+++ b/packages/office-addin-debugging/package.json
@@ -23,6 +23,7 @@
     "Office"
   ],
   "dependencies": {
+    "adm-zip": "^0.5.9",
     "commander": "^6.2.0",
     "node-fetch": "^2.6.1",
     "office-addin-cli": "^1.5.4",
@@ -33,6 +34,7 @@
     "office-addin-usage-data": "^1.6.4"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.0",
     "@types/express": "^4.17.13",
     "@types/mocha": "^5.2.5",
     "@types/node": "^14.17.2",

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -3,6 +3,7 @@
 
 import * as AdmZip from "adm-zip";
 import * as fetch from "node-fetch";
+import * as fs from "fs";
 import * as fspath from "path";
 import * as devCerts from "office-addin-dev-certs";
 import * as devSettings from "office-addin-dev-settings";
@@ -429,5 +430,12 @@ async function extractManifest(zipPath: string): Promise<string> {
   const targetPath: string = fspath.join(process.env.TEMP as string, "addinManifest");
   const zip = new AdmZip(zipPath); // reading archives
   zip.extractAllTo(targetPath, true); // overwrite
-  return fspath.join(targetPath, "manifest.json");
+
+  const manifestPath = fspath.join(targetPath, "manifest.json");
+  if (fs.existsSync(manifestPath)) {
+    return manifestPath;
+  }
+  else {
+    throw new Error(`The zip file '${zipPath}' does not contain a "manifest.json" file`);
+  }
 }

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as AdmZip from "adm-zip";
 import * as fetch from "node-fetch";
+import * as fspath from "path";
 import * as devCerts from "office-addin-dev-certs";
 import * as devSettings from "office-addin-dev-settings";
 import * as os from "os";
@@ -291,6 +293,9 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
     console.log(enableDebugging ? "Debugging is being started..." : "Starting without debugging...");
     console.log(`App type: ${appType}`);
 
+    if (manifestPath.endsWith(".zip")) {
+      manifestPath = await extractManifest(manifestPath);
+    }
     const manifestInfo = await OfficeAddinManifest.readManifestFile(manifestPath);
 
     if (!manifestInfo.id) {
@@ -418,4 +423,11 @@ export async function waitUntilPackagerIsRunning(
   retryDelay: number = 1000
 ): Promise<boolean> {
   return waitUntil(async () => await isPackagerRunning(statusUrl), retryCount, retryDelay);
+}
+
+async function extractManifest(zipPath: string): Promise<string> {
+  const targetPath: string = fspath.join(process.env.TEMP as string, "addinManifest");
+  const zip = new AdmZip(zipPath); // reading archives
+  zip.extractAllTo(targetPath, true); // overwrite
+  return fspath.join(targetPath, "manifest.json");
 }

--- a/packages/office-addin-manifest/test/manifests/devPreviewManifest.json
+++ b/packages/office-addin-manifest/test/manifests/devPreviewManifest.json
@@ -19,8 +19,8 @@
     "termsOfUseUrl": "https://www.contoso.com/servicesagreement"
   },
   "icons": {
-    "outline": "test/assets/icon-64.png",
-    "color": "test/assets/icon-128.png"
+    "outline": "../assets/icon-64.png",
+    "color": "../assets/icon-128.png"
   },
   "accentColor": "#230201",
   "localizationInfo": {

--- a/packages/office-addin-manifest/test/manifests/manifest.json
+++ b/packages/office-addin-manifest/test/manifests/manifest.json
@@ -18,8 +18,8 @@
     "termsOfUseUrl": "https://www.contoso.com/servicesagreement"
   },
   "icons": {
-    "outline": "test/assets/icon-64.png",
-    "color": "test/assets/icon-128.png"
+    "outline": "../assets/icon-64.png",
+    "color": "../assets/icon-128.png"
   },
   "accentColor": "#230201",
   "localizationInfo": {

--- a/packages/office-addin-manifest/test/manifests/manifest.local.json
+++ b/packages/office-addin-manifest/test/manifests/manifest.local.json
@@ -18,8 +18,8 @@
     "termsOfUseUrl": "https://www.contoso.com/servicesagreement"
   },
   "icons": {
-    "outline": "test/assets/icon-64.png",
-    "color": "test/assets/icon-128.png"
+    "outline": "../assets/icon-64.png",
+    "color": "../assets/icon-128.png"
   },
   "accentColor": "#230201",
   "localizationInfo": {

--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -490,11 +490,11 @@ describe("Unit Tests", function() {
         assert.strictEqual(info.defaultLocale, "en-us");
         assert.strictEqual(info.description, "A template to get started.");
         assert.strictEqual(info.displayName, "Contoso Task Pane Add-in");
-        assert.strictEqual(info.highResolutionIconUrl, "test/assets/icon-128.png", "highResolutionIconUrl");
+        assert.strictEqual(info.highResolutionIconUrl, "../assets/icon-128.png", "highResolutionIconUrl");
         assert.strictEqual(info.hosts instanceof Array, true, "hosts");
         assert.strictEqual(info.hosts!.length, 1);
         assert.strictEqual(info.hosts![0], "mail");
-        assert.strictEqual(info.iconUrl, "test/assets/icon-128.png", "iconUrl");
+        assert.strictEqual(info.iconUrl, "../assets/icon-128.png", "iconUrl");
         assert.strictEqual(info.officeAppType, "AddinCommands");
         assert.strictEqual(info.permissions, "Mailbox.ReadWrite");
         assert.strictEqual(info.providerName, "Contoso");
@@ -510,11 +510,11 @@ describe("Unit Tests", function() {
         assert.strictEqual(info.defaultLocale, "en-us");
         assert.strictEqual(info.description, "A template to get started.");
         assert.strictEqual(info.displayName, "Contoso Task Pane Add-in");
-        assert.strictEqual(info.highResolutionIconUrl, "test/assets/icon-128.png", "highResolutionIconUrl");
+        assert.strictEqual(info.highResolutionIconUrl, "../assets/icon-128.png", "highResolutionIconUrl");
         assert.strictEqual(info.hosts instanceof Array, true, "hosts");
         assert.strictEqual(info.hosts!.length, 1);
         assert.strictEqual(info.hosts![0], "mail");
-        assert.strictEqual(info.iconUrl, "test/assets/icon-128.png", "iconUrl");
+        assert.strictEqual(info.iconUrl, "../assets/icon-128.png", "iconUrl");
         assert.strictEqual(info.officeAppType, "AddinCommands");
         assert.strictEqual(info.permissions, "Mailbox.ReadWrite");
         assert.strictEqual(info.providerName, "Contoso");


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
In the toolkit the manifest is generated into a build location that add-ins can they use for setting up debugging.  However, the required images are not part of the manifest output of the toolkit.  In order to work with toolkit manifest handling, we need to be able to process receiving a zip file (which contains the manifest and the related required images) for the manifest path.  We extract this so we can get at the manifest information and then re-zip it using icon references that are relative to the manifest location rather than the working directory of the debugging command.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
Yes . . . allows for zip files as manifest paths

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
It may be necessary to document the fact that zip files can be accepted as arguments to the cli command.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran automated tests.  Also linked to a generated project and updated the command to feed it a generated zip file as an argument to sideload.