### PR TITLE
Fix devserver shutdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3285,9 +3285,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-proxy-agent": {
@@ -9638,9 +9638,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-proxy-agent": {

--- a/packages/office-addin-debugging/src/port.ts
+++ b/packages/office-addin-debugging/src/port.ts
@@ -74,7 +74,7 @@ export function getProcessIdsForPort(port: number): Promise<number[]> {
         if (isWin32) {
           lines.forEach((line) => {
             /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-            const [protocol, localAddress, foreignAddress, status, processId] = line.split(" ").filter((text) => text);
+            const [protocol, localAddress, foreignAddress, status, processId] = line.trim().split(" ").filter((text) => text);
             if (processId !== undefined && processId !== '0') {
               const localAddressPort = parsePort(localAddress);
               if (localAddressPort === port) {
@@ -86,6 +86,7 @@ export function getProcessIdsForPort(port: number): Promise<number[]> {
           lines.forEach((line) => {
             /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             const [proto, recv, send, local_address, remote_address, state, program] = line
+              .trim()
               .split(" ")
               .filter((text) => text);
             if (local_address !== undefined && local_address.endsWith(`:${port}`) && program !== undefined) {
@@ -99,6 +100,7 @@ export function getProcessIdsForPort(port: number): Promise<number[]> {
           lines.forEach((line) => {
             /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             const [process, processId, user, fd, type, device, size, node, name] = line
+              .trim()
               .split(" ")
               .filter((text) => text);
             if (processId !== undefined && processId !== "PID") {


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
When determining if a dev-server is already running we have to parse the output of the "netstat" command and split each line into element that can be evaluated.  There was a newline character that was messing up some parsed value comparisons.  Added the trim to remove the extra character and make the comparison behave correctly.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Used log statement to verify the comparison value and code flow.  Ran automated tests.