### PR TITLE
[minor] Add handling for new @linkedEntityDataProvider and @excludeFromAutoComplete jsdoc tags

### DIFF
--- a/packages/custom-functions-metadata/Specification.md
+++ b/packages/custom-functions-metadata/Specification.md
@@ -11,7 +11,9 @@ The function parameter types may be provided using the [@param](#param) tag in J
 ## Tags
 * [@cancelable](#cancelable)
 * [@customfunction](#customfunction) id name
+* [@excludeFromAutoComplete](#excludeFromAutoComplete)
 * [@helpurl](#helpurl) url
+* [@linkedEntityDataProvider](#linkedEntityDataProvider)
 * [@param](#param) _{type}_ name description
 * [@requiresAddress](#requiresAddress)
 * [@requiresParameterAddresses](#requiresParameterAddresses)
@@ -60,11 +62,32 @@ Provides the display name for the custom function.
 * Maximum length is 128 characters.
 
 ---
+### @excludeFromAutoComplete
+
+Indicates that the function will be excluded from the autocomplete drop-down list and Formula Builder.
+
+If the function is manually spelled correctly in the grid, the function will still execute.
+
+A function cannot have both `@excludeFromAutoComplete` and `@linkedEntityDataProvider` tags.
+
+---
 ### @helpurl
 
 Syntax: @helpurl _url_
 
 The provided _url_ is displayed in Excel.
+
+---
+### @linkedEntityDataProvider
+
+Indicates that the function is a "special" custom function that is meant to act as the "loadFunction" for user defined `LinkedDataType`s. 
+
+The function will be excluded from the autocomplete drop-down list and Formula Builder since it should only callable by the Excel runtime.
+
+* Must accept and return a single non-repeating, non-optional, scalar parameter of type `Any`.
+* Must not be a XLL-compatible custom function.
+* Must allow rich data as input.
+* A `@linkedEntityDataProvider` function cannot be combined with `@streaming`, `@volatile`, or `@excludeFromAutoComplete` tags.
 
 ---
 ### @param 

--- a/packages/custom-functions-metadata/Specification.md
+++ b/packages/custom-functions-metadata/Specification.md
@@ -84,7 +84,7 @@ Indicates that the function is a "special" custom function that is meant to act 
 
 The function will be excluded from the autocomplete drop-down list and Formula Builder since it should only callable by the Excel runtime.
 
-* Must accept and return a single non-repeating, non-optional, scalar parameter of type `Any`.
+* Must accept and return a single non-repeating, non-optional, scalar parameter of type `unknown`.
 * Must not be a XLL-compatible custom function.
 * Must allow rich data as input.
 * A `@linkedEntityDataProvider` function cannot be combined with `@streaming`, `@volatile`, or `@excludeFromAutoComplete` tags.

--- a/packages/custom-functions-metadata/package-lock.json
+++ b/packages/custom-functions-metadata/package-lock.json
@@ -12,7 +12,7 @@
         "assert": "^1.5.0",
         "commander": "^10.0.0",
         "nconf": "^0.12.0",
-        "office-addin-usage-data": "^1.6.8",
+        "office-addin-usage-data": "^1.6.9",
         "xregexp": "^4.3.0"
       },
       "bin": {
@@ -26,7 +26,7 @@
         "@types/xregexp": "^3.0.30",
         "concurrently": "^6.2.2",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^2.2.8",
+        "office-addin-lint": "^2.2.9",
         "office-addin-prettier-config": "^1.2.0",
         "rimraf": "^3.0.2",
         "ts-node": "^10.9.1",
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.8.tgz",
-      "integrity": "sha512-SFlt1QNyy6TvCqDVzFbIeQqEtmzTMduRcCvRW9GjrbPv+7lp2UUfhe2IiCtL9Webtv/LoJUZdLQwg3k5jUL7Ew==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.9.tgz",
+      "integrity": "sha512-zU0eC4UsgbauQXEivOlcaenHnlxlzhc6sQMHKJoK3pDmp08uJeoc1EV1PNgiF6i1Py+4xIkIaDAsqlYEbjoumQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -3666,7 +3666,7 @@
         "eslint-plugin-office-addins": "^2.1.8",
         "eslint-plugin-prettier": "^3.3.1",
         "office-addin-prettier-config": "^1.2.0",
-        "office-addin-usage-data": "^1.6.8",
+        "office-addin-usage-data": "^1.6.9",
         "prettier": "^2.2.1"
       },
       "bin": {
@@ -3689,9 +3689,9 @@
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.8.tgz",
-      "integrity": "sha512-D/yyctao9VoatKTvAR+fAyajEbKaVuTTjRgJjYOY6dI8MxubQWKSxjMbowyUFxAY/HkDXAIg6nGV8SmuQUONLQ==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.9.tgz",
+      "integrity": "sha512-SDqFRNZD/iTtgEbHczlswjsUB0OLYU6s+5EKcHzwQxvZIEocsTW9sqj/3eR3qi2IT8oTHFBJxilws1yckshiPA==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
@@ -7647,9 +7647,9 @@
       }
     },
     "office-addin-lint": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.8.tgz",
-      "integrity": "sha512-SFlt1QNyy6TvCqDVzFbIeQqEtmzTMduRcCvRW9GjrbPv+7lp2UUfhe2IiCtL9Webtv/LoJUZdLQwg3k5jUL7Ew==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.2.9.tgz",
+      "integrity": "sha512-zU0eC4UsgbauQXEivOlcaenHnlxlzhc6sQMHKJoK3pDmp08uJeoc1EV1PNgiF6i1Py+4xIkIaDAsqlYEbjoumQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -7660,7 +7660,7 @@
         "eslint-plugin-office-addins": "^2.1.8",
         "eslint-plugin-prettier": "^3.3.1",
         "office-addin-prettier-config": "^1.2.0",
-        "office-addin-usage-data": "^1.6.8",
+        "office-addin-usage-data": "^1.6.9",
         "prettier": "^2.2.1"
       },
       "dependencies": {
@@ -7679,9 +7679,9 @@
       "dev": true
     },
     "office-addin-usage-data": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.8.tgz",
-      "integrity": "sha512-D/yyctao9VoatKTvAR+fAyajEbKaVuTTjRgJjYOY6dI8MxubQWKSxjMbowyUFxAY/HkDXAIg6nGV8SmuQUONLQ==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.9.tgz",
+      "integrity": "sha512-SDqFRNZD/iTtgEbHczlswjsUB0OLYU6s+5EKcHzwQxvZIEocsTW9sqj/3eR3qi2IT8oTHFBJxilws1yckshiPA==",
       "requires": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",

--- a/packages/custom-functions-metadata/src/parseTree.ts
+++ b/packages/custom-functions-metadata/src/parseTree.ts
@@ -111,6 +111,7 @@ const TYPE_MAPPINGS_SIMPLE = {
   [ts.SyntaxKind.StringKeyword]: "string",
   [ts.SyntaxKind.BooleanKeyword]: "boolean",
   [ts.SyntaxKind.AnyKeyword]: "any",
+  [ts.SyntaxKind.UnknownKeyword]: "any",
 };
 
 const TYPE_MAPPINGS = {
@@ -123,6 +124,7 @@ const TYPE_MAPPINGS = {
   [ts.SyntaxKind.EnumKeyword]: "any",
   [ts.SyntaxKind.ObjectKeyword]: "any",
   [ts.SyntaxKind.VoidKeyword]: "any",
+  [ts.SyntaxKind.UnknownKeyword]: "any",
 };
 
 const TYPE_CUSTOM_FUNCTIONS_STREAMING = {

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/expected.js.errors.txt
@@ -1,0 +1,1 @@
+@excludeFromAutoComplete cannot be used with @linkedEntityDataProvider. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/expected.ts.errors.txt
@@ -1,0 +1,1 @@
+@excludeFromAutoComplete cannot be used with @linkedEntityDataProvider. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.js
@@ -3,7 +3,7 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the excludeFromAutoComplete tag
- * @param linkedEntityId {any} Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @excludeFromAutoComplete

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.js
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the linkedEntityDataProvider tag in combination with the excludeFromAutoComplete tag
+ * @param linkedEntityId {any} Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @customfunction
+ * @linkedEntityDataProvider
+ * @excludeFromAutoComplete
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ */
+function linkedEntityDataProviderTest(linkedEntityId) {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the linkedEntityDataProvider tag in combination with the excludeFromAutoComplete tag
+ * @param {any} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @customfunction
+ * @linkedEntityDataProvider
+ * @excludeFromAutoComplete
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ */
+async function linkedEntityDataProviderTest(linkedEntityId: any): Promise<any> {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the excludeFromAutoComplete tag
- * @param {any} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param {unknown} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @excludeFromAutoComplete
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: any): Promise<any> {
+async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
@@ -3,11 +3,11 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the excludeFromAutoComplete tag
- * @param {unknown} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @excludeFromAutoComplete
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
 async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
     // Empty

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/expected.js.errors.txt
@@ -1,0 +1,1 @@
+@streaming cannot be used with @linkedEntityDataProvider. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/expected.ts.errors.txt
@@ -1,0 +1,1 @@
+@streaming cannot be used with @linkedEntityDataProvider. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.js
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the linkedEntityDataProvider tag in combination with the streaming tag
+ * @param linkedEntityId {any} Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @customfunction
+ * @linkedEntityDataProvider
+ * @streaming
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ */
+function linkedEntityDataProviderTest(linkedEntityId) {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.js
@@ -3,7 +3,7 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the streaming tag
- * @param linkedEntityId {any} Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @streaming

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the streaming tag
- * @param {any} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param {unknown} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @streaming
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: any): Promise<any> {
+async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
@@ -3,11 +3,11 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the streaming tag
- * @param {unknown} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @streaming
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
 async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
     // Empty

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the linkedEntityDataProvider tag in combination with the streaming tag
+ * @param {any} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @customfunction
+ * @linkedEntityDataProvider
+ * @streaming
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ */
+async function linkedEntityDataProviderTest(linkedEntityId: any): Promise<any> {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/expected.js.errors.txt
@@ -1,0 +1,1 @@
+@volatile cannot be used with @linkedEntityDataProvider. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/expected.ts.errors.txt
@@ -1,0 +1,1 @@
+@volatile cannot be used with @linkedEntityDataProvider. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.js
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the linkedEntityDataProvider tag in combination with the volatile tag
+ * @param linkedEntityId {any} Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @customfunction
+ * @linkedEntityDataProvider
+ * @volatile
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ */
+function linkedEntityDataProviderTest(linkedEntityId) {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.js
@@ -3,7 +3,7 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the volatile tag
- * @param linkedEntityId {any} Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @volatile

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the volatile tag
- * @param {any} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param {unknown} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @volatile
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: any): Promise<any> {
+async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
@@ -3,11 +3,11 @@
 
 /**
  * Test the linkedEntityDataProvider tag in combination with the volatile tag
- * @param {unknown} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @volatile
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
 async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
     // Empty

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the linkedEntityDataProvider tag in combination with the volatile tag
+ * @param {any} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @customfunction
+ * @linkedEntityDataProvider
+ * @volatile
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ */
+async function linkedEntityDataProviderTest(linkedEntityId: any): Promise<any> {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/excludefromautocomplete/expected.json
+++ b/packages/custom-functions-metadata/test/cases/excludefromautocomplete/expected.json
@@ -1,0 +1,15 @@
+{
+    "allowCustomDataForDataTypeAny": true,
+    "functions": [
+        {
+            "description": "Test the excludeFromAutoComplete tag",
+            "id": "EXCLUDEFROMAUTOCOMPLETETEST",
+            "name": "EXCLUDEFROMAUTOCOMPLETETEST",
+            "options": {
+                "excludeFromAutoComplete": true
+            },
+            "parameters": [],
+            "result": {}
+        }
+    ]
+}

--- a/packages/custom-functions-metadata/test/cases/excludefromautocomplete/functions.js
+++ b/packages/custom-functions-metadata/test/cases/excludefromautocomplete/functions.js
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the excludeFromAutoComplete tag
+ * @customfunction
+ * @excludeFromAutoComplete
+ */
+function excludeFromAutoCompleteTest() {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/excludefromautocomplete/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/excludefromautocomplete/functions.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the excludeFromAutoComplete tag
+ * @customfunction
+ * @excludeFromAutoComplete
+ */
+function excludeFromAutoCompleteTest() {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/expected.json
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/expected.json
@@ -1,0 +1,21 @@
+{
+    "allowCustomDataForDataTypeAny": true,
+    "functions": [
+        {
+            "description": "Test the linkedEntityDataProvider tag",
+            "id": "LINKEDENTITYDATAPROVIDERTEST",
+            "name": "LINKEDENTITYDATAPROVIDERTEST",
+            "options": {
+                "linkedEntityDataProvider": true
+            },
+            "parameters": [
+                {
+                    "description": "Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.",
+                    "name": "linkedEntityId",
+                    "type": "any"
+                }
+            ],
+            "result": {}
+        }
+    ]
+}

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.js
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.js
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the linkedEntityDataProvider tag
+ * @param linkedEntityId {any} Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @customfunction
+ * @linkedEntityDataProvider
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ */
+function linkedEntityDataProviderTest(linkedEntityId) {
+    // Empty
+}

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.js
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.js
@@ -3,7 +3,7 @@
 
 /**
  * Test the linkedEntityDataProvider tag
- * @param linkedEntityId {any} Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
@@ -3,10 +3,10 @@
 
 /**
  * Test the linkedEntityDataProvider tag
- * @param {unknown} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
 async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
     // Empty

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
@@ -3,11 +3,11 @@
 
 /**
  * Test the linkedEntityDataProvider tag
- * @param {any} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param {unknown} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
  * @linkedEntityDataProvider
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: any): Promise<any> {
+async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Test the linkedEntityDataProvider tag
+ * @param {any} linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @customfunction
+ * @linkedEntityDataProvider
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ */
+async function linkedEntityDataProviderTest(linkedEntityId: any): Promise<any> {
+    // Empty
+}


### PR DESCRIPTION
**Change Description**:

    This PR adds handling for the new @linkedEntityDataProvider and @excludeFromAutoComplete metadata tags needed for 3P Linked Entities in Excel.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
    Yes, we need to add documentation for the new tags


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Wrote new test cases and confirmed they all pass. Will link NPM package to office-js-api to test everything before checking in.
