### PR TITLE
[patch] Ignore trailing \r in parsed processId

### DIFF
--- a/packages/office-addin-debugging/src/port.ts
+++ b/packages/office-addin-debugging/src/port.ts
@@ -75,7 +75,7 @@ export function getProcessIdsForPort(port: number): Promise<number[]> {
           lines.forEach((line) => {
             /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             const [protocol, localAddress, foreignAddress, status, processId] = line.trim().split(" ").filter((text) => text);
-            if (processId !== undefined && processId !== '0') {
+            if (processId !== undefined && processId.trim() !== '0') {
               const localAddressPort = parsePort(localAddress);
               if (localAddressPort === port) {
                 processIds.add(parseInt(processId, 10));


### PR DESCRIPTION
In Windows, `npm start` often fails to start the dev server, logging `The dev server is already running on port 3000`, even though it's been stopped with `npm stop` before.  Only the first `npm stop` call shows that it found a process id to stop, so the server is indeed being stopped correctly.

The issue is caused by `getProcessIdsForPort()` often returning `[ 0 ]` and interpreting it as _there's a pid so the server is still running_, since the line being parsed contains a trailing "\r" which breaks the check `!== '0'` in https://github.com/OfficeDev/Office-Addin-Scripts/blob/master/packages/office-addin-debugging/src/port.ts#L78
```ts
if (processId !== undefined && processId !== '0') {
```

Logging the parts being parsed in [`getProcessIdsForPort()`](https://github.com/OfficeDev/Office-Addin-Scripts/blob/master/packages/office-addin-debugging/src/port.ts#L77) shows this:
```js
{
  protocol: 'TCP',
  localAddress: '[::1]:3000',
  foreignAddress: '[::1]:50300',
  status: 'TIME_WAIT',
  processId: '0\r'
}
{
  protocol: 'TCP',
  localAddress: '[::1]:3000',
  foreignAddress: '[::1]:50301',
  status: 'TIME_WAIT',
  processId: '0\r'
}
{
  protocol: 'TCP',
  localAddress: '[::1]:3000',
  foreignAddress: '[::1]:50302',
  status: 'TIME_WAIT',
  processId: '0\r'
}
```

`processId.trim()` fixes the check and can be called since we've already guarded against `undefined` before.

_This PR does not impact command syntax or documentation. Testing has been done manually on Win32 (the change affects Windows only)_
