### PR TITLE
[patch] Update version of manifest converter package dependency

### DIFF
--- a/packages/office-addin-project/package-lock.json
+++ b/packages/office-addin-project/package-lock.json
@@ -14,7 +14,7 @@
         "fs-extra": "^7.0.1",
         "inquirer": "^7.3.3",
         "office-addin-manifest": "^1.12.5",
-        "office-addin-manifest-converter": "^0.2.3",
+        "office-addin-manifest-converter": "^0.2.4",
         "office-addin-usage-data": "^1.6.5",
         "path": "^0.12.7"
       },
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/office-addin-manifest-converter": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.2.3.tgz",
-      "integrity": "sha512-X7w+iRtiO1HbS2/NJNH/8ZP8YYrbt9x7IgqCppLKCU+zJqZoRGbcVjb2RxOtVUGzVWV2aPlxBnqEsQ1eftQHcg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.2.4.tgz",
+      "integrity": "sha512-TGL6tUEbnMjVxFm/6XddwUkyF4a9947IxHETP2I/hqtFTD2JXoRVi2bQ6l5x938bla450mu3nfof0QFJtwbgHw==",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.5",
         "commander": "^9.0.0",
@@ -7216,9 +7216,9 @@
       }
     },
     "office-addin-manifest-converter": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.2.3.tgz",
-      "integrity": "sha512-X7w+iRtiO1HbS2/NJNH/8ZP8YYrbt9x7IgqCppLKCU+zJqZoRGbcVjb2RxOtVUGzVWV2aPlxBnqEsQ1eftQHcg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.2.4.tgz",
+      "integrity": "sha512-TGL6tUEbnMjVxFm/6XddwUkyF4a9947IxHETP2I/hqtFTD2JXoRVi2bQ6l5x938bla450mu3nfof0QFJtwbgHw==",
       "requires": {
         "@xmldom/xmldom": "^0.8.5",
         "commander": "^9.0.0",

--- a/packages/office-addin-project/package.json
+++ b/packages/office-addin-project/package.json
@@ -23,7 +23,7 @@
     "fs-extra": "^7.0.1",
     "inquirer": "^7.3.3",
     "office-addin-manifest": "^1.12.5",
-    "office-addin-manifest-converter": "^0.2.3",
+    "office-addin-manifest-converter": "^0.2.4",
     "office-addin-usage-data": "^1.6.5",
     "path": "^0.12.7"
   },


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
Update the version of office-addin-manifest-converter (for converting xml => json) that we depend on (which includes a P0 bug fix)

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran automated tests.