### PR TITLE
[Patch] Fix getInstalledApps.ps1 so it can get correct installed apps

### DIFF
--- a/packages/office-addin-sso/src/scripts/getInstalledApps.ps1
+++ b/packages/office-addin-sso/src/scripts/getInstalledApps.ps1
@@ -1,1 +1,4 @@
- Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | ConvertTo-Json
+($apps32bit= Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate) | Out-Null
+($apps64bit= Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate) | Out-Null
+($allapps = $($apps32bit; $apps64bit) | ConvertTo-Json) | Out-Null
+$allapps


### PR DESCRIPTION
**Change Description**:

   getInstalledApps.ps1 should look up the installed apps from 32-bit and 64-bit registry path.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    No


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
    No

**Validation/testing performed**:

The script is validated with its consumer, isAzureCliInstalled() defined configure.ts
