### PR TITLE
[Major] Remove json2xml convert

### DIFF
--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -15,8 +15,8 @@
         "fs-extra": "^9.0.1",
         "inquirer": "^7.3.3",
         "junk": "^3.1.0",
-        "office-addin-manifest": "^1.11.0",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-manifest": "^1.12.0",
+        "office-addin-usage-data": "^1.6.4",
         "open": "^6.4.0",
         "string_decoder": "1.3.0",
         "whatwg-url": "^7.1.0",
@@ -39,7 +39,7 @@
         "concurrently": "^6.2.2",
         "cpy-cli": "4.1.0",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^2.2.3",
+        "office-addin-lint": "^2.2.4",
         "rimraf": "^3.0.2",
         "sinon": "^7.5.0",
         "ts-node": "^10.9.1",
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
+      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -915,9 +915,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.10.tgz",
-      "integrity": "sha512-oSf1juCgymrSez8NI4A2sr4+uB/mFd9MXplYGPEBnfAuWmmyeVcHa6xLPiaRBcXkcb/28bgxmQLTVwFKE1yfsg==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
@@ -926,7 +926,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.7",
+        "@babel/parser": "^7.20.13",
         "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -2085,14 +2085,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz",
-      "integrity": "sha512-SVLafp0NXpoJY7ut6VFVUU9I+YeFsDzeQwtK0WZ+xbRN3mtxJ08je+6Oi2N89qDn087COdO0u3blKZNv9VetRQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.49.0.tgz",
+      "integrity": "sha512-IhxabIpcf++TBaBa1h7jtOWyon80SXPRLDq0dVz5SLFC/eW6tofkw/O7Ar3lkx5z5U6wzbKDrl2larprp5kk5Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.48.0",
-        "@typescript-eslint/type-utils": "5.48.0",
-        "@typescript-eslint/utils": "5.48.0",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/type-utils": "5.49.0",
+        "@typescript-eslint/utils": "5.49.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -2118,14 +2118,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
-      "integrity": "sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
+      "integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.48.0",
-        "@typescript-eslint/types": "5.48.0",
-        "@typescript-eslint/typescript-estree": "5.48.0",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2145,13 +2145,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz",
-      "integrity": "sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
+      "integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.48.0",
-        "@typescript-eslint/visitor-keys": "5.48.0"
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2162,13 +2162,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
-      "integrity": "sha512-vbtPO5sJyFjtHkGlGK4Sthmta0Bbls4Onv0bEqOGm7hP9h8UpRsHJwsrCiWtCUndTRNQO/qe6Ijz9rnT/DB+7g==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.49.0.tgz",
+      "integrity": "sha512-eUgLTYq0tR0FGU5g1YHm4rt5H/+V2IPVkP0cBmbhRyEmyGe4XvJ2YJ6sYTmONfjmdMqyMLad7SB8GvblbeESZA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.48.0",
-        "@typescript-eslint/utils": "5.48.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
+        "@typescript-eslint/utils": "5.49.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.0.tgz",
-      "integrity": "sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
+      "integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2202,13 +2202,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz",
-      "integrity": "sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
+      "integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.48.0",
-        "@typescript-eslint/visitor-keys": "5.48.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2258,16 +2258,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.0.tgz",
-      "integrity": "sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
+      "integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.48.0",
-        "@typescript-eslint/types": "5.48.0",
-        "@typescript-eslint/typescript-estree": "5.48.0",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -2284,12 +2284,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz",
-      "integrity": "sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
+      "integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.48.0",
+        "@typescript-eslint/types": "5.49.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -4375,9 +4375,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.3.tgz",
-      "integrity": "sha512-gBZoVOjU2tjSPBmwZE4xIIkkbBBsZAToKALE0LBYR6IgK4g4a/4+S8aFbqsE5W9quSHn8FyaT1DT4NFOhm5A1A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.4.tgz",
+      "integrity": "sha512-fs7qHWVirBJ23HQf07juSDz8csDyGChM2GnOZw9nuxhdPQdIB+zMTuHd1NKwL6kMvo/lCL1fy27pJBWYjag/cQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -4440,9 +4440,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.31.11",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
-      "integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.1.tgz",
+      "integrity": "sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.6",
@@ -4457,7 +4457,7 @@
         "object.hasown": "^1.1.2",
         "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.3",
+        "resolve": "^2.0.0-next.4",
         "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.8"
       },
@@ -7844,9 +7844,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.3.tgz",
-      "integrity": "sha512-TIglSHkMTMNWtzWH/w6wlct03eZoxyMM4gY3CXqOAE6mfJTCdCO0L1NDoUjmpbmcIvLF90brMRs87DrQ5rO9hg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.4.tgz",
+      "integrity": "sha512-FO5kI12+1uRuTLQtcc5IE07hA/Mybo+9pehb9SMA06UoVq8Pw1sjwHq9kC0/BFe8PAx+0qoFBVn2fTlc8wDC2A==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -7854,10 +7854,10 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^2.1.3",
+        "eslint-plugin-office-addins": "^2.1.4",
         "eslint-plugin-prettier": "^3.3.1",
         "office-addin-prettier-config": "^1.2.0",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -7865,9 +7865,9 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.11.0.tgz",
-      "integrity": "sha512-XYRENsYqLJkgvVzvVfwDpPcNgZtN7jL+oezQb+ASb/npVO0UEefz9PzCxPM6l+qwErmVw5Uh+yGh+WaWA/ftXw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.0.tgz",
+      "integrity": "sha512-9FwCqGX1tj/6kH6qhtMQC+emTiETkN/pbIqBaSnQyszbN834uERbFnJHfvd8jvvNpGnDqgNnRTnV93LifGeDLg==",
       "dependencies": {
         "@microsoft/teams-manifest": "^0.0.7",
         "adm-zip": "^0.5.9",
@@ -7875,7 +7875,7 @@
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -8001,9 +8001,9 @@
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.3.tgz",
-      "integrity": "sha512-KXg3Wa1lm4D1KmAjShXpAZReeF+Psu96JTAFv09KWa+gIRvQQcA6kuzP1ie7DPn+ILRPhRzRthpWw2h4L15xZA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.4.tgz",
+      "integrity": "sha512-h6L2lMuQHoc9dACWlB/j55YmXix/k0UmQiXtzoORAirSVX8Y2WM2eLhHuOiYJ/Zk1l7kntj4dJnJx3+cNEfmWg==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
@@ -11305,9 +11305,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
+      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
       "dev": true
     },
     "@babel/runtime": {
@@ -11341,9 +11341,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.20.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.10.tgz",
-      "integrity": "sha512-oSf1juCgymrSez8NI4A2sr4+uB/mFd9MXplYGPEBnfAuWmmyeVcHa6xLPiaRBcXkcb/28bgxmQLTVwFKE1yfsg==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
@@ -11352,7 +11352,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.7",
+        "@babel/parser": "^7.20.13",
         "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -12360,14 +12360,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz",
-      "integrity": "sha512-SVLafp0NXpoJY7ut6VFVUU9I+YeFsDzeQwtK0WZ+xbRN3mtxJ08je+6Oi2N89qDn087COdO0u3blKZNv9VetRQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.49.0.tgz",
+      "integrity": "sha512-IhxabIpcf++TBaBa1h7jtOWyon80SXPRLDq0dVz5SLFC/eW6tofkw/O7Ar3lkx5z5U6wzbKDrl2larprp5kk5Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.48.0",
-        "@typescript-eslint/type-utils": "5.48.0",
-        "@typescript-eslint/utils": "5.48.0",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/type-utils": "5.49.0",
+        "@typescript-eslint/utils": "5.49.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -12377,53 +12377,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
-      "integrity": "sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
+      "integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.48.0",
-        "@typescript-eslint/types": "5.48.0",
-        "@typescript-eslint/typescript-estree": "5.48.0",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz",
-      "integrity": "sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
+      "integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.48.0",
-        "@typescript-eslint/visitor-keys": "5.48.0"
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
-      "integrity": "sha512-vbtPO5sJyFjtHkGlGK4Sthmta0Bbls4Onv0bEqOGm7hP9h8UpRsHJwsrCiWtCUndTRNQO/qe6Ijz9rnT/DB+7g==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.49.0.tgz",
+      "integrity": "sha512-eUgLTYq0tR0FGU5g1YHm4rt5H/+V2IPVkP0cBmbhRyEmyGe4XvJ2YJ6sYTmONfjmdMqyMLad7SB8GvblbeESZA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.48.0",
-        "@typescript-eslint/utils": "5.48.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
+        "@typescript-eslint/utils": "5.49.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.0.tgz",
-      "integrity": "sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
+      "integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz",
-      "integrity": "sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
+      "integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.48.0",
-        "@typescript-eslint/visitor-keys": "5.48.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -12454,28 +12454,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.0.tgz",
-      "integrity": "sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
+      "integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.48.0",
-        "@typescript-eslint/types": "5.48.0",
-        "@typescript-eslint/typescript-estree": "5.48.0",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz",
-      "integrity": "sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
+      "integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.48.0",
+        "@typescript-eslint/types": "5.49.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -14144,9 +14144,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.3.tgz",
-      "integrity": "sha512-gBZoVOjU2tjSPBmwZE4xIIkkbBBsZAToKALE0LBYR6IgK4g4a/4+S8aFbqsE5W9quSHn8FyaT1DT4NFOhm5A1A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.4.tgz",
+      "integrity": "sha512-fs7qHWVirBJ23HQf07juSDz8csDyGChM2GnOZw9nuxhdPQdIB+zMTuHd1NKwL6kMvo/lCL1fy27pJBWYjag/cQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -14184,9 +14184,9 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.31.11",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
-      "integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
+      "version": "7.32.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.1.tgz",
+      "integrity": "sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.6",
@@ -14201,7 +14201,7 @@
         "object.hasown": "^1.1.2",
         "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.3",
+        "resolve": "^2.0.0-next.4",
         "semver": "^6.3.0",
         "string.prototype.matchall": "^4.0.8"
       },
@@ -16680,9 +16680,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.3.tgz",
-      "integrity": "sha512-TIglSHkMTMNWtzWH/w6wlct03eZoxyMM4gY3CXqOAE6mfJTCdCO0L1NDoUjmpbmcIvLF90brMRs87DrQ5rO9hg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.4.tgz",
+      "integrity": "sha512-FO5kI12+1uRuTLQtcc5IE07hA/Mybo+9pehb9SMA06UoVq8Pw1sjwHq9kC0/BFe8PAx+0qoFBVn2fTlc8wDC2A==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -16690,17 +16690,17 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^2.1.3",
+        "eslint-plugin-office-addins": "^2.1.4",
         "eslint-plugin-prettier": "^3.3.1",
         "office-addin-prettier-config": "^1.2.0",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-manifest": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.11.0.tgz",
-      "integrity": "sha512-XYRENsYqLJkgvVzvVfwDpPcNgZtN7jL+oezQb+ASb/npVO0UEefz9PzCxPM6l+qwErmVw5Uh+yGh+WaWA/ftXw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.0.tgz",
+      "integrity": "sha512-9FwCqGX1tj/6kH6qhtMQC+emTiETkN/pbIqBaSnQyszbN834uERbFnJHfvd8jvvNpGnDqgNnRTnV93LifGeDLg==",
       "requires": {
         "@microsoft/teams-manifest": "^0.0.7",
         "adm-zip": "^0.5.9",
@@ -16708,7 +16708,7 @@
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.6.3",
+        "office-addin-usage-data": "^1.6.4",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -16816,9 +16816,9 @@
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.3.tgz",
-      "integrity": "sha512-KXg3Wa1lm4D1KmAjShXpAZReeF+Psu96JTAFv09KWa+gIRvQQcA6kuzP1ie7DPn+ILRPhRzRthpWw2h4L15xZA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.4.tgz",
+      "integrity": "sha512-h6L2lMuQHoc9dACWlB/j55YmXix/k0UmQiXtzoORAirSVX8Y2WM2eLhHuOiYJ/Zk1l7kntj4dJnJx3+cNEfmWg==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",

--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -4,7 +4,7 @@
   "description": "Configure developer settings for Office Add-ins.",
   "main": "./lib/main.js",
   "scripts": {
-    "build": "rimraf lib && cpy src/DevXTool.exe lib --flat && concurrently \"tsc -p tsconfig.json\"",
+    "build": "rimraf lib && concurrently \"tsc -p tsconfig.json\"",
     "cli": "node lib/cli.js",
     "lint": "office-addin-lint check",
     "lint:fix": "office-addin-lint fix",

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -309,7 +309,7 @@ export async function sideloadAddIn(
       appType = AppType.Desktop;
     }
 
-    if (!canSideloadJson()) {
+    if (manifestPath.endsWith(".json") && !canSideloadJson()) {
       throw new ExpectedError("Development envionrment doesn't support json manifests.");
     }
     const manifest: ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestPath);

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -309,17 +309,9 @@ export async function sideloadAddIn(
       appType = AppType.Desktop;
     }
 
-    // Converting json to xml manifest . . . Temporary until service is ready.
-    // depending on environment
-    if (manifestPath.endsWith(".json") && !canSideloadJson()) {
-      if (isDotnetInstalled()) {
-        // Run json => xml conversion tool.
-        manifestPath = await convertJsonToXmlManifest(manifestPath);
-      } else {
-        throw new ExpectedError(".Net 5 or greater is required for json manifests.");
-      }
+    if (!canSideloadJson()) {
+      throw new ExpectedError("Development envionrment doesn't support json manifests.");
     }
-
     const manifest: ManifestInfo = await OfficeAddinManifest.readManifestFile(manifestPath);
     const appsInManifest: OfficeApp[] = getOfficeAppsForManifestHosts(manifest.hosts);
 
@@ -365,67 +357,6 @@ export async function sideloadAddIn(
   } catch (err: any) {
     usageDataObject.reportException("sideloadAddIn()", err);
     throw err;
-  }
-}
-
-function isDotnetInstalled(): boolean {
-  try {
-    // Find the .Net runtimes installed
-    let result = childProcess.execSync("dotnet --list-runtimes");
-    const pattern = /(?<=Microsoft.NETCore.App )[\d.]+/g;
-    const matches = result.toString("utf-8").match(pattern);
-    let foundDotNet = false;
-
-    // Look for version 5 or greater
-    matches?.forEach((match) => {
-      const major: number = parseInt(match.split(".")[0]);
-      foundDotNet = foundDotNet || major >= 5;
-    });
-
-    return foundDotNet;
-  } catch (err) {
-    return false;
-  }
-}
-
-async function convertJsonToXmlManifest(manifestPath: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    if (manifestPath.endsWith(".json") && fs.existsSync(manifestPath)) {
-      console.log("Converting json to back compat xml");
-      const convertToolPath = path.resolve(__dirname, ".\\DevXTool.exe");
-      const newManifestPath = path.join(process.env.TEMP as string, "manifest.xml");
-      const command = `"${convertToolPath}" "${manifestPath}" "${newManifestPath}"`;
-
-      childProcess.exec(command, (error, stdout) => {
-        if (error) {
-          console.log(`Error converting file:\n ${stdout}\n ${error}`);
-          reject("");
-        } else {
-          console.log(`Successfully converted manifest to xml:\n ${stdout}`);
-          stripBom(newManifestPath);
-          resolve(newManifestPath);
-        }
-      });
-    } else {
-      reject(new Error(`The file '${manifestPath}' is not valid`));
-    }
-  });
-}
-
-function stripBom(manifestPath: string) {
-  try {
-    if (fs.existsSync(manifestPath)) {
-      const fileData: string = fs.readFileSync(manifestPath, "utf8");
-      let updateFileData: string;
-      if (fileData.charCodeAt(0) === 0xfeff) {
-        updateFileData = fileData.slice(1);
-      } else {
-        updateFileData = fileData;
-      }
-      fs.writeFileSync(manifestPath, updateFileData);
-    }
-  } catch (err) {
-    console.log("Error trying to update converted xml");
   }
 }
 


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
For devpreview in May 2022 we added temporary code to convert json manifests back to xml so they could be sideloaded for testing.  This is no longer needed as support for sideloading json manifests is coming.  This is a breaking change for anyone trying to use json manifests with an older version of Outlook that doesn't support json manifests.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
Yes.  Updated tooling will only work with new builds of office.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran automated tests.
