### PR TITLE
User/adrians/add expiration date to sso

### DIFF
--- a/packages/office-addin-sso/README.md
+++ b/packages/office-addin-sso/README.md
@@ -13,9 +13,11 @@ Configure an application in Azure Active Active Directory with necessary permiss
 
 Syntax:
 
-`office-addin-sso configure <manifest>`
+`office-addin-sso configure <manifest> [secret-ttl]`
 
 `manifest`: path to manifest file.
+
+`secret-ttl`: time to live for the secret used in the Azure app registration, in days.
 
 #
 

--- a/packages/office-addin-sso/README.md
+++ b/packages/office-addin-sso/README.md
@@ -17,7 +17,7 @@ Syntax:
 
 `manifest`: path to manifest file.
 
-`secret-ttl`: time to live for the secret used in the Azure app registration, in days.
+`secret-ttl`: time to live for the secret used in the Azure app registration, in days. Default is 60 days.
 
 #
 

--- a/packages/office-addin-sso/src/cli.ts
+++ b/packages/office-addin-sso/src/cli.ts
@@ -12,7 +12,7 @@ import * as commands from "./commands";
 commander.name("office-addin-sso");
 commander.version(process.env.npm_package_version || "(version not available)");
 
-commander.command("configure <manifest-path>").action(commands.configureSSO);
+commander.command("configure <manifest-path> [secret-ttl]").action(commands.configureSSO);
 
 commander.command("start <manifest-path>").action(commands.startSSOService);
 

--- a/packages/office-addin-sso/src/commands.ts
+++ b/packages/office-addin-sso/src/commands.ts
@@ -13,7 +13,7 @@ import inquirer = require("inquirer");
 
 /* global process, console */
 
-export async function configureSSO(manifestPath: string) {
+export async function configureSSO(manifestPath: string, secretTTL?: string) {
   // Check platform and return if not Windows or Mac
   if (process.platform !== "win32" && process.platform !== "darwin") {
     console.log(chalk.yellow(`${process.platform} is not supported. Only Windows and Mac are supported`));
@@ -27,6 +27,16 @@ export async function configureSSO(manifestPath: string) {
     };
     const answer = await inquirer.prompt([question]);
     if (!answer.didUserConfirm) {
+      return;
+    }
+  }
+
+  // If no expiration date was provided, or if we fail to parse the number, we default to 60 days
+  let ttl: number = 60;
+  if (!!secretTTL) {
+    ttl = parseInt(secretTTL);
+    if (isNaN(ttl)) {
+      console.log("Secret TTL value provided is not a number");
       return;
     }
   }
@@ -98,7 +108,7 @@ export async function configureSSO(manifestPath: string) {
 
       // Create an application secret and add to the credential store
       console.log("Setting application secret");
-      const secret: string = await configure.setApplicationSecret(applicationJson);
+      const secret: string = await configure.setApplicationSecret(applicationJson, ttl);
       console.log(chalk.green(`App secret is ${secret}`));
 
       // Add secret to Credential Store (Windows) or Keychain(Mac)

--- a/packages/office-addin-sso/src/commands.ts
+++ b/packages/office-addin-sso/src/commands.ts
@@ -31,7 +31,8 @@ export async function configureSSO(manifestPath: string, secretTTL?: string) {
     }
   }
 
-  // If no expiration date was provided, or if we fail to parse the number, we default to 60 days
+  // We default to 60 days if no ttl was provided.
+  // If we fail to parse the ttl provided, we notify user and abort.
   let ttl: number = 60;
   if (!!secretTTL) {
     ttl = parseInt(secretTTL);

--- a/packages/office-addin-sso/src/configure.ts
+++ b/packages/office-addin-sso/src/configure.ts
@@ -187,9 +187,12 @@ async function promiseExecuteCommand(
   });
 }
 
-export async function setApplicationSecret(applicationJson: Object): Promise<string> {
+export async function setApplicationSecret(applicationJson: Object, secretTTL?: number): Promise<string> {
   try {
     let azRestCommand: string = await fs.readFileSync(defaults.azRestAddSecretCommandPath, "utf8");
+    let now = new Date();
+    let expirationDate = new Date(now.setDate(now.getDate() + secretTTL)).toISOString();
+    azRestCommand = azRestCommand.replace("<Token_Expire_Date>", expirationDate);
     azRestCommand = azRestCommand.replace("<App_Object_ID>", applicationJson["id"]);
     const secretJson: Object = await promiseExecuteCommand(azRestCommand);
     return secretJson["secretText"];

--- a/packages/office-addin-sso/src/scripts/azAddSecretCmd.txt
+++ b/packages/office-addin-sso/src/scripts/azAddSecretCmd.txt
@@ -1,1 +1,1 @@
-az rest -m post -u https://graph.microsoft.com/v1.0/applications/<App_Object_ID>/addPassword --headers "Content-Type=application/json" --body "{\"passwordCredential\": { \"displayName\": \"sso-secretsss\", \"endDateTime\": \"<Token_Expire_Date>\"}}"
+az rest -m post -u https://graph.microsoft.com/v1.0/applications/<App_Object_ID>/addPassword --headers "Content-Type=application/json" --body "{\"passwordCredential\": { \"displayName\": \"sso-secret\", \"endDateTime\": \"<Token_Expire_Date>\"}}"

--- a/packages/office-addin-sso/src/scripts/azAddSecretCmd.txt
+++ b/packages/office-addin-sso/src/scripts/azAddSecretCmd.txt
@@ -1,1 +1,1 @@
-az rest -m post -u https://graph.microsoft.com/v1.0/applications/<App_Object_ID>/addPassword --headers "Content-Type=application/json" --body "{\"passwordCredential\": { \"displayName\": \"sso-secret\"}}"
+az rest -m post -u https://graph.microsoft.com/v1.0/applications/<App_Object_ID>/addPassword --headers "Content-Type=application/json" --body "{\"passwordCredential\": { \"displayName\": \"sso-secretsss\", \"endDateTime\": \"<Token_Expire_Date>\"}}"


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:

    Updated the office-addin-sso configure command to include an optional parameter [secret-ttl] that takes the time to live for the secret used in the Azure app registration, in days. Default is 60 days.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
   Added parameter to office-addin-sso configure command.
   [secret-ttl]: takes the time to live for the secret used in the Azure app registration, in days. Default is 60 days.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)

   [secret-ttl]: takes the time to live for the secret used in the Azure app registration, in days. Default is 60 days.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Tested with no input for new parameter, bad input (not a number), and a valid input
