### PR TITLE
[patch] Use devPreviewSchema type for json manifest handling

### DIFF
--- a/packages/office-addin-manifest/package-lock.json
+++ b/packages/office-addin-manifest/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/teams-manifest": "^0.0.7",
+        "@microsoft/teams-manifest": "^0.0.9",
         "adm-zip": "^0.5.9",
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@microsoft/teams-manifest": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/teams-manifest/-/teams-manifest-0.0.7.tgz",
-      "integrity": "sha512-H+gIhiRnQNDmQTUGr7mQFn53iu+K/F/6e+BlmzrEddhVJ03BM8o/BkJWMvNBsZREhDtX3re4vS4pCw4L1TI2Eg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/teams-manifest/-/teams-manifest-0.0.9.tgz",
+      "integrity": "sha512-cf7UYn8JxdhL83qshEAnc8vdk+KY4uKJqtlAvPSONVdzJZwO1iPxoyzdo0lTSCB+givg2Ipt4aLob2pCkg0r7w==",
       "dependencies": {
         "ajv": "^8.5.0",
         "ajv-draft-04": "^1.0.0",
@@ -5112,9 +5112,9 @@
       }
     },
     "@microsoft/teams-manifest": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/teams-manifest/-/teams-manifest-0.0.7.tgz",
-      "integrity": "sha512-H+gIhiRnQNDmQTUGr7mQFn53iu+K/F/6e+BlmzrEddhVJ03BM8o/BkJWMvNBsZREhDtX3re4vS4pCw4L1TI2Eg==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/teams-manifest/-/teams-manifest-0.0.9.tgz",
+      "integrity": "sha512-cf7UYn8JxdhL83qshEAnc8vdk+KY4uKJqtlAvPSONVdzJZwO1iPxoyzdo0lTSCB+givg2Ipt4aLob2pCkg0r7w==",
       "requires": {
         "ajv": "^8.5.0",
         "ajv-draft-04": "^1.0.0",

--- a/packages/office-addin-manifest/package.json
+++ b/packages/office-addin-manifest/package.json
@@ -22,7 +22,7 @@
     "Office Add-in"
   ],
   "dependencies": {
-    "@microsoft/teams-manifest": "^0.0.7",
+    "@microsoft/teams-manifest": "^0.0.9",
     "adm-zip": "^0.5.9",
     "chalk": "^2.4.2",
     "commander": "^6.2.0",

--- a/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
+++ b/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { ManifestUtil, TeamsAppManifest } from "@microsoft/teams-manifest";
+import { devPreview, ManifestUtil, TeamsAppManifest } from "@microsoft/teams-manifest";
 import { v4 as uuidv4 } from "uuid";
 import { ManifestInfo } from "../manifestInfo";
 import { ManifestHandler } from "./manifestHandler";
@@ -10,19 +10,19 @@ export class ManifestHandlerJson extends ManifestHandler {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   async modifyManifest(guid?: string, displayName?: string): Promise<TeamsAppManifest> {
     try {
-      const teamsAppManifest: TeamsAppManifest = await ManifestUtil.loadFromPath(this.manifestPath);
+      const appManifest: TeamsAppManifest = await ManifestUtil.loadFromPath(this.manifestPath);
 
       if (typeof guid !== "undefined") {
         if (!guid || guid === "random") {
           guid = uuidv4();
         }
-        teamsAppManifest.id = guid;
+        appManifest.id = guid;
       }
 
       if (typeof displayName !== "undefined") {
-        teamsAppManifest.name.short = displayName;
+        appManifest.name.short = displayName;
       }
-      return teamsAppManifest;
+      return appManifest;
     } catch (err) {
       throw new Error(`Unable to modify json data for manifest file: ${this.manifestPath}. \n${err}`);
     }
@@ -30,35 +30,32 @@ export class ManifestHandlerJson extends ManifestHandler {
 
   async parseManifest(): Promise<ManifestInfo> {
     try {
-      const file: TeamsAppManifest = await ManifestUtil.loadFromPath(this.manifestPath);
+      const file: devPreview.DevPreviewSchema = await ManifestUtil.loadFromPath(this.manifestPath);
       return this.getManifestInfo(file);
     } catch (err) {
       throw new Error(`Unable to read data for manifest file: ${this.manifestPath}. \n${err}`);
     }
   }
 
-  // TODO: change teamsAppManifest type to TeamsAppManifest
-  getManifestInfo(teamsAppManifest: any): ManifestInfo {
+  getManifestInfo(appManifest: devPreview.DevPreviewSchema): ManifestInfo {
     const manifestInfo: ManifestInfo = new ManifestInfo();
 
     // Need to handle mutliple version of the prerelease json manifest schema
-    const extensionElement = teamsAppManifest?.extensions
-      ? teamsAppManifest.extensions[0]
-      : teamsAppManifest?.extension;
+    const extensionElement = appManifest.extensions?.[0];
 
-    manifestInfo.id = teamsAppManifest.id;
-    manifestInfo.appDomains = teamsAppManifest?.validDomains;
-    manifestInfo.defaultLocale = teamsAppManifest?.localizationInfo?.defaultLanguageTag;
-    manifestInfo.description = teamsAppManifest?.description?.short;
-    manifestInfo.displayName = teamsAppManifest?.name?.short;
-    manifestInfo.highResolutionIconUrl = teamsAppManifest?.icons?.color;
+    manifestInfo.id = appManifest.id;
+    manifestInfo.appDomains = appManifest.validDomains;
+    manifestInfo.defaultLocale = appManifest.localizationInfo?.defaultLanguageTag;
+    manifestInfo.description = appManifest.description.short;
+    manifestInfo.displayName = appManifest.name.short;
+    manifestInfo.highResolutionIconUrl = appManifest.icons.color;
     manifestInfo.hosts = extensionElement?.requirements?.scopes;
-    manifestInfo.iconUrl = teamsAppManifest?.icons?.color;
+    manifestInfo.iconUrl = appManifest.icons.color;
     manifestInfo.officeAppType = extensionElement?.requirements?.capabilities?.[0]?.name;
-    manifestInfo.permissions = teamsAppManifest?.authorization?.permissions?.resourceSpecific?.[0]?.name;
-    manifestInfo.providerName = teamsAppManifest?.developer?.name;
-    manifestInfo.supportUrl = teamsAppManifest?.developer?.websiteUrl;
-    manifestInfo.version = teamsAppManifest?.version;
+    manifestInfo.permissions = appManifest.authorization?.permissions?.resourceSpecific?.[0]?.name;
+    manifestInfo.providerName = appManifest.developer.name;
+    manifestInfo.supportUrl = appManifest.developer.websiteUrl;
+    manifestInfo.version = appManifest.version;
 
     return manifestInfo;
   }

--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -481,26 +481,6 @@ describe("Unit Tests", function() {
       });
     });
     describe("readManifestFile() JSON", function() {
-      it("should read the dev preview manifest json info", async function() {
-        const info: ManifestInfo = await OfficeAddinManifest.readManifestFile(path.normalize("test/manifests/devPreviewManifest.json"));
-        assert.strictEqual(info.id, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
-        assert.strictEqual(info.appDomains instanceof Array, true, "appDomains");
-        assert.strictEqual(info.appDomains!.length, 1);
-        assert.strictEqual(info.appDomains![0], "contoso.com");
-        assert.strictEqual(info.defaultLocale, "en-us");
-        assert.strictEqual(info.description, "A template to get started.");
-        assert.strictEqual(info.displayName, "Contoso Task Pane Add-in");
-        assert.strictEqual(info.highResolutionIconUrl, "../assets/icon-128.png", "highResolutionIconUrl");
-        assert.strictEqual(info.hosts instanceof Array, true, "hosts");
-        assert.strictEqual(info.hosts!.length, 1);
-        assert.strictEqual(info.hosts![0], "mail");
-        assert.strictEqual(info.iconUrl, "../assets/icon-128.png", "iconUrl");
-        assert.strictEqual(info.officeAppType, "AddinCommands");
-        assert.strictEqual(info.permissions, "Mailbox.ReadWrite");
-        assert.strictEqual(info.providerName, "Contoso");
-        assert.strictEqual(info.supportUrl, "https://www.contoso.com");
-        assert.strictEqual(info.version, "1.0.0");
-      });
       it("should read the manifest json info", async function() {
         const info: ManifestInfo = await OfficeAddinManifest.readManifestFile(path.normalize("test/manifests/manifest.json"));
         assert.strictEqual(info.id, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
Update the package reference for teams-manifest and then use devPreview.DevPreviewSchema type for json manifest handling.  Note this will remove compatibility of older json manifest schema versions, but an unpublished major version has already happened for similar breaking changes.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
Potentially.  Previous documentation on json manifest projects may not be valid anymore (dev preview from May 2022 will not work any more)

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Manually created a project and used the script that depend on this to deploy a json manifest project.  Ran automated tests.