### PR TITLE
[patch] Fix when add loopback exemption failed will break the debug process

### DIFF
--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -306,7 +306,18 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
     // enable loopback for Edge
     if (isWindowsPlatform && parseInt(os.release(), 10) === 10) {
       const name = isDesktopAppType ? "EdgeWebView" : "EdgeWebBrowser";
-      await devSettings.ensureLoopbackIsEnabled(name);
+      try {
+        await devSettings.ensureLoopbackIsEnabled(name);
+      } catch (err: any) {
+        // if add loopback exemption failed, report the error then continue
+        console.error(err)
+        console.warn("Failed to add loopback exemption.\nTry to sideload the Office Add-in without loopback exemption.\nThe Office Add-in may not load correctly.\n")
+        usageDataObject.reportException("startDebugging()", err, {
+          app: app,
+          document: document,
+          appType: appType,
+        });
+      }
     }
 
     // enable debugging

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -311,7 +311,7 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
       } catch (err: any) {
         // if add loopback exemption failed, report the error then continue
         console.error(err)
-        console.warn("Failed to add loopback exemption.\nTry to sideload the Office Add-in without loopback exemption.\nThe Office Add-in may not load correctly.\n")
+        console.warn("Failed to add loopback exemption.\nWill try to sideload the Office Add-in without the loopback exemption, but it might not load correctly from localhost.\n")
         usageDataObject.reportException("startDebugging()", err, {
           app: app,
           document: document,


### PR DESCRIPTION
# Change Description:

This PR fix the issue when add loopback exemption failed, the debug start process will totally break.\
The behavior will be the same as when user type `No` for add loopback exempt question.

Detail in this [issue 840](https://github.com/OfficeDev/Office-Addin-Scripts/issues/840)

## Change QA

1. **Do these changes impact *command syntax* of any of the packages?** 
No.
2. **Do these changes impact *documentation*?**
Maybe No.

I search the docs and found the following articles:
* [Manually sideload an add-in to Office on the web](https://learn.microsoft.com/en-us/office/dev/add-ins/testing/sideload-office-add-ins-for-testing#manually-sideload-an-add-in-to-office-on-the-web)
* [Start the Excel, PowerPoint, or Word add-in project](https://learn.microsoft.com/en-us/office/dev/add-ins/develop/debug-office-add-ins-in-visual-studio#start-the-excel-powerpoint-or-word-add-in-project)
* [Can't open add-in from localhost: Use a local loopback exemption](https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-troubleshooting#cant-open-add-in-from-localhost-use-a-local-loopback-exemption)
* [When the add-in tries to open, get "ADD-IN ERROR We can't open this add-in from the localhost" error](https://learn.microsoft.com/en-us/office/dev/add-ins/concepts/browsers-used-by-office-web-add-ins#when-the-add-in-tries-to-open-get-add-in-error-we-cant-open-this-add-in-from-the-localhost-error)

And accroding to [issue 840](https://github.com/OfficeDev/Office-Addin-Scripts/issues/840), I assume that this PR won't change the docs.\
\+ @Rick-Kirkham for verify.

## Validation/testing performed:

1. Disable all loopback with fiddler tools
2. **_Code change_**, **_build_** and **_global link_** the package `office-addin-dev-settings`
3. Create a project with `npx --package yo --package generator-office -- yo office --skip-install`
4. In this project, run the `npm i` and `npm link office-addin-dev-settings`
5. Run `npm run start`
6. In loopback question, type `Y`
7. See following:
![npm run start](https://github.com/OfficeDev/Office-Addin-Scripts/assets/122421505/21ed3176-2b6c-4539-ba1d-8e2f69131e9f)

