### PR TITLE
[patch] Fix dev-certs verify.ps1

### DIFF
--- a/packages/office-addin-dev-certs/scripts/verify.ps1
+++ b/packages/office-addin-dev-certs/scripts/verify.ps1
@@ -30,7 +30,7 @@ if ($PSVersionTable.PSVersion.Major -le 5) {
 if(Get-Command -name Import-Certificate -ErrorAction SilentlyContinue){
     $result = Get-ChildItem cert:\\CurrentUser\\Root | Where-Object Issuer -like "*CN=$CaCertificateName*"
     if (!$ReturnInvalidCertificate) {
-        $result = $result | Where-Object { $_.NotAfter -gt (Get-Date) }
+        $result = $result | Where-Object { $_.NotAfter -gt (Get-Date).AddDays(1) }
         if ($result -and ($result.Length -eq 1) -and (Test-Path $CaCertificatePath) -and (Test-Path $LocalhostCertificatePath)) {
             # Check that CA certificate in store is the same as ca.crt
             $caCert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CaCertificatePath)
@@ -59,5 +59,5 @@ if(Get-Command -name Import-Certificate -ErrorAction SilentlyContinue){
 }
 else{
     # Legacy system support
-    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object { $_.Subject -like "*CN=$CaCertificateName*"} | Where-Object { $_.NotAfter -gt (Get-Date) } | Format-List
+    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object { $_.Subject -like "*CN=$CaCertificateName*"} | Where-Object { $_.NotAfter -gt (Get-Date).AddDays(1) } | Format-List
 }

--- a/packages/office-addin-dev-certs/scripts/verify.ps1
+++ b/packages/office-addin-dev-certs/scripts/verify.ps1
@@ -30,7 +30,7 @@ if ($PSVersionTable.PSVersion.Major -le 5) {
 if(Get-Command -name Import-Certificate -ErrorAction SilentlyContinue){
     $result = Get-ChildItem cert:\\CurrentUser\\Root | Where-Object Issuer -like "*CN=$CaCertificateName*"
     if (!$ReturnInvalidCertificate) {
-        $result = $result | Where-Object { $_.NotAfter -gt [datetime]::today.AddDays(-1) }
+        $result = $result | Where-Object { $_.NotAfter -gt (Get-Date) }
         if ($result -and ($result.Length -eq 1) -and (Test-Path $CaCertificatePath) -and (Test-Path $LocalhostCertificatePath)) {
             # Check that CA certificate in store is the same as ca.crt
             $caCert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CaCertificatePath)
@@ -59,5 +59,5 @@ if(Get-Command -name Import-Certificate -ErrorAction SilentlyContinue){
 }
 else{
     # Legacy system support
-    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object { $_.Subject -like "*CN=$CaCertificateName*"} | Where-Object { $_.NotAfter -gt [datetime]::today.AddDays(-1) } | Format-List
+    Get-ChildItem cert:\\CurrentUser\\Root | Where-Object { $_.Subject -like "*CN=$CaCertificateName*"} | Where-Object { $_.NotAfter -gt (Get-Date) } | Format-List
 }


### PR DESCRIPTION
**Change Description**:

Previously, it could be expired for up to 2 days but still verify.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No


**Validation/testing performed**:

I can now run my addin from vscode and not see
![image](https://user-images.githubusercontent.com/5975405/226066548-b198074d-a533-4ce9-be89-341f7a7b7d52.png)

but now I just see blank and it's stuck saying "We're loading the add-ins run time" Not sure if it's related or not.

