### PR TITLE
[minor] Fix 'uninstall' and 'verify' for Linux platform in office-addin-dev-certs package.

### DIFF
--- a/packages/office-addin-dev-certs/src/uninstall.ts
+++ b/packages/office-addin-dev-certs/src/uninstall.ts
@@ -26,7 +26,7 @@ function getUninstallCommand(machine: boolean = false): string {
     }
     case "linux":
       const script = path.resolve(__dirname, "../scripts/uninstall_linux.sh");
-      return `sudo sh '${script}' '${defaults.certificateName}'`;
+      return `sudo sh '${script}' '${defaults.caCertificateFileName}'`;
     default:
       throw new ExpectedError(`Platform not supported: ${process.platform}`);
   }

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -31,7 +31,7 @@ function getVerifyCommand(returnInvalidCertificate: boolean): string {
     }
     case "linux":
       const script = path.resolve(__dirname, "../scripts/verify_linux.sh");
-      return `sh '${script}' '${defaults.certificateName}'`;
+      return `sh '${script}' '${defaults.caCertificateFileName}'`;
     default:
       throw new ExpectedError(`Platform not supported: ${process.platform}`);
   }


### PR DESCRIPTION
Fixes a bug with office-addin-dev-certs on Linux. The verify command always thought the cert was not installed, causing every run of a generic sample app to generate and install new certificates. This was frustrating when trying to debug certificate issues when running a sample app for the first time.
