### PR TITLE
[minor] Add Arch Linux support to certificate installation

### DIFF
--- a/packages/office-addin-dev-certs/scripts/install_linux.sh
+++ b/packages/office-addin-dev-certs/scripts/install_linux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -f "/usr/sbin/update-ca-certificates" ]; then
+     sudo mkdir -p /usr/local/share/ca-certificates/office-addin-dev-certs && sudo cp $1 /usr/local/share/ca-certificates/office-addin-dev-certs && sudo /usr/sbin/update-ca-certificates
+elif [ -f "/usr/sbin/update-ca-trust" ]; then
+    sudo cp $1 /etc/ca-certificates/trust-source/anchors/office-addin-dev-certs-ca.crt && sudo /usr/sbin/update-ca-trust
+fi

--- a/packages/office-addin-dev-certs/scripts/uninstall_linux.sh
+++ b/packages/office-addin-dev-certs/scripts/uninstall_linux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -f "/usr/sbin/update-ca-certificates" ]; then
+    sudo rm -r /usr/local/share/ca-certificates/office-addin-dev-certs/$1 && sudo /usr/sbin/update-ca-certificates --fresh
+elif [ -f "/usr/sbin/update-ca-trust" ]; then
+    sudo rm -r /etc/ca-certificates/trust-source/anchors/office-addin-dev-certs-ca.crt && sudo /usr/sbin/update-ca-trust
+fi

--- a/packages/office-addin-dev-certs/scripts/verify_linux.sh
+++ b/packages/office-addin-dev-certs/scripts/verify_linux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -f "/usr/sbin/update-ca-certificates" ]; then
+    echo [ -f /usr/local/share/ca-certificates/office-addin-dev-certs/$1 ] && openssl x509 -in /usr/local/share/ca-certificates/office-addin-dev-certs/$1 -checkend 86400 -noout
+elif [ -f "/usr/sbin/update-ca-trust" ]; then
+    echo [ -f /etc/ca-certificates/trust-source/anchors/office-addin-dev-certs-ca.crt ] && openssl x509 -in /etc/ca-certificates/trust-source/anchors/office-addin-dev-certs-ca.crt -checkend 86400 -noout
+fi

--- a/packages/office-addin-dev-certs/src/install.ts
+++ b/packages/office-addin-dev-certs/src/install.ts
@@ -25,7 +25,8 @@ function getInstallCommand(caCertificatePath: string, machine: boolean = false):
       const keychainFile = machine ? "/Library/Keychains/System.keychain" : "~/Library/Keychains/login.keychain-db"
       return `${prefix}security add-trusted-cert -d -r trustRoot -k ${keychainFile} '${caCertificatePath}'`;
     case "linux":
-      return `sudo mkdir -p /usr/local/share/ca-certificates/office-addin-dev-certs && sudo cp ${caCertificatePath} /usr/local/share/ca-certificates/office-addin-dev-certs && sudo /usr/sbin/update-ca-certificates`;
+      const script = path.resolve(__dirname, "../scripts/install_linux.sh");
+      return `sudo sh '${script}' '${caCertificatePath}'`;
     default:
       throw new ExpectedError(`Platform not supported: ${process.platform}`);
   }

--- a/packages/office-addin-dev-certs/src/uninstall.ts
+++ b/packages/office-addin-dev-certs/src/uninstall.ts
@@ -25,7 +25,8 @@ function getUninstallCommand(machine: boolean = false): string {
       return `sudo sh '${script}' '${defaults.certificateName}'`;
     }
     case "linux":
-      return `sudo rm -r /usr/local/share/ca-certificates/office-addin-dev-certs/${defaults.caCertificateFileName} && sudo /usr/sbin/update-ca-certificates --fresh`;
+      const script = path.resolve(__dirname, "../scripts/uninstall_linux.sh");
+      return `sudo sh '${script}' '${defaults.certificateName}'`;
     default:
       throw new ExpectedError(`Platform not supported: ${process.platform}`);
   }

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -30,7 +30,8 @@ function getVerifyCommand(returnInvalidCertificate: boolean): string {
       return `sh '${script}' '${defaults.certificateName}'`;
     }
     case "linux":
-      return `[ -f /usr/local/share/ca-certificates/office-addin-dev-certs/${defaults.caCertificateFileName} ] && openssl x509 -in /usr/local/share/ca-certificates/office-addin-dev-certs/${defaults.caCertificateFileName} -checkend 86400 -noout`;
+      const script = path.resolve(__dirname, "../scripts/verify_linux.sh");
+      return `sh '${script}' '${defaults.certificateName}'`;
     default:
       throw new ExpectedError(`Platform not supported: ${process.platform}`);
   }


### PR DESCRIPTION
I did put it as minor, however I have not tested changes on Ubuntu. Hopefully someone else can test, but I will have access to Ubuntu machine in a few days, I can do the tests.

**Change Description**:

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    `npm run dev-server` or `npm run start:web` are affected, it now works on Arch Linux properly.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
    no

**Validation/testing performed**:

I tested on Arch running `npm run dev-server` and `npm run start:web`, it properly verifies and installs the certificate and changes are propagated to Сhromium. Without a need to manually trust these certificates.

**Important note**:
Since the folder structure is different for Arch and Ubuntu, in the Arch version the certificate file name is not `defaults.certificateName`, but is hardcoded, it can be changed to `some_prefix_${defaults.certificateName}` if needed.

**More info about Linux Certificates**
https://wiki.archlinux.org/title/User:Grawity/Adding_a_trusted_CA_certificate

Fixes #765