### PR TITLE
Cf plugin multiple function files

### DIFF
--- a/packages/custom-functions-metadata-plugin/package-lock.json
+++ b/packages/custom-functions-metadata-plugin/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.7",
       "license": "MIT",
       "dependencies": {
-        "custom-functions-metadata": "^1.4.5"
+        "custom-functions-metadata": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^14.17.2",
@@ -19,7 +19,7 @@
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
-        "webpack": "^5.24.4"
+        "webpack": "^5.76.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1377,12 +1377,12 @@
       }
     },
     "node_modules/custom-functions-metadata": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.4.5.tgz",
-      "integrity": "sha512-5t1YtziYLshyhcAw8cBfjXhl887Ysltubt2gZXQm6hjLVQCoAmZ47L5wJoe5iVQlYcZUzVygBIDeIQ23H4n7TA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.5.0.tgz",
+      "integrity": "sha512-m6a2vK5YBh7ybhpkI/X9PItO5+ZU6Ww+Y3bJ7kK/5x3Y1zaAh3HvVoSIDD0/SViSonxiimMQdE1WNgHbDbXNWw==",
       "dependencies": {
         "assert": "^1.5.0",
-        "commander": "^6.2.0",
+        "commander": "^10.0.0",
         "nconf": "^0.12.0",
         "office-addin-usage-data": "^1.6.5",
         "xregexp": "^4.3.0"
@@ -1392,11 +1392,11 @@
       }
     },
     "node_modules/custom-functions-metadata/node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
       "engines": {
-        "node": ">= 6"
+        "node": ">=14"
       }
     },
     "node_modules/date-fns": {
@@ -5264,21 +5264,21 @@
       }
     },
     "custom-functions-metadata": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.4.5.tgz",
-      "integrity": "sha512-5t1YtziYLshyhcAw8cBfjXhl887Ysltubt2gZXQm6hjLVQCoAmZ47L5wJoe5iVQlYcZUzVygBIDeIQ23H4n7TA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/custom-functions-metadata/-/custom-functions-metadata-1.5.0.tgz",
+      "integrity": "sha512-m6a2vK5YBh7ybhpkI/X9PItO5+ZU6Ww+Y3bJ7kK/5x3Y1zaAh3HvVoSIDD0/SViSonxiimMQdE1WNgHbDbXNWw==",
       "requires": {
         "assert": "^1.5.0",
-        "commander": "^6.2.0",
+        "commander": "^10.0.0",
         "nconf": "^0.12.0",
         "office-addin-usage-data": "^1.6.5",
         "xregexp": "^4.3.0"
       },
       "dependencies": {
         "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+          "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA=="
         }
       }
     },

--- a/packages/custom-functions-metadata-plugin/package.json
+++ b/packages/custom-functions-metadata-plugin/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "webpack": "^5.24.4"
+    "webpack": "^5.76.0"
   },
   "gitHead": "dffbcd4d1397534105b98fb13ba0fb1c3aba2dea"
 }

--- a/packages/custom-functions-metadata-plugin/src/loader.ts
+++ b/packages/custom-functions-metadata-plugin/src/loader.ts
@@ -1,16 +1,19 @@
 import { IAssociate } from "custom-functions-metadata";
 import CustomFunctionsMetadataPlugin from "./customfunctionsplugin";
 
+// Add associate calls to the functions file's source (one file)
 function addFunctionAssociations(this: any, source: string): string {
   const input = this.getOptions().input as string;
+  const file = this.getOptions().file as string;
   if (!CustomFunctionsMetadataPlugin.generateResults[input]) {
     return source;
   }
-  CustomFunctionsMetadataPlugin.generateResults[input].associate.forEach(
-    (item: IAssociate) => {
-      source += `\nCustomFunctions.associate("${item.id}", ${item.functionName});`;
-    }
-  );
+  const associations = CustomFunctionsMetadataPlugin.generateResults[
+    input
+  ].associate.filter((item: IAssociate) => item.sourceFileName === file);
+  associations.forEach((item: IAssociate) => {
+    source += `\nCustomFunctions.associate("${item.id}", ${item.functionName});`;
+  });
   return source;
 }
 


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
Update custom functions plugin to take in multiple files as input to pass to the metadata generator.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
Maybe . . . the webpack config file will now allow for an array of strings in the plugin configuration.  Not sure if this plugin is referenced anywhere in our documentation.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Tried on a test project with different webpack configurations.