### PR TITLE
Fix check for Microsoft Azure CLI substring

### DIFF
--- a/packages/office-addin-sso/src/configure.ts
+++ b/packages/office-addin-sso/src/configure.ts
@@ -54,7 +54,12 @@ export async function isAzureCliInstalled(): Promise<boolean> {
       case "win32": {
         const appsInstalledWindowsCommand: string = `powershell -ExecutionPolicy Bypass -File "${defaults.getInstalledAppsPath}"`;
         const appsWindows: any = await promiseExecuteCommand(appsInstalledWindowsCommand);
-        cliInstalled = appsWindows.filter((app) => app.DisplayName === "Microsoft Azure CLI").length > 0;
+        cliInstalled = appsWindows.filter((app) => {
+          if (app!==null && app.DisplayName!==null){
+            if (app.DisplayName.includes("Microsoft Azure CLI")) return true;
+          }
+          return false;
+        });
         // Send usage data
         usageDataObject.reportSuccess("isAzureCliInstalled()", {
           cliInstalled: cliInstalled,


### PR DESCRIPTION
Microsoft Azure CLI (32-bit) and similar strings will no longer match the check. Modified to check for the substring instead.

This is a patch.
Needs someone to double-check testing that this works correctly when Azure CLI is installed, and when it is uninstalled.