### PR TITLE
[minor] Add method for setting a "RefreshAddins" registry key.

### DIFF
--- a/packages/office-addin-dev-settings/src/dev-settings-mac.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-mac.ts
@@ -72,11 +72,12 @@ export async function registerAddIn(manifestPath: string, officeApps?: OfficeApp
         registration = await registerWithTeams(zipPath);
       }
 
-      // TODO: when mac outlook support dev sideload
-      // Save registration in "OutlookSideloadManifestPath" as "TitleId"
+      // TODO: Save registration in "OutlookSideloadManifestPath" as "TitleId"
+      // and add support for refreshing add-ins in Outlook via registry key
+
     } else if (manifestPath.endsWith(".xml")) {
-      // TODO: when mac outlook support dev sideload
-      // Look for "Outlook" in manifests.hosts and enable outlook sideloading if there.
+      // TODO: Look for "Outlook" in manifests.hosts and enable outlook sideloading if there.
+      // and add support for refreshing add-ins in Outlook via registry key
     }
 
     // Save manifest path in "registry"
@@ -110,6 +111,7 @@ export async function unregisterAddIn(addinId: string, manifestPath: string): Pr
     if (registeredFileName === manifestFileName || registeredFileName.startsWith(addinId)) {
       if (!registeredFileName.endsWith(".xml")) {
         unacquireWithTeams(registeredFileName.substring(registeredFileName.indexOf(".") + 1));
+        // TODO: Add support for refreshing add-ins in Outlook via registry key
       }
       fs.unlinkSync(registeredAddIn.manifestPath);
     }
@@ -123,7 +125,8 @@ export async function unregisterAllAddIns(): Promise<void> {
     const registeredFileName = path.basename(registeredAddIn.manifestPath);
     if (!registeredFileName.endsWith(".xml")) {
       unacquireWithTeams(registeredFileName.substring(registeredFileName.indexOf(".") + 1));
-    }
+        // TODO: Add support for refreshing add-ins in Outlook via registry key
+      }
     fs.unlinkSync(registeredAddIn.manifestPath);
   }
 }

--- a/packages/office-addin-dev-settings/src/dev-settings-windows.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-windows.ts
@@ -22,6 +22,7 @@ const DeveloperSettingsRegistryKey: string = `HKEY_CURRENT_USER\\SOFTWARE\\Micro
 
 const OpenDevTools: string = "OpenDevTools";
 export const OutlookSideloadManifestPath: string = "OutlookSideloadManifestPath";
+const RefreshAddins: string = "RefreshAddins";
 const RuntimeLogging: string = "RuntimeLogging";
 const SourceBundleExtension: string = "SourceBundleExtension";
 const SourceBundleHost: string = "SourceBundleHost";
@@ -71,12 +72,6 @@ export async function enableDebugging(
 export async function enableLiveReload(addinId: string, enable: boolean = true): Promise<void> {
   const key = getDeveloperSettingsRegistryKey(addinId);
   return registry.addBooleanValue(key, UseLiveReload, enable);
-}
-
-async function enableOutlookSideloading(manifestPath: string): Promise<void> {
-  const key = getDeveloperSettingsRegistryKey(OutlookSideloadManifestPath);
-
-  return registry.addStringValue(key, "", manifestPath); // empty string for the default value
 }
 
 export async function enableRuntimeLogging(path: string): Promise<void> {
@@ -193,6 +188,7 @@ export async function registerAddIn(manifestPath: string, registration?: string)
         filePath = manifestPath;
       }
       registration = await registerWithTeams(filePath);
+      enableRefreshAddins();
     }
 
     const key = getDeveloperSettingsRegistryKey(OutlookSideloadManifestPath);
@@ -318,6 +314,12 @@ async function unacquire(key: registry.RegistryKey, id: string) {
     if (registration != undefined) {
       unacquireWithTeams(registration);
       registry.deleteValue(key, TitleId);
+      enableRefreshAddins();
     }
   }
+}
+
+async function enableRefreshAddins() {
+  const key = new registry.RegistryKey(`${DeveloperSettingsRegistryKey}`);
+  await registry.addBooleanValue(key, RefreshAddins, true);
 }

--- a/packages/office-addin-dev-settings/src/publish.ts
+++ b/packages/office-addin-dev-settings/src/publish.ts
@@ -24,7 +24,6 @@ export async function registerWithTeams(filePath: string): Promise<string> {
           reject(error);
         } else {
           console.log(`\n${stdout}\nSuccessfully registered package! (${titleId})\n STDERR: ${stderr}\n`);
-          forceCacheUpdate();
           resolve(titleId);
         }
       });
@@ -62,39 +61,8 @@ export async function unacquireWithTeams(titleId: string): Promise<void> {
         reject(error);
       } else {
         console.log(`\n${stdout}\nSuccessfully unacquired title!\n STDERR: ${stderr}\n`);
-        forceCacheUpdate();
         resolve();
       }
     });
   });
-}
-
-function forceCacheUpdate() {
-  // TODO: find HubAppFileCache on Mac and do the same targeted delete
-  if (process.platform === "win32") {
-    const cachePath: string = path.join(process.env.LOCALAPPDATA as string, "Microsoft\\Outlook\\HubAppFileCache");
-
-    if (fs.existsSync(cachePath)) {
-      // Get list of folders with hashed names
-      const subFolders: fs.Dirent[] = fs.readdirSync(cachePath, { withFileTypes: true }).filter((entry: fs.Dirent) => {
-        return entry.isDirectory();
-      });
-
-      // Delete any found file that prevents TAOS service calls
-      subFolders.forEach((folder: fs.Dirent) => {
-        const targetFiles: string[] = [
-          path.resolve(cachePath, folder.name, "TaosSource\\CacheProperties"),
-          path.resolve(cachePath, folder.name, "TaosSource\\PersistedCacheSynced"),
-          path.resolve(cachePath, folder.name, "TaosSource\\u8qUM7HfoAFQ6YiuZO0RVQ=="),
-          path.resolve(cachePath, folder.name, "TaosSource\\ZplQ1yfT07QnEV2xMoi+GQ=="),
-        ];
-        targetFiles.forEach((file) => {
-          if (fs.existsSync(file)) {
-            console.log(`Deleting File: ${file}`);
-            fs.unlinkSync(file);
-          }
-        });
-      });
-    }
-  }
 }


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:

    For the json manifest scenario, removing the cache modification call that were added as a workaround and replace it with setting a registry key that will signal to the host app that a refresh of add-ins is needed.  This will work for both sideloading and unacquiring.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran automated tests.  Create local package that was installed with a test project and used to verify registry was set.  This was test in combination with the host change to read the registry value and clear it.