### PR TITLE
[patch] Fix sideload bugs with path (spaces) and registery (dependency flaw)

### DIFF
--- a/packages/office-addin-dev-settings/package-lock.json
+++ b/packages/office-addin-dev-settings/package-lock.json
@@ -14,12 +14,12 @@
         "fs-extra": "^9.0.1",
         "inquirer": "^7.3.3",
         "junk": "^3.1.0",
-        "office-addin-manifest": "^1.12.7",
-        "office-addin-usage-data": "^1.6.7",
+        "office-addin-manifest": "^1.12.8",
+        "office-addin-usage-data": "^1.6.8",
         "open": "^6.4.0",
         "string_decoder": "1.3.0",
         "whatwg-url": "^7.1.0",
-        "winreg": "^1.2.4"
+        "winreg": "1.2.4"
       },
       "bin": {
         "office-addin-dev-settings": "cli.js"
@@ -38,7 +38,7 @@
         "concurrently": "^6.2.2",
         "cpy-cli": "4.1.0",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^2.2.7",
+        "office-addin-lint": "^2.2.8",
         "rimraf": "^3.0.2",
         "sinon": "^7.5.0",
         "ts-node": "^10.9.1",
@@ -636,12 +636,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -904,19 +904,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1009,9 +1009,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -1070,9 +1070,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -2936,9 +2936,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
-      "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/jsonfile": {
@@ -5468,9 +5468,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.7.tgz",
-      "integrity": "sha512-LyuYvSJ1xvcXa8s6BZT5XQ84beweziuuj88mKL+bSNMflAtcJFUtiErG/Z6baH/dh/Jgp2yTwaoyNTuJJrrSRw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.8.tgz",
+      "integrity": "sha512-ReXyUE8DvbIE/eFRhiSc4iSJXNqetWMC6+3s+wA5xwRuu33GBDM89LUEo2GUbdGD90S/A9mIcLDTk7gt1M+SSQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -9216,9 +9216,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.7.tgz",
-      "integrity": "sha512-Va84C1X5DH7mgGgK08GE2KF97zUe2S328c7wkzJI3hqHgXPxwOjNAisAV42FH/XNB0TEyugufxpPW+NWKHdIIA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.8.tgz",
+      "integrity": "sha512-SFlt1QNyy6TvCqDVzFbIeQqEtmzTMduRcCvRW9GjrbPv+7lp2UUfhe2IiCtL9Webtv/LoJUZdLQwg3k5jUL7Ew==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -9226,10 +9226,10 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^2.1.7",
+        "eslint-plugin-office-addins": "^2.1.8",
         "eslint-plugin-prettier": "^3.3.1",
         "office-addin-prettier-config": "^1.2.0",
-        "office-addin-usage-data": "^1.6.7",
+        "office-addin-usage-data": "^1.6.8",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -9237,9 +9237,9 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.7.tgz",
-      "integrity": "sha512-FtcosrQFyFxpGtk375JoHlsvEqYKt/Yi46ucUHdsi4f5axZKD3kd9geNq3dHaUYH3wXz679Wj67zTzF511R4QQ==",
+      "version": "1.12.8",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.8.tgz",
+      "integrity": "sha512-N6nwnaPaRuRe1tbNzOYbG/CYG+eDli21b5x0g4E6mfWwpmNJCITim45tU2MCYpounVbxNfAv3s+Gnka69V0k9w==",
       "dependencies": {
         "@microsoft/teams-manifest": "^0.1.0",
         "adm-zip": "^0.5.9",
@@ -9247,7 +9247,7 @@
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.6.7",
+        "office-addin-usage-data": "^1.6.8",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.5.0"
@@ -9422,9 +9422,9 @@
       }
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.7.tgz",
-      "integrity": "sha512-O3sAYt+DsW2VUBrc1/kpbLqJIJYNzEDiOlkQ/eBPZm1QjlPxTB/hFdfZ9xamaou0Fcx8Twvi2O609tTZl6+liw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.8.tgz",
+      "integrity": "sha512-D/yyctao9VoatKTvAR+fAyajEbKaVuTTjRgJjYOY6dI8MxubQWKSxjMbowyUFxAY/HkDXAIg6nGV8SmuQUONLQ==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
@@ -12921,12 +12921,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -13042,9 +13042,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true
     },
     "@babel/runtime": {
@@ -13130,19 +13130,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -13216,9 +13216,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -13264,9 +13264,9 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -14827,9 +14827,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
-      "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "@types/jsonfile": {
@@ -16823,9 +16823,9 @@
       "requires": {}
     },
     "eslint-plugin-office-addins": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.7.tgz",
-      "integrity": "sha512-LyuYvSJ1xvcXa8s6BZT5XQ84beweziuuj88mKL+bSNMflAtcJFUtiErG/Z6baH/dh/Jgp2yTwaoyNTuJJrrSRw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-2.1.8.tgz",
+      "integrity": "sha512-ReXyUE8DvbIE/eFRhiSc4iSJXNqetWMC6+3s+wA5xwRuu33GBDM89LUEo2GUbdGD90S/A9mIcLDTk7gt1M+SSQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -19616,9 +19616,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.7.tgz",
-      "integrity": "sha512-Va84C1X5DH7mgGgK08GE2KF97zUe2S328c7wkzJI3hqHgXPxwOjNAisAV42FH/XNB0TEyugufxpPW+NWKHdIIA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.8.tgz",
+      "integrity": "sha512-SFlt1QNyy6TvCqDVzFbIeQqEtmzTMduRcCvRW9GjrbPv+7lp2UUfhe2IiCtL9Webtv/LoJUZdLQwg3k5jUL7Ew==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -19626,17 +19626,17 @@
         "commander": "^6.2.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-office-addins": "^2.1.7",
+        "eslint-plugin-office-addins": "^2.1.8",
         "eslint-plugin-prettier": "^3.3.1",
         "office-addin-prettier-config": "^1.2.0",
-        "office-addin-usage-data": "^1.6.7",
+        "office-addin-usage-data": "^1.6.8",
         "prettier": "^2.2.1"
       }
     },
     "office-addin-manifest": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.7.tgz",
-      "integrity": "sha512-FtcosrQFyFxpGtk375JoHlsvEqYKt/Yi46ucUHdsi4f5axZKD3kd9geNq3dHaUYH3wXz679Wj67zTzF511R4QQ==",
+      "version": "1.12.8",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.12.8.tgz",
+      "integrity": "sha512-N6nwnaPaRuRe1tbNzOYbG/CYG+eDli21b5x0g4E6mfWwpmNJCITim45tU2MCYpounVbxNfAv3s+Gnka69V0k9w==",
       "requires": {
         "@microsoft/teams-manifest": "^0.1.0",
         "adm-zip": "^0.5.9",
@@ -19644,7 +19644,7 @@
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
         "node-fetch": "^2.6.1",
-        "office-addin-usage-data": "^1.6.7",
+        "office-addin-usage-data": "^1.6.8",
         "path": "^0.12.7",
         "uuid": "^8.3.2",
         "xml2js": "^0.5.0"
@@ -19789,9 +19789,9 @@
       }
     },
     "office-addin-usage-data": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.7.tgz",
-      "integrity": "sha512-O3sAYt+DsW2VUBrc1/kpbLqJIJYNzEDiOlkQ/eBPZm1QjlPxTB/hFdfZ9xamaou0Fcx8Twvi2O609tTZl6+liw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.8.tgz",
+      "integrity": "sha512-D/yyctao9VoatKTvAR+fAyajEbKaVuTTjRgJjYOY6dI8MxubQWKSxjMbowyUFxAY/HkDXAIg6nGV8SmuQUONLQ==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",

--- a/packages/office-addin-dev-settings/package.json
+++ b/packages/office-addin-dev-settings/package.json
@@ -32,7 +32,7 @@
     "open": "^6.4.0",
     "string_decoder": "1.3.0",
     "whatwg-url": "^7.1.0",
-    "winreg": "^1.2.4"
+    "winreg": "1.2.4"
   },
   "peerDependencies": {
     "@microsoft/teamsfx-cli": "2.0.3-alpha.e5db52f29.0"

--- a/packages/office-addin-dev-settings/src/publish.ts
+++ b/packages/office-addin-dev-settings/src/publish.ts
@@ -13,7 +13,7 @@ export async function registerWithTeams(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
     if ((filePath.endsWith(".zip") || filePath.endsWith(".xml")) && fs.existsSync(filePath)) {
       const pathSwitch = filePath.endsWith(".zip") ? "--file-path" : "--xml-path";
-      const sideloadCommand = `npx -p @microsoft/teamsfx-cli@2.0.3-alpha.e5db52f29.0 teamsfx m365 sideloading ${pathSwitch} ${filePath}`;
+      const sideloadCommand = `npx -p @microsoft/teamsfx-cli@2.0.3-alpha.e5db52f29.0 teamsfx m365 sideloading ${pathSwitch} "${filePath}"`;
 
       console.log(`running: ${sideloadCommand}`);
       childProcess.exec(sideloadCommand, (error, stdout, stderr) => {


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:

    Fix two bugs:
   - teamsfx-cli command needed to quote the manifest path
   - The new version of winreg has a bug in it when values contain spaces

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
 Ran automated test.  Tried local package in projects using an xml manifest and a json manifest each with project names that cotained spaces.