### PR TITLE
[patch] Update config to use es5 trailing comma rule and move dependency to dev

### DIFF
--- a/packages/office-addin-prettier-config/prettier.config.js
+++ b/packages/office-addin-prettier-config/prettier.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  printWidth: 120
+  printWidth: 120,
+  trailingComma: "es5"
 }

--- a/packages/office-addin-sso/package.json
+++ b/packages/office-addin-sso/package.json
@@ -35,7 +35,6 @@
     "jwks-rsa": "2.1.4",
     "morgan": "1.9.1",
     "node-fetch": "^2.6.1",
-    "office-addin-lint": "^2.3.2",
     "office-addin-usage-data": "^1.6.11",
     "pug": "^3.0.2"
   },
@@ -50,6 +49,7 @@
     "mocha": "^9.1.1",
     "office-addin-cli": "^1.6.2",
     "office-addin-dev-certs": "^1.13.2",
+    "office-addin-lint": "^2.3.2",
     "office-addin-manifest": "^1.13.2",
     "office-addin-test-helpers": "^1.5.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
When updating the eslint and prettier plugin versions a rule was changed to require trailing commas.  We need to be compatible with older "es" version so setting the prettier config to that.  Also move a dependency to lint to the dev section in another package

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Crated a test project with the prettier error and verify it was gone after updated package was used.