### PR TITLE
[patch] Update json manifest registration check

### DIFF
--- a/packages/office-addin-dev-settings/src/dev-settings-mac.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-mac.ts
@@ -98,8 +98,8 @@ export async function unregisterAddIn(addinId: string, manifestPath: string): Pr
     const manifestFileName = path.basename(manifestPath);
 
     if (registeredFileName === manifestFileName || registeredFileName.startsWith(addinId)) {
-      if (!registeredFileName.endsWith("*.xml")) {
-        unacquireWithTeams(registeredFileName.substring(registeredFileName.indexOf(".")));
+      if (!registeredFileName.endsWith(".xml")) {
+        unacquireWithTeams(registeredFileName.substring(registeredFileName.indexOf(".") + 1));
       }
       fs.unlinkSync(registeredAddIn.manifestPath);
     }
@@ -111,8 +111,8 @@ export async function unregisterAllAddIns(): Promise<void> {
 
   for (const registeredAddIn of registeredAddIns) {
     const registeredFileName = path.basename(registeredAddIn.manifestPath);
-    if (!registeredFileName.endsWith("*.xml")) {
-      unacquireWithTeams(registeredFileName.substring(registeredFileName.indexOf(".")));
+    if (!registeredFileName.endsWith(".xml")) {
+      unacquireWithTeams(registeredFileName.substring(registeredFileName.indexOf(".") + 1));
     }
     fs.unlinkSync(registeredAddIn.manifestPath);
   }


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
The check for xml vs. json manifest registration detection on mac machines were always indicating json manifest.  Needed to update conditional statements (and substring extraction) to look for just the extension

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran test project on Mac machine and ran automated tests.