### PR TITLE
[patch] Change project convert to keep image urls

### DIFF
--- a/packages/office-addin-project/package-lock.json
+++ b/packages/office-addin-project/package-lock.json
@@ -13,7 +13,7 @@
         "commander": "^6.2.1",
         "fs-extra": "^7.0.1",
         "inquirer": "^7.3.3",
-        "office-addin-manifest": "^1.12.0",
+        "office-addin-manifest": "^1.12.2",
         "office-addin-manifest-converter": "^0.1.9",
         "office-addin-usage-data": "^1.6.4",
         "path": "^0.12.7"
@@ -3333,9 +3333,9 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.0.tgz",
-      "integrity": "sha512-9FwCqGX1tj/6kH6qhtMQC+emTiETkN/pbIqBaSnQyszbN834uERbFnJHfvd8jvvNpGnDqgNnRTnV93LifGeDLg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.2.tgz",
+      "integrity": "sha512-ydhleJHgffUSbEvIKcntRTQlWvkN6geAycSCYh4q40bTEVIuANahcBHlT2oZgfsgaH6+AK0aQsI9TU6mOPU9AQ==",
       "dependencies": {
         "@microsoft/teams-manifest": "^0.0.7",
         "adm-zip": "^0.5.9",
@@ -7126,9 +7126,9 @@
       }
     },
     "office-addin-manifest": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.0.tgz",
-      "integrity": "sha512-9FwCqGX1tj/6kH6qhtMQC+emTiETkN/pbIqBaSnQyszbN834uERbFnJHfvd8jvvNpGnDqgNnRTnV93LifGeDLg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.2.tgz",
+      "integrity": "sha512-ydhleJHgffUSbEvIKcntRTQlWvkN6geAycSCYh4q40bTEVIuANahcBHlT2oZgfsgaH6+AK0aQsI9TU6mOPU9AQ==",
       "requires": {
         "@microsoft/teams-manifest": "^0.0.7",
         "adm-zip": "^0.5.9",

--- a/packages/office-addin-project/src/convert.ts
+++ b/packages/office-addin-project/src/convert.ts
@@ -33,7 +33,7 @@ export async function convertProject(
 
   await backupProject(backupPath);
   try {
-    await convert(manifestPath, outputPath, false, false);
+    await convert(manifestPath, outputPath, false /* imageDownload */, true /* imageUrls */);
     updatePackages();
     await updateManifestXmlReferences();
     fs.unlinkSync(manifestPath);


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
Change the call to the manifest convert library to use "true" for preserving URLs. (and updated package version in lock file)

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Converted a xml project created earlier.  Ran automated tests.