### PR TITLE
[patch] Prevent false positive in Root CA certificate check by ignoring extraneous PowerShell output

### DIFF
--- a/packages/office-addin-dev-certs/scripts/verify.ps1
+++ b/packages/office-addin-dev-certs/scripts/verify.ps1
@@ -14,9 +14,19 @@ Param (
     [string]
     $LocalhostCertificatePath,
 
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $OutputMarker,
+
     [switch]
     $ReturnInvalidCertificate
 )
+
+# An optional output marker that can be used to find the beginning of this script's output
+if ($OutputMarker) {
+    Write-Output $OutputMarker
+}
 
 # Without this, the script always succeeds (exit code = 0)
 $ErrorActionPreference = 'Stop'

--- a/packages/office-addin-dev-certs/test/test.ts
+++ b/packages/office-addin-dev-certs/test/test.ts
@@ -232,7 +232,8 @@ describe("office-addin-dev-certs", function() {
             if (process.platform === "darwin") {
                 execSync = sandbox.fake.throws("test error");
             } else {
-                execSync = sandbox.fake.returns("");
+                // output marker is an empty string on platforms other than win32
+                execSync = sandbox.fake.returns(verify.outputMarker);
             }
             sandbox.stub(childProcess, "execSync").callsFake(execSync);
             try {
@@ -245,7 +246,8 @@ describe("office-addin-dev-certs", function() {
             }
         });
         it("certificate found in trusted store case", async function() {
-            const execSync = sandbox.fake.returns("Certificate details");
+            // output marker is an empty string on platforms other than win32
+            const execSync = sandbox.fake.returns(`${verify.outputMarker}Certificate details`);
             sandbox.stub(childProcess, "execSync").callsFake(execSync);
             try {
                 const ret = await verify.isCaCertificateInstalled();


### PR DESCRIPTION
The Root CA certificate wasn't properly installed when running `npm start`, turns out the installation was skipped because the code interpreted PowerShell output from my profile as a successful check for an installed certificate.

The change: A PowerShell command might generate initial output (in my case it was some information echo'd in my profile) - this broke the check since the code assumes the cert exists if *any content* is returned. The code now only returns true if the name of the certificate is contained in the returned output:
```bash
Subject      : O=Developer CA for Microsoft Office Add-ins, L=Redmond, S=WA, C=US, CN=Developer CA for Microsoft
               Office Add-ins
```
The code matches the **`O=Developer CA for Microsoft Office Add-ins,`** part.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No

**Validation/testing performed**:

I ran `npm start` without the change and the Root CA certificate was not installed. After the change, `npm start` correctly determined the certificate wasn't present and installed it.
