### PR TITLE
[minor] Add context.load(...) linter case

### DIFF
--- a/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/call-sync-after-load.ts
@@ -1,15 +1,11 @@
 import { TSESTree } from "@typescript-eslint/utils";
 import { Reference } from "@typescript-eslint/utils/dist/ts-eslint-scope";
-import {
-  isLoadFunction,
-  parseLoadArguments,
-  parsePropertiesArgument,
-} from "../utils/load";
+import { isLoadCall, parsePropertiesArgument } from "../utils/load";
 import {
   findPropertiesRead,
   findOfficeApiReferences,
   OfficeApiReference,
-  findTopLevelExpression,
+  findCallExpression,
 } from "../utils/utils";
 
 export = {
@@ -58,59 +54,19 @@ export = {
         const variable = reference.resolved;
 
         if (operation === "Load" && variable) {
-          if (
-            identifier.parent?.type == TSESTree.AST_NODE_TYPES.MemberExpression
-          ) {
-            // Look for <obj>.load(...) call
-            const topParent = findTopLevelExpression(identifier.parent);
-
-            if (
-              isLoadFunction(topParent) &&
-              topParent.parent?.type === TSESTree.AST_NODE_TYPES.CallExpression
-            ) {
-              const argument = topParent.parent.arguments[0];
-              let propertyNames: string[] = argument
-                ? parsePropertiesArgument(argument)
-                : ["*"];
-              propertyNames.forEach((propertyName: string) => {
-                needSync.add({
-                  variable: variable.name,
-                  property: propertyName,
-                });
-              });
-              return;
-            }
-          } else if (
-            // Look for context.load(<obj>, "...") call
-            identifier.parent?.type == TSESTree.AST_NODE_TYPES.CallExpression
-          ) {
-            const callee: TSESTree.MemberExpression = identifier.parent
-              .callee as TSESTree.MemberExpression;
-            const args: TSESTree.CallExpressionArgument[] =
-              identifier.parent.arguments;
-            if (
-              isLoadFunction(callee) &&
-              args[0] == identifier &&
-              args.length < 3
-            ) {
-              const propertyNames: string[] = args[1]
-                ? parsePropertiesArgument(args[1])
-                : ["*"];
-              propertyNames.forEach((propertyName: string) => {
-                needSync.add({
-                  variable: variable.name,
-                  property: propertyName,
-                });
-              });
-            }
-          }
-        }
-
-        if (operation === "Sync") {
+          const propertiesArgument = getPropertiesArgument(identifier);
+          const propertyNames: string[] = propertiesArgument
+            ? parsePropertiesArgument(propertiesArgument)
+            : ["*"];
+          propertyNames.forEach((propertyName: string) => {
+            needSync.add({
+              variable: variable.name,
+              property: propertyName,
+            });
+          });
+        } else if (operation === "Sync") {
           needSync.clear();
-        }
-
-        if (operation === "Read" && variable) {
+        } else if (operation === "Read" && variable) {
           const propertyName: string = findPropertiesRead(
             reference.identifier.parent
           );
@@ -128,6 +84,37 @@ export = {
           }
         }
       });
+    }
+
+    function getPropertiesArgument(
+      identifier: TSESTree.Identifier
+    ): TSESTree.CallExpressionArgument | undefined {
+      let propertiesArgument;
+      if (
+        identifier.parent?.type === TSESTree.AST_NODE_TYPES.MemberExpression
+      ) {
+        // Look for <obj>.load(...) call
+        const methodCall = findCallExpression(identifier.parent);
+
+        if (methodCall && isLoadCall(methodCall)) {
+          propertiesArgument = methodCall.arguments[0];
+        }
+      } else if (
+        identifier.parent?.type === TSESTree.AST_NODE_TYPES.CallExpression
+      ) {
+        // Look for context.load(<obj>, "...") call
+        const args: TSESTree.CallExpressionArgument[] =
+          identifier.parent.arguments;
+        if (
+          isLoadCall(identifier.parent) &&
+          args[0] == identifier &&
+          args.length < 3
+        ) {
+          propertiesArgument = args[1];
+        }
+      }
+
+      return propertiesArgument;
     }
 
     return {

--- a/packages/eslint-plugin-office-addins/src/rules/call-sync-before-read.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/call-sync-before-read.ts
@@ -1,6 +1,6 @@
 import { TSESTree } from "@typescript-eslint/utils";
 import { Variable } from "@typescript-eslint/utils/dist/ts-eslint-scope";
-import { findTopLevelExpression } from "../utils/utils";
+import { findTopMemberExpression } from "../utils/utils";
 import { findOfficeApiReferences, OfficeApiReference } from "../utils/utils";
 
 export = {
@@ -26,7 +26,7 @@ export = {
 
     function checkPropertyIsRead(node: TSESTree.MemberExpression): boolean {
       const topExpression: TSESTree.MemberExpression =
-        findTopLevelExpression(node);
+        findTopMemberExpression(node);
       switch (topExpression.parent?.type) {
         case TSESTree.AST_NODE_TYPES.AssignmentExpression:
           return topExpression.parent.right === topExpression;

--- a/packages/eslint-plugin-office-addins/src/rules/load-object-before-read.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/load-object-before-read.ts
@@ -57,9 +57,7 @@ export = {
           const node: TSESTree.Node = reference.identifier;
           const parent = node.parent;
 
-          if (
-            parent?.type === TSESTree.AST_NODE_TYPES.VariableDeclarator
-          ) {
+          if (parent?.type === TSESTree.AST_NODE_TYPES.VariableDeclarator) {
             getFound = false; // In case of reassignment
 
             if (
@@ -72,9 +70,7 @@ export = {
             }
           }
 
-          if (
-            parent?.type === TSESTree.AST_NODE_TYPES.AssignmentExpression
-          ) {
+          if (parent?.type === TSESTree.AST_NODE_TYPES.AssignmentExpression) {
             getFound = false; // In case of reassignment
 
             if (
@@ -100,7 +96,9 @@ export = {
               topParent.parent?.type === TSESTree.AST_NODE_TYPES.CallExpression
             ) {
               const argument = topParent.parent.arguments[0];
-              let propertyNames: string[] = argument ? parsePropertiesArgument(argument) : ["*"];
+              let propertyNames: string[] = argument
+                ? parsePropertiesArgument(argument)
+                : ["*"];
               propertyNames.forEach((propertyName: string) => {
                 loadLocation.set(propertyName, node.range[1]);
               });
@@ -110,10 +108,13 @@ export = {
 
           // Look for context.load(<obj>, "...") call
           if (parent?.type === TSESTree.AST_NODE_TYPES.CallExpression) {
-            const callee: TSESTree.MemberExpression = parent?.callee as TSESTree.MemberExpression;
+            const callee: TSESTree.MemberExpression =
+              parent?.callee as TSESTree.MemberExpression;
             const args: TSESTree.CallExpressionArgument[] = parent?.arguments;
             if (isLoadFunction(callee) && args[0] == node && args.length < 3) {
-              const propertyNames: string[] = args[1] ? parsePropertiesArgument(args[1]) : ["*"];
+              const propertyNames: string[] = args[1]
+                ? parsePropertiesArgument(args[1])
+                : ["*"];
               propertyNames.forEach((propertyName: string) => {
                 loadLocation.set(propertyName, node.range[1]);
               });

--- a/packages/eslint-plugin-office-addins/src/rules/test-for-null-using-isNullObject.ts
+++ b/packages/eslint-plugin-office-addins/src/rules/test-for-null-using-isNullObject.ts
@@ -1,16 +1,10 @@
-import {
-  TSESTree,
-  AST_NODE_TYPES,
-} from "@typescript-eslint/utils";
+import { TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
 import {
   Reference,
   Scope,
   Variable,
 } from "@typescript-eslint/utils/dist/ts-eslint-scope";
-import {
-  RuleFix,
-  RuleFixer,
-} from "@typescript-eslint/utils/dist/ts-eslint";
+import { RuleFix, RuleFixer } from "@typescript-eslint/utils/dist/ts-eslint";
 import { isGetOrNullObjectFunction } from "../utils/getFunction";
 
 export = {

--- a/packages/eslint-plugin-office-addins/src/utils/load.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/load.ts
@@ -19,6 +19,17 @@ export function isLoadReference(node: TSESTree.Identifier) {
   );
 }
 
+export function isContextLoadArgumentReference(node: TSESTree.Identifier) {
+  return (
+    node.parent?.type === AST_NODE_TYPES.CallExpression &&
+    node.parent.callee.type === AST_NODE_TYPES.MemberExpression &&
+    node.parent.callee.object.type === AST_NODE_TYPES.Identifier &&
+    node.parent.callee.object.name === "context" &&
+    node.parent.callee.property.type === AST_NODE_TYPES.Identifier &&
+    node.parent.callee.property.name === "load"
+  );
+}
+
 function parseObjectExpressionProperty(
   objectExpression: TSESTree.ObjectExpression
 ): string[] {

--- a/packages/eslint-plugin-office-addins/src/utils/load.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/load.ts
@@ -77,24 +77,26 @@ export function parseLoadArguments(node: TSESTree.MemberExpression): string[] {
       return [];
     }
 
-    let properties: string[] = [];
-    if (argument.type === AST_NODE_TYPES.ArrayExpression) {
-      argument.elements.forEach((element) => {
-        if (element.type === TSESTree.AST_NODE_TYPES.Literal) {
-          properties = properties.concat(
-            parseLoadStringArgument(element.value as string)
-          );
-        }
-      });
-    } else if (argument.type === TSESTree.AST_NODE_TYPES.Literal) {
-      properties = properties.concat(
-        parseLoadStringArgument(argument.value as string)
-      );
-    } else if (argument.type === TSESTree.AST_NODE_TYPES.ObjectExpression) {
-      properties = properties.concat(parseObjectExpressionProperty(argument));
-    }
-
-    return properties;
+    return parsePropertiesArgument(argument);
   }
-  throw new Error("error in getLoadArgument function.");
+  throw new Error("error in parseLoadArgument function.");
+}
+
+export function parsePropertiesArgument(argument: TSESTree.CallExpressionArgument): string[] {
+  let properties: string[] = [];
+  if (argument.type === AST_NODE_TYPES.ArrayExpression) {
+    argument.elements.forEach((element) => {
+      if (element.type === TSESTree.AST_NODE_TYPES.Literal) {
+        properties = properties.concat(
+          parseLoadStringArgument(element.value as string)
+        );
+      }
+    });
+  } else if (argument.type === TSESTree.AST_NODE_TYPES.Literal) {
+    properties = parseLoadStringArgument(argument.value as string);
+  } else if (argument.type === TSESTree.AST_NODE_TYPES.ObjectExpression) {
+    properties = parseObjectExpressionProperty(argument);
+  }
+
+  return properties;
 }

--- a/packages/eslint-plugin-office-addins/src/utils/load.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/load.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 import { findTopLevelExpression } from "./utils";
 
 export function isLoadFunction(node: TSESTree.MemberExpression): boolean {
@@ -82,7 +79,9 @@ export function parseLoadArguments(node: TSESTree.MemberExpression): string[] {
   throw new Error("error in parseLoadArgument function.");
 }
 
-export function parsePropertiesArgument(argument: TSESTree.CallExpressionArgument): string[] {
+export function parsePropertiesArgument(
+  argument: TSESTree.CallExpressionArgument
+): string[] {
   let properties: string[] = [];
   if (argument.type === AST_NODE_TYPES.ArrayExpression) {
     argument.elements.forEach((element) => {

--- a/packages/eslint-plugin-office-addins/src/utils/utils.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/utils.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 import {
   Reference,
   Scope,

--- a/packages/eslint-plugin-office-addins/src/utils/utils.ts
+++ b/packages/eslint-plugin-office-addins/src/utils/utils.ts
@@ -17,7 +17,7 @@ function isContextSyncIdentifier(node: TSESTree.Identifier): boolean {
   );
 }
 
-export function findTopLevelExpression(
+export function findTopMemberExpression(
   node: TSESTree.MemberExpression
 ): TSESTree.MemberExpression {
   while (node.parent && node.parent.type === AST_NODE_TYPES.MemberExpression) {
@@ -25,6 +25,19 @@ export function findTopLevelExpression(
   }
 
   return node;
+}
+
+export function findCallExpression(
+  node: TSESTree.MemberExpression
+): TSESTree.CallExpression | undefined {
+  while (node.parent && node.parent.type === AST_NODE_TYPES.MemberExpression) {
+    node = node.parent;
+  }
+
+  if (node.parent?.type === AST_NODE_TYPES.CallExpression) {
+    return node.parent;
+  }
+  return undefined;
 }
 
 export type OfficeApiReference = {
@@ -84,7 +97,8 @@ function findOfficeApiReferencesInScope(scope: Scope): void {
 }
 
 function isMethod(node: TSESTree.MemberExpression): boolean {
-  const topExpression: TSESTree.MemberExpression = findTopLevelExpression(node);
+  const topExpression: TSESTree.MemberExpression =
+    findTopMemberExpression(node);
   return (
     topExpression.parent?.type === AST_NODE_TYPES.CallExpression &&
     topExpression.parent.callee === topExpression

--- a/packages/eslint-plugin-office-addins/test/rules/call-sync-after-load.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/call-sync-after-load.test.ts
@@ -55,6 +55,27 @@ ruleTester.run('call-sync-after-load', rule, {
         await context.sync();
         console.log(range.address);`
     },
+    {
+      code: `
+        var range = worksheet.getSelectedRange();
+        range.load();
+        await context.sync();
+        console.log(range.address);`
+    },
+    {
+      code: `
+        var property = worksheet.getItem("sheet");
+        context.load(property, "values");
+        await context.sync();
+        console.log(property.values);`
+    },
+    {
+      code: `
+        var property = worksheet.getItem("sheet");
+        context.load(property);
+        await context.sync();
+        console.log(property.values);`
+    },
   ],
   invalid: [
     {
@@ -88,6 +109,43 @@ ruleTester.run('call-sync-after-load', rule, {
         range.load("*");
         console.log(range.address);`,
       errors: [{ messageId: "callSyncAfterLoad", data: { name: "range", loadValue: "address" }}]
+    },
+    {
+      code: `
+        var range = worksheet.getSelectedRange();
+        range.load();
+        console.log(range.address);`,
+      errors: [{ messageId: "callSyncAfterLoad", data: { name: "range", loadValue: "address" }}]
+    },
+    {
+      code: `
+        var property = worksheet.getItem("sheet");
+        await context.sync();
+        context.load(property, "values");
+        console.log(property.values);`,
+      errors: [{ messageId: "callSyncAfterLoad", data: { name: "property", loadValue: "values" }}]
+    },
+    {
+      code: `
+        var property = worksheet.getItem("sheet");
+        context.load(property, "values");
+        console.log(property.values);`,
+      errors: [{ messageId: "callSyncAfterLoad", data: { name: "property", loadValue: "values" }}]
+    },
+    {
+      code: `
+        var property = worksheet.getItem("sheet");
+        await context.sync();
+        context.load(property);
+        console.log(property.values);`,
+      errors: [{ messageId: "callSyncAfterLoad", data: { name: "property", loadValue: "values" }}]
+    },
+    {
+      code: `
+        var property = worksheet.getItem("sheet");
+        context.load(property);
+        console.log(property.values);`,
+      errors: [{ messageId: "callSyncAfterLoad", data: { name: "property", loadValue: "values" }}]
     },
   ]
 });

--- a/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/load-object-before-read.test.ts
@@ -116,6 +116,14 @@ ruleTester.run('load-object-before-read', rule, {
     {
       code: `
         var range = worksheet.getSelectedRange();
+        range.load();
+        await context.sync();
+        console.log(range.address);
+        console.log(range.font);`
+    },
+    {
+      code: `
+        var range = worksheet.getSelectedRange();
         range.load({ format: { fill: { color: true } }, address: true } );
         await context.sync();
         console.log(range.format.fill.color);
@@ -129,6 +137,24 @@ ruleTester.run('load-object-before-read', rule, {
         await context.sync();
         const cell = spillParent.isNullObject ? first : spillParent;
         console.log(cell);`
+    },
+    {
+      code: `
+        var myRange = context.workbook.worksheets.getSelectedRange();
+        context.load(myRange, 'values');
+        console.log(myRange.values);`
+    },
+    {
+      code: `
+        var myRange = context.workbook.worksheets.getSelectedRange();
+        context.load(myRange);
+        console.log(myRange.values);`
+    },
+    {
+      code: `
+        var myRange = context.workbook.worksheets.getSelectedRange();
+        context.load(myRange, ['values', 'address']);
+        console.log(myRange.values);`
     },
   ],
   invalid: [
@@ -220,6 +246,20 @@ ruleTester.run('load-object-before-read', rule, {
         await context.sync();
         console.log(range.format.fill.color);`,
       errors: [{ messageId: "loadBeforeRead", data: { name: "range", loadValue: "format/fill/color" }  }]
+    },
+    {
+      code: `
+        var myRange = context.workbook.worksheets.getSelectedRange();
+        context.load("myRange", "values");
+        console.log(myRange.values);`,
+        errors: [{ messageId: "loadBeforeRead", data: { name: "myRange", loadValue: "values" }  }]  
+    },
+    {
+      code: `
+        var myRange = context.workbook.worksheets.getSelectedRange();
+        context.load(myRange, "values", "address");
+        console.log(myRange.values);`,
+        errors: [{ messageId: "loadBeforeRead", data: { name: "myRange", loadValue: "values" }  }]  
     },
   ]
 });

--- a/packages/eslint-plugin-office-addins/test/rules/no-navigational-load.test.ts
+++ b/packages/eslint-plugin-office-addins/test/rules/no-navigational-load.test.ts
@@ -115,6 +115,12 @@ ruleTester.run('no-navigational-load', rule, {
 		},
 		{
 			code: `
+                var property = worksheet.getItem("sheet");
+                context.load(property, 'styles'); // Navigational`,
+			errors: [{ messageId: "navigationalLoad", data: { loadValue: "styles" } }]
+		},
+		{
+			code: `
                 var range = worksheet.getRange("A1");
                 range.load('fill'); // Navigational`,
 			errors: [{ messageId: "navigationalLoad", data: { loadValue: "fill" } }]
@@ -122,7 +128,20 @@ ruleTester.run('no-navigational-load', rule, {
 		{
 			code: `
                 var range = worksheet.getRange("A1");
+                context.load(range, 'fill'); // Navigational`,
+			errors: [{ messageId: "navigationalLoad", data: { loadValue: "fill" } }]
+		},
+		{
+			code: `
+                var range = worksheet.getRange("A1");
                 range.load("borders/fill");
+                console.log(range.borders.fill); // Navigational`,
+			errors: [{ messageId: "navigationalLoad", data: { loadValue: "borders/fill" } }]
+		},
+		{
+			code: `
+                var range = worksheet.getRange("A1");
+                context.load(range, "borders/fill");
                 console.log(range.borders.fill); // Navigational`,
 			errors: [{ messageId: "navigationalLoad", data: { loadValue: "borders/fill" } }]
 		},

--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -9,13 +9,13 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/teamsfx-cli": "1.2.2",
+        "@microsoft/teamsfx-cli": "^1.2.2",
         "adm-zip": "^0.5.9",
         "commander": "^6.2.0",
         "fs-extra": "^9.0.1",
         "inquirer": "^7.3.3",
         "junk": "^3.1.0",
-        "office-addin-manifest": "^1.12.1",
+        "office-addin-manifest": "^1.12.2",
         "office-addin-usage-data": "^1.6.4",
         "open": "^6.4.0",
         "string_decoder": "1.3.0",
@@ -7629,9 +7629,9 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.1.tgz",
-      "integrity": "sha512-suYuQWXwjQ9X+LMmca1o0xFIRP4JNyWP141IofQD+0FovmCg4SS+rJkmJk5SEtO/bDblijmnX9UZBhwaunIw8w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.2.tgz",
+      "integrity": "sha512-ydhleJHgffUSbEvIKcntRTQlWvkN6geAycSCYh4q40bTEVIuANahcBHlT2oZgfsgaH6+AK0aQsI9TU6mOPU9AQ==",
       "dependencies": {
         "@microsoft/teams-manifest": "^0.0.7",
         "adm-zip": "^0.5.9",
@@ -16272,9 +16272,9 @@
       }
     },
     "office-addin-manifest": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.1.tgz",
-      "integrity": "sha512-suYuQWXwjQ9X+LMmca1o0xFIRP4JNyWP141IofQD+0FovmCg4SS+rJkmJk5SEtO/bDblijmnX9UZBhwaunIw8w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.2.tgz",
+      "integrity": "sha512-ydhleJHgffUSbEvIKcntRTQlWvkN6geAycSCYh4q40bTEVIuANahcBHlT2oZgfsgaH6+AK0aQsI9TU6mOPU9AQ==",
       "requires": {
         "@microsoft/teams-manifest": "^0.0.7",
         "adm-zip": "^0.5.9",


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
A customer reported that the call to context.load(<obj>, <property>) was not being used by the linter rules to recognize that a load for an object had been called.  This change adds that case when detecting load calls and, in the process, refactor a few other things to try and make the rule more readable.  There are 3 rules that take into account the new load recognition and test cases added for those.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Added various linter test cases for the specific load changes for each of the rules affected.