### PR TITLE
[Patch] Set allowCustomDataForDataTypeAny to true by default for custom function metadata generation

### DIFF
--- a/packages/custom-functions-metadata-plugin/package.json
+++ b/packages/custom-functions-metadata-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-functions-metadata-plugin",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "author": "Office Dev",
   "bugs": {
     "url": "https://github.com/OfficeDev/Office-Addin-Scripts/issues"
@@ -26,7 +26,7 @@
     "watch": "tsc -p tsconfig.json -w"
   },
   "dependencies": {
-    "custom-functions-metadata": "^1.5.3"
+    "custom-functions-metadata": "^1.5.4"
   },
   "devDependencies": {
     "@types/node": "^14.17.2",

--- a/packages/custom-functions-metadata/package.json
+++ b/packages/custom-functions-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-functions-metadata",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Generate metadata for Excel Custom Functions.",
   "main": "./lib/main.js",
   "scripts": {

--- a/packages/custom-functions-metadata/src/generate.ts
+++ b/packages/custom-functions-metadata/src/generate.ts
@@ -178,8 +178,8 @@ export async function generateCustomFunctionsMetadata(
 
     if (functions.length > 0) {
       const metadata = {
-        functions: functions,
         allowCustomDataForDataTypeAny: true,
+        functions: functions,
       }
       generateResults.metadataJson = JSON.stringify(metadata, null, 4);
     }

--- a/packages/custom-functions-metadata/src/generate.ts
+++ b/packages/custom-functions-metadata/src/generate.ts
@@ -177,10 +177,11 @@ export async function generateCustomFunctionsMetadata(
     });
 
     if (functions.length > 0) {
-      generateResults.metadataJson = JSON.stringify({
+      const metadata = {
         functions: functions,
         allowCustomDataForDataTypeAny: true,
-      }, null, 4);
+      }
+      generateResults.metadataJson = JSON.stringify(metadata, null, 4);
     }
   }
 

--- a/packages/custom-functions-metadata/src/generate.ts
+++ b/packages/custom-functions-metadata/src/generate.ts
@@ -177,7 +177,10 @@ export async function generateCustomFunctionsMetadata(
     });
 
     if (functions.length > 0) {
-      generateResults.metadataJson = JSON.stringify({ functions: functions }, null, 4);
+      generateResults.metadataJson = JSON.stringify({
+        functions: functions,
+        allowCustomDataForDataTypeAny: true,
+      }, null, 4);
     }
   }
 

--- a/packages/custom-functions-metadata/test/cases/basic/expected.json
+++ b/packages/custom-functions-metadata/test/cases/basic/expected.json
@@ -7,5 +7,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/basic/expected.json
+++ b/packages/custom-functions-metadata/test/cases/basic/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "basic custom function",
@@ -7,6 +8,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/cancelable-invocation/expected.json
+++ b/packages/custom-functions-metadata/test/cases/cancelable-invocation/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test support for the CustomFunctions.CancelableInvocation",
@@ -10,6 +11,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/cancelable-invocation/expected.json
+++ b/packages/custom-functions-metadata/test/cases/cancelable-invocation/expected.json
@@ -10,5 +10,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/cancelable/expected.json
+++ b/packages/custom-functions-metadata/test/cases/cancelable/expected.json
@@ -15,5 +15,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/cancelable/expected.json
+++ b/packages/custom-functions-metadata/test/cases/cancelable/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test support for the cancelable tag",
@@ -15,6 +16,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/default-parameter-types/expected.json
+++ b/packages/custom-functions-metadata/test/cases/default-parameter-types/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test default string parameter",
@@ -81,6 +82,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/default-parameter-types/expected.json
+++ b/packages/custom-functions-metadata/test/cases/default-parameter-types/expected.json
@@ -81,5 +81,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/description/expected.json
+++ b/packages/custom-functions-metadata/test/cases/description/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "id": "NODESCRIPTION",
@@ -20,6 +21,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/description/expected.json
+++ b/packages/custom-functions-metadata/test/cases/description/expected.json
@@ -20,5 +20,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/dimensionality-matrix/expected.json
+++ b/packages/custom-functions-metadata/test/cases/dimensionality-matrix/expected.json
@@ -17,5 +17,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/dimensionality-matrix/expected.json
+++ b/packages/custom-functions-metadata/test/cases/dimensionality-matrix/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "custom function with dimensionality matrix",
@@ -17,6 +18,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/helpurl/expected.json
+++ b/packages/custom-functions-metadata/test/cases/helpurl/expected.json
@@ -27,5 +27,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/helpurl/expected.json
+++ b/packages/custom-functions-metadata/test/cases/helpurl/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "helpUrl": "https://www.contoso.com/help",
@@ -27,6 +28,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/invocation/expected.json
+++ b/packages/custom-functions-metadata/test/cases/invocation/expected.json
@@ -12,5 +12,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/invocation/expected.json
+++ b/packages/custom-functions-metadata/test/cases/invocation/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test support for the CustomFunctions.Invocation",
@@ -12,6 +13,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/js-function-name-lowercase/expected.json
+++ b/packages/custom-functions-metadata/test/cases/js-function-name-lowercase/expected.json
@@ -7,5 +7,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/js-function-name-lowercase/expected.json
+++ b/packages/custom-functions-metadata/test/cases/js-function-name-lowercase/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Lowercase function name test",
@@ -7,6 +8,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/js-function-name-mixed-case/expected.json
+++ b/packages/custom-functions-metadata/test/cases/js-function-name-mixed-case/expected.json
@@ -7,5 +7,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/js-function-name-mixed-case/expected.json
+++ b/packages/custom-functions-metadata/test/cases/js-function-name-mixed-case/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Mixedcase function name test",
@@ -7,6 +8,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/js-function-name-uppercase/expected.json
+++ b/packages/custom-functions-metadata/test/cases/js-function-name-uppercase/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Uppercase function name test",
@@ -7,6 +8,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/js-function-name-uppercase/expected.json
+++ b/packages/custom-functions-metadata/test/cases/js-function-name-uppercase/expected.json
@@ -7,5 +7,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/multiple-function-files/expected.json
+++ b/packages/custom-functions-metadata/test/cases/multiple-function-files/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "basic custom function",
@@ -14,6 +15,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/multiple-function-files/expected.json
+++ b/packages/custom-functions-metadata/test/cases/multiple-function-files/expected.json
@@ -14,5 +14,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/optional-parameter-types/expected.json
+++ b/packages/custom-functions-metadata/test/cases/optional-parameter-types/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test function for optional string parameter",
@@ -81,6 +82,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/optional-parameter-types/expected.json
+++ b/packages/custom-functions-metadata/test/cases/optional-parameter-types/expected.json
@@ -81,5 +81,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/param-types/expected.json
+++ b/packages/custom-functions-metadata/test/cases/param-types/expected.json
@@ -60,5 +60,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/param-types/expected.json
+++ b/packages/custom-functions-metadata/test/cases/param-types/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Parameter type not specified",
@@ -60,6 +61,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/repeating-param-1d-reference/expected.json
+++ b/packages/custom-functions-metadata/test/cases/repeating-param-1d-reference/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "custom function with 1d repeating parameter",
@@ -30,6 +31,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/repeating-param-1d-reference/expected.json
+++ b/packages/custom-functions-metadata/test/cases/repeating-param-1d-reference/expected.json
@@ -30,5 +30,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/repeating-param-1d/expected.json
+++ b/packages/custom-functions-metadata/test/cases/repeating-param-1d/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "custom function with 1d repeating parameter",
@@ -30,6 +31,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/repeating-param-1d/expected.json
+++ b/packages/custom-functions-metadata/test/cases/repeating-param-1d/expected.json
@@ -30,5 +30,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/repeating-param-3d-reference/expected.json
+++ b/packages/custom-functions-metadata/test/cases/repeating-param-3d-reference/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "custom function with 3d repeating parameter",
@@ -18,6 +19,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/repeating-param-3d-reference/expected.json
+++ b/packages/custom-functions-metadata/test/cases/repeating-param-3d-reference/expected.json
@@ -18,5 +18,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/repeating-param-3d/expected.json
+++ b/packages/custom-functions-metadata/test/cases/repeating-param-3d/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "custom function with 3d repeating parameter",
@@ -18,6 +19,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/repeating-param-3d/expected.json
+++ b/packages/custom-functions-metadata/test/cases/repeating-param-3d/expected.json
@@ -18,5 +18,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/requiresaddress-cancelable/expected.json
+++ b/packages/custom-functions-metadata/test/cases/requiresaddress-cancelable/expected.json
@@ -17,5 +17,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/requiresaddress-cancelable/expected.json
+++ b/packages/custom-functions-metadata/test/cases/requiresaddress-cancelable/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test the requiresAddress tag with cancelable type",
@@ -17,6 +18,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/requiresaddress/expected.json
+++ b/packages/custom-functions-metadata/test/cases/requiresaddress/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test the requiresAddress tag",
@@ -16,6 +17,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/requiresaddress/expected.json
+++ b/packages/custom-functions-metadata/test/cases/requiresaddress/expected.json
@@ -16,5 +16,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/requiresparameteraddresses/expected.json
+++ b/packages/custom-functions-metadata/test/cases/requiresparameteraddresses/expected.json
@@ -54,5 +54,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/requiresparameteraddresses/expected.json
+++ b/packages/custom-functions-metadata/test/cases/requiresparameteraddresses/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test the requiresParameterAddresses tag",
@@ -54,6 +55,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/return-type-explicit/expected.json
+++ b/packages/custom-functions-metadata/test/cases/return-type-explicit/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "id": "RETURNSBOOLEAN",
@@ -114,6 +115,5 @@
                 "type": "string"
             }
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/return-type-explicit/expected.json
+++ b/packages/custom-functions-metadata/test/cases/return-type-explicit/expected.json
@@ -114,5 +114,6 @@
                 "type": "string"
             }
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/return-type-implicit/expected.json
+++ b/packages/custom-functions-metadata/test/cases/return-type-implicit/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "id": "RETURNSBOOLEAN",
@@ -84,6 +85,5 @@
             "parameters": [],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/return-type-implicit/expected.json
+++ b/packages/custom-functions-metadata/test/cases/return-type-implicit/expected.json
@@ -84,5 +84,6 @@
             "parameters": [],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/expected.json
@@ -18,5 +18,6 @@
                 "type": "string"
             }
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-matrix/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test function for streaming type",
@@ -18,6 +19,5 @@
                 "type": "string"
             }
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/expected.json
@@ -17,5 +17,6 @@
                 "type": "string"
             }
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation-dimensionality-scalar/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test function for streaming type",
@@ -17,6 +18,5 @@
                 "type": "string"
             }
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation/expected.json
@@ -17,5 +17,6 @@
                 "type": "number"
             }
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/streaming-invocation/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming-invocation/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test function for streaming type",
@@ -17,6 +18,5 @@
                 "type": "number"
             }
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }

--- a/packages/custom-functions-metadata/test/cases/streaming/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming/expected.json
@@ -15,5 +15,6 @@
             ],
             "result": {}
         }
-    ]
+    ],
+    "allowCustomDataForDataTypeAny": true
 }

--- a/packages/custom-functions-metadata/test/cases/streaming/expected.json
+++ b/packages/custom-functions-metadata/test/cases/streaming/expected.json
@@ -1,4 +1,5 @@
 {
+    "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
             "description": "Test function for streaming tag",
@@ -15,6 +16,5 @@
             ],
             "result": {}
         }
-    ],
-    "allowCustomDataForDataTypeAny": true
+    ]
 }


### PR DESCRIPTION
**Change Description**:

  Custom function metadata generation now adds `allowCustomDataForDataTypeAny:true` by default to functions.json.

1. **Do these changes impact *command syntax* of any of the packages?** 
    No


2. **Do these changes impact *documentation*?**
    On page [Use data types with custom functions in Excel](https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-data-types-concepts), it is mentioned that "To use the data types integration with custom functions, the custom functions JSON metadata file must be manually updated to include the property allowCustomDataForDataTypeAny. Set this property to true.". This paragraph can be removed since manually adding allowCustomDataForDataTypeAny is no longer needed.

**Validation/testing performed**:

npm run test passes
