### PR TITLE
[patch] Return object from calls to load()

### DIFF
--- a/packages/office-addin-mock/src/officeMockObject.ts
+++ b/packages/office-addin-mock/src/officeMockObject.ts
@@ -33,7 +33,7 @@ export class OfficeMockObject {
     }
     let properties: string[] = [];
 
-    if (propertyArgument === undefined) { 
+    if (propertyArgument === undefined) {
       // an empty load call mean load all properties
       properties = ["*"];
     } else if (typeof propertyArgument === "string") {
@@ -47,6 +47,8 @@ export class OfficeMockObject {
     properties.forEach((property: string) => {
       this.loadMultipleProperties(property);
     });
+
+    return this;
   }
 
   /**

--- a/packages/office-addin-mock/test/officeMockObject.test.ts
+++ b/packages/office-addin-mock/test/officeMockObject.test.ts
@@ -95,6 +95,13 @@ describe("Test OfficeMockObject class", function() {
 
       assert.strictEqual(officeMock.notAProperty, undefined);
     });
+    it("Load call with assignment", async function() {
+      const officeMock = new OfficeMockObject(testObject);
+
+      const range = officeMock.range.load("color");
+      await officeMock.sync();
+      assert.strictEqual(range.color, "blue");
+    });
     it("Missing load", async function() {
       const officeMock = new OfficeMockObject(testObject);
       assert.strictEqual(officeMock.range.color, "Error, property was not loaded");


### PR DESCRIPTION
**Change Description**:

Aligns return value for `load` with that used in production (i.e., return the object).

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)

No.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)

No.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

Wrote a test. Tested manually
