### PR TITLE
[minor] Add TAOS sideload support for MetaOS WXP

### DIFF
--- a/packages/office-addin-dev-settings/src/dev-settings-windows.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-windows.ts
@@ -9,6 +9,7 @@ import {
   ManifestInfo,
   OfficeApp,
   OfficeAddinManifest,
+  ManifestType,
 } from "office-addin-manifest";
 import { DebuggingMethod, RegisteredAddin, SourceBundleUrlComponents, WebViewType } from "./dev-settings";
 import { ExpectedError } from "office-addin-usage-data";
@@ -178,7 +179,7 @@ export async function registerAddIn(manifestPath: string, registration?: string)
   const appsInManifest = getOfficeAppsForManifestHosts(manifest.hosts);
 
   // Register using the service
-  if (manifestPath.endsWith(".json") || appsInManifest.indexOf(OfficeApp.Outlook) >= 0) {
+  if (manifest.manifestType === ManifestType.JSON || appsInManifest.indexOf(OfficeApp.Outlook) >= 0) {
     if (!registration) {
       let filePath = "";
       if (manifestPath.endsWith(".json")) {

--- a/packages/office-addin-dev-settings/src/dev-settings-windows.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-windows.ts
@@ -182,10 +182,10 @@ export async function registerAddIn(manifestPath: string, registration?: string)
   if (manifest.manifestType === ManifestType.JSON || appsInManifest.indexOf(OfficeApp.Outlook) >= 0) {
     if (!registration) {
       let filePath = "";
-      if (manifestPath.endsWith(".json")) {
+      if (manifest.manifestType === ManifestType.JSON) {
         const targetPath: string = fspath.join(process.env.TEMP as string, "manifest.zip");
         filePath = await exportMetadataPackage(targetPath, manifestPath);
-      } else if (manifestPath.endsWith(".xml")) {
+      } else if (manifest.manifestType === ManifestType.XML) {
         filePath = manifestPath;
       }
       registration = await registerWithTeams(filePath);

--- a/packages/office-addin-dev-settings/src/dev-settings-windows.ts
+++ b/packages/office-addin-dev-settings/src/dev-settings-windows.ts
@@ -178,7 +178,7 @@ export async function registerAddIn(manifestPath: string, registration?: string)
   const appsInManifest = getOfficeAppsForManifestHosts(manifest.hosts);
 
   // Register using the service
-  if (appsInManifest.indexOf(OfficeApp.Outlook) >= 0) {
+  if (manifestPath.endsWith(".json") || appsInManifest.indexOf(OfficeApp.Outlook) >= 0) {
     if (!registration) {
       let filePath = "";
       if (manifestPath.endsWith(".json")) {

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -255,6 +255,7 @@ async function getOfficeExePath(app: OfficeApp): Promise<string> {
         break;
       default:
         hostApp = "OUTLOOK.EXE";
+        break;
     }
 
     const InstallPathRegistryKey: string = `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${hostApp}`;

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -369,7 +369,7 @@ async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document
   }
 
   // for Outlook, open Outlook.exe; for other Office apps, open the document
-  if (manifest.manifestType === ManifestType.JSON && app == OfficeApp.Outlook) {
+  if (app == OfficeApp.Outlook) {
     const version: string | undefined = await getOutlookVersion();
     if (version && !hasOfficeVersion("16.0.13709", version)) {
       throw new ExpectedError(

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -255,8 +255,7 @@ async function getOfficeExePath(app: OfficeApp): Promise<string> {
         hostApp = "powerpnt.exe";
         break;
       default:
-        hostApp = "OUTLOOK.EXE";
-        break;
+        throw new Error("The Office host not supported.");
     }
 
     const InstallPathRegistryKey: string = `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${hostApp}`;
@@ -383,7 +382,7 @@ async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document
 
   // for Outlook, Word, Excel, PowerPoint open {Host}.exe; for other Office apps, open the document
   let path: string;
-  if (app == OfficeApp.Outlook) {
+  if (manifest.manifestType === ManifestType.JSON && app == OfficeApp.Outlook) {
     const version: string | undefined = await getOutlookVersion();
     if (version && !hasOfficeVersion("16.0.13709", version)) {
       throw new ExpectedError(

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -93,9 +93,7 @@ export async function generateSideloadFile(app: OfficeApp, manifest: ManifestInf
         data = Buffer.from(webExtensionXml);
       }
       // If manifestType is JSON, remove the web extension folder
-      if (entry.entryName.startsWith(webExtensionFolderPath) && manifest.manifestType == ManifestType.JSON) {
-        outZip.deleteFile(entry.entryName);
-      } else {
+      if (!entry.entryName.startsWith(webExtensionFolderPath) || manifest.manifestType !== ManifestType.JSON) {
         outZip.addFile(entry.entryName, data, entry.comment, entry.attr);
       }
     });

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -237,34 +237,36 @@ async function getOutlookVersion(): Promise<string | undefined> {
   }
 }
 
-async function getWXPOExePath(app: OfficeApp): Promise<string> {
-  let HostApp: string = "";
+async function getOfficeExePath(app: OfficeApp): Promise<string> {
+  let hostApp: string = "";
   try {
     switch (app) {
       case OfficeApp.Excel:
-        HostApp = "EXCEL";
+        hostApp = "excel.exe";
         break;
       case OfficeApp.Outlook:
-        HostApp = "OUTLOOK";
+        hostApp = "OUTLOOK.EXE";
         break;
       case OfficeApp.Word:
-        HostApp = "WINWORD";
+        hostApp = "Winword.exe";
         break;
       case OfficeApp.PowerPoint:
-        HostApp = "POWERPNT";
+        hostApp = "powerpnt.exe";
         break;
+      default:
+        hostApp = "OUTLOOK.EXE";
     }
 
-    const InstallPathRegistryKey: string = `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${HostApp}.EXE`;
+    const InstallPathRegistryKey: string = `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${hostApp}`;
     const key = new registry.RegistryKey(`${InstallPathRegistryKey}`);
     const ExePath: string | undefined = await registry.getStringValue(key, "");
 
     if (!ExePath) {
-      throw new Error(`${HostApp}.exe registry empty`);
+      throw new Error(`${hostApp} registry empty`);
     }
     return ExePath;
   } catch (err) {
-    const errorMessage: string = `Unable to find "${HostApp}" install location: \n${err}`;    
+    const errorMessage: string = `Unable to find "${hostApp}" install location: \n${err}`;    
     throw new Error(errorMessage);
   }
 }
@@ -386,9 +388,9 @@ async function launchDesktopApp(app: OfficeApp, manifestPath: string, manifest: 
         `The current version of Outlook does not support sideload. Please use version 16.0.13709 or greater.`
       );
     }
-    path = await getWXPOExePath(app);
+    path = await getOfficeExePath(app);
   } else if (manifestPath.endsWith(".json")) {
-    path = await getWXPOExePath(app);
+    path = await getOfficeExePath(app);
   } else {
     path = await generateSideloadFile(app, manifest, document);
   }

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -381,15 +381,15 @@ async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document
 
   // for Outlook, Word, Excel, PowerPoint open {Host}.exe; for other Office apps, open the document
   let path: string;
-  if (manifest.manifestType === ManifestType.JSON && app == OfficeApp.Outlook) {
-    const version: string | undefined = await getOutlookVersion();
-    if (version && !hasOfficeVersion("16.0.13709", version)) {
-      throw new ExpectedError(
-        `The current version of Outlook does not support sideload. Please use version 16.0.13709 or greater.`
-      );
+  if (manifest.manifestType === ManifestType.JSON) {
+    if (app == OfficeApp.Outlook) {
+      const version: string | undefined = await getOutlookVersion();
+      if (version && !hasOfficeVersion("16.0.13709", version)) {
+        throw new ExpectedError(
+          `The current version of Outlook does not support sideload. Please use version 16.0.13709 or greater.`
+        );
+      }
     }
-    path = await getOfficeExePath(app);
-  } else if (manifest.manifestType === ManifestType.JSON) {
     path = await getOfficeExePath(app);
   } else {
     path = await generateSideloadFile(app, manifest, document);

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -85,7 +85,7 @@ export async function generateSideloadFile(app: OfficeApp, manifest: ManifestInf
     .readAsText(extEntry)
     .replace(/00000000-0000-0000-0000-000000000000/g, manifest.id)
     .replace(/1.0.0.0/g, manifest.version);
-    
+
     templateZip.getEntries().forEach(function (entry) {
       var data: Buffer = entry.getData();
       if (entry == extEntry && manifest.manifestType == ManifestType.XML) {

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -369,7 +369,6 @@ async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document
   }
 
   // for Outlook, open Outlook.exe; for other Office apps, open the document
-  let path: string;
   if (manifest.manifestType === ManifestType.JSON && app == OfficeApp.Outlook) {
     const version: string | undefined = await getOutlookVersion();
     if (version && !hasOfficeVersion("16.0.13709", version)) {

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -86,17 +86,17 @@ export async function generateSideloadFile(app: OfficeApp, manifest: ManifestInf
       .replace(/00000000-0000-0000-0000-000000000000/g, manifest.id)
       .replace(/1.0.0.0/g, manifest.version);
 
+    const webExtensionFolderPath = webExtensionPath.substring(0, webExtensionPath.lastIndexOf("/"))
     templateZip.getEntries().forEach(function (entry) {
       var data: Buffer = entry.getData();
       if (entry == extEntry && manifest.manifestType == ManifestType.XML) {
         data = Buffer.from(webExtensionXml);
       }
-      outZip.addFile(entry.entryName, data, entry.comment, entry.attr);
-
-      const webExtensionFolderPath = webExtensionPath.substring(0, webExtensionPath.lastIndexOf("/"))
       // If manifestType is JSON, remove the web extension folder
       if (entry.entryName.startsWith(webExtensionFolderPath) && manifest.manifestType == ManifestType.JSON) {
         outZip.deleteFile(entry.entryName);
+      } else {
+        outZip.addFile(entry.entryName, data, entry.comment, entry.attr);
       }
     });
 

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -12,6 +12,7 @@ import {
   ManifestInfo,
   OfficeApp,
   OfficeAddinManifest,
+  ManifestType,
 } from "office-addin-manifest";
 import open = require("open");
 import semver = require("semver");
@@ -356,7 +357,7 @@ export async function sideloadAddIn(
     switch (appType) {
       case AppType.Desktop:
         await registerAddIn(manifestPath, registration);
-        await launchDesktopApp(app, manifestPath, manifest, document);
+        await launchDesktopApp(app, manifest, document);
         break;
       case AppType.Web: {
         if (!document) {
@@ -375,7 +376,7 @@ export async function sideloadAddIn(
   }
 }
 
-async function launchDesktopApp(app: OfficeApp, manifestPath: string, manifest: ManifestInfo, document?: string) {
+async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document?: string) {
   if (!isSideloadingSupportedForDesktopHost(app)) {
     throw new ExpectedError(`Sideload to the ${getOfficeAppName(app)} app is not supported.`);
   }
@@ -390,7 +391,7 @@ async function launchDesktopApp(app: OfficeApp, manifestPath: string, manifest: 
       );
     }
     path = await getOfficeExePath(app);
-  } else if (manifestPath.endsWith(".json")) {
+  } else if (manifest.manifestType === ManifestType.JSON) {
     path = await getOfficeExePath(app);
   } else {
     path = await generateSideloadFile(app, manifest, document);

--- a/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
+++ b/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
@@ -51,7 +51,7 @@ export class ManifestHandlerJson extends ManifestHandler {
     manifestInfo.highResolutionIconUrl = appManifest.icons.color;
     manifestInfo.hosts = extensionElement?.requirements?.scopes;
     manifestInfo.iconUrl = appManifest.icons.color;
-    manifestInfo.officeAppType = "TaskPaneApp"; 
+    manifestInfo.officeAppType = "TaskPaneApp"; // Should check "ContentRuntimes" in JSON the tell if the Office type is "ContentApp". Hard code here because web extension will be removed after all.
     manifestInfo.permissions = appManifest.authorization?.permissions?.resourceSpecific?.[0]?.name;
     manifestInfo.providerName = appManifest.developer.name;
     manifestInfo.supportUrl = appManifest.developer.websiteUrl;

--- a/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
+++ b/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
@@ -3,7 +3,7 @@
 
 import { devPreview, ManifestUtil } from "@microsoft/teams-manifest";
 import { v4 as uuidv4 } from "uuid";
-import { ManifestInfo } from "../manifestInfo";
+import { ManifestInfo, ManifestType } from "../manifestInfo";
 import { ManifestHandler } from "./manifestHandler";
 
 export class ManifestHandlerJson extends ManifestHandler {
@@ -56,6 +56,7 @@ export class ManifestHandlerJson extends ManifestHandler {
     manifestInfo.providerName = appManifest.developer.name;
     manifestInfo.supportUrl = appManifest.developer.websiteUrl;
     manifestInfo.version = appManifest.version;
+    manifestInfo.manifestType = ManifestType.JSON;
 
     return manifestInfo;
   }

--- a/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
+++ b/packages/office-addin-manifest/src/manifestHandler/manifestHandlerJson.ts
@@ -51,7 +51,7 @@ export class ManifestHandlerJson extends ManifestHandler {
     manifestInfo.highResolutionIconUrl = appManifest.icons.color;
     manifestInfo.hosts = extensionElement?.requirements?.scopes;
     manifestInfo.iconUrl = appManifest.icons.color;
-    manifestInfo.officeAppType = extensionElement?.requirements?.capabilities?.[0]?.name;
+    manifestInfo.officeAppType = "TaskPaneApp"; 
     manifestInfo.permissions = appManifest.authorization?.permissions?.resourceSpecific?.[0]?.name;
     manifestInfo.providerName = appManifest.developer.name;
     manifestInfo.supportUrl = appManifest.developer.websiteUrl;

--- a/packages/office-addin-manifest/src/manifestHandler/manifestHandlerXml.ts
+++ b/packages/office-addin-manifest/src/manifestHandler/manifestHandlerXml.ts
@@ -6,7 +6,7 @@ import * as util from "util";
 import { v4 as uuidv4 } from "uuid";
 import * as xml2js from "xml2js";
 import * as xmlMethods from "../xml";
-import { DefaultSettings, ManifestInfo } from "../manifestInfo";
+import { DefaultSettings, ManifestInfo, ManifestType } from "../manifestInfo";
 import { ManifestHandler } from "./manifestHandler";
 const writeFileAsync = util.promisify(fs.writeFile);
 export type Xml = xmlMethods.Xml;
@@ -45,6 +45,7 @@ export class ManifestHandlerXml extends ManifestHandler {
       manifest.providerName = xmlMethods.getXmlElementValue(officeApp, "ProviderName");
       manifest.supportUrl = xmlMethods.getXmlElementAttributeValue(officeApp, "SupportUrl");
       manifest.version = xmlMethods.getXmlElementValue(officeApp, "Version");
+      manifest.manifestType = ManifestType.XML;
 
       if (defaultSettingsXml) {
         const defaultSettings: DefaultSettings = new DefaultSettings();

--- a/packages/office-addin-manifest/src/manifestInfo.ts
+++ b/packages/office-addin-manifest/src/manifestInfo.ts
@@ -7,6 +7,11 @@ export class DefaultSettings {
   public requestedHeight?: string;
 }
 
+export enum ManifestType {
+  JSON = "json",
+  XML = "xml",
+}
+
 export class ManifestInfo {
   public id?: string;
   public allowSnapshot?: string;
@@ -23,6 +28,7 @@ export class ManifestInfo {
   public providerName?: string;
   public supportUrl?: string;
   public version?: string;
+  public manifestType?: ManifestType;
 
   public defaultSettings?: DefaultSettings;
 }

--- a/packages/office-addin-manifest/test/test.ts
+++ b/packages/office-addin-manifest/test/test.ts
@@ -495,7 +495,7 @@ describe("Unit Tests", function() {
         assert.strictEqual(info.hosts!.length, 1);
         assert.strictEqual(info.hosts![0], "mail");
         assert.strictEqual(info.iconUrl, "../assets/icon-128.png", "iconUrl");
-        assert.strictEqual(info.officeAppType, "AddinCommands");
+        assert.strictEqual(info.officeAppType, "TaskPaneApp");
         assert.strictEqual(info.permissions, "Mailbox.ReadWrite");
         assert.strictEqual(info.providerName, "Contoso");
         assert.strictEqual(info.supportUrl, "https://www.contoso.com");


### PR DESCRIPTION
When the manifest is WXP JSON, the following changes are made:
- Switch to TAOS sideload option.
- Launch host directly.