### PR TITLE
Update office-addin-manifest-converter converter package

### DIFF
--- a/packages/office-addin-project/package-lock.json
+++ b/packages/office-addin-project/package-lock.json
@@ -13,8 +13,8 @@
         "commander": "^6.2.1",
         "fs-extra": "^7.0.1",
         "inquirer": "^7.3.3",
-        "office-addin-manifest": "^1.13.3",
-        "office-addin-manifest-converter": "^0.3.1",
+        "office-addin-manifest": "^1.13.4",
+        "office-addin-manifest-converter": "^0.4.0",
         "office-addin-usage-data": "^1.6.12",
         "path": "^0.12.7"
       },
@@ -3550,12 +3550,12 @@
       }
     },
     "node_modules/office-addin-manifest": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.13.3.tgz",
-      "integrity": "sha512-pcIJTkLCKddGWyTQYkxWRcumZo9NzPdkQN43c17oylpvH2W0HgsZyBIazkwAjqAETy0VX40NbSQ8ejf4c9jvcA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.13.4.tgz",
+      "integrity": "sha512-bzjc+ypvJT+UBUSsfugftOZh/CZECR5GwJ7PMYcFuB/zGPuh41jeAxbuXhlAy8AeJpQgEsTK3B7N1aDr+JPqjg==",
       "dependencies": {
         "@microsoft/teams-manifest": "^0.1.3",
-        "adm-zip": "^0.5.9",
+        "adm-zip": "0.5.12",
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
@@ -3570,9 +3570,9 @@
       }
     },
     "node_modules/office-addin-manifest-converter": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.3.1.tgz",
-      "integrity": "sha512-b0KumPkwfFqNTQ66Wjjbw5FU+wFMds6zvnGQit5yhHksv01aqQ/abBoI6T7hE5QV4Zx0wZrFGLntYMSShWFi0Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.4.0.tgz",
+      "integrity": "sha512-+MPb4nwXFKOsRLbDWnA0FJB/vPHPL1Ip8u5yvH9vcq8HBO6VNmQOGdR/AlsiEh3NB6M17wBhlnB3d4t+8WhCPw==",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.5",
         "commander": "^9.0.0",
@@ -7614,12 +7614,12 @@
       }
     },
     "office-addin-manifest": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.13.3.tgz",
-      "integrity": "sha512-pcIJTkLCKddGWyTQYkxWRcumZo9NzPdkQN43c17oylpvH2W0HgsZyBIazkwAjqAETy0VX40NbSQ8ejf4c9jvcA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.13.4.tgz",
+      "integrity": "sha512-bzjc+ypvJT+UBUSsfugftOZh/CZECR5GwJ7PMYcFuB/zGPuh41jeAxbuXhlAy8AeJpQgEsTK3B7N1aDr+JPqjg==",
       "requires": {
         "@microsoft/teams-manifest": "^0.1.3",
-        "adm-zip": "^0.5.9",
+        "adm-zip": "0.5.12",
         "chalk": "^2.4.2",
         "commander": "^6.2.0",
         "fs-extra": "^7.0.1",
@@ -7682,9 +7682,9 @@
       }
     },
     "office-addin-manifest-converter": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.3.1.tgz",
-      "integrity": "sha512-b0KumPkwfFqNTQ66Wjjbw5FU+wFMds6zvnGQit5yhHksv01aqQ/abBoI6T7hE5QV4Zx0wZrFGLntYMSShWFi0Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest-converter/-/office-addin-manifest-converter-0.4.0.tgz",
+      "integrity": "sha512-+MPb4nwXFKOsRLbDWnA0FJB/vPHPL1Ip8u5yvH9vcq8HBO6VNmQOGdR/AlsiEh3NB6M17wBhlnB3d4t+8WhCPw==",
       "requires": {
         "@xmldom/xmldom": "^0.8.5",
         "commander": "^9.0.0",

--- a/packages/office-addin-project/package.json
+++ b/packages/office-addin-project/package.json
@@ -23,7 +23,7 @@
     "fs-extra": "^7.0.1",
     "inquirer": "^7.3.3",
     "office-addin-manifest": "^1.13.4",
-    "office-addin-manifest-converter": "^0.3.1",
+    "office-addin-manifest-converter": "^0.4.0",
     "office-addin-usage-data": "^1.6.12",
     "path": "^0.12.7"
   },

--- a/packages/office-addin-project/src/cli.ts
+++ b/packages/office-addin-project/src/cli.ts
@@ -33,6 +33,10 @@ commander
     "-p, --project <project-path>",
     "Specify the location of the root directory of the project.  Default is the directory of the manifest file."
   )
+  .option(
+    "--preview",
+    "Use the devPreview version of the json schema in the manifest output"
+  )
   .option( "--confirm", "Confirmes the conversion")
   .action(commands.convert);
 

--- a/packages/office-addin-project/src/cli.ts
+++ b/packages/office-addin-project/src/cli.ts
@@ -34,7 +34,7 @@ commander
     "Specify the location of the root directory of the project.  Default is the directory of the manifest file."
   )
   .option(
-    "--preview",
+    "--preview-manifest-schema",
     "Use the devPreview version of the json schema in the manifest output"
   )
   .option( "--confirm", "Confirmes the conversion")

--- a/packages/office-addin-project/src/commands.ts
+++ b/packages/office-addin-project/src/commands.ts
@@ -12,10 +12,11 @@ export async function convert(command: commander.Command) {
     const manifestPath: string = command.manifest ?? "./manifest.xml";
     const backupPath: string = command.backup ?? "./backup.zip";
     const projectPath: string = command.project ?? "";
+    const devPreview: boolean = command.preview ?? false;
     const shouldContinue = command.confirm ?? await asksForUserConfirmation();
 
     if (shouldContinue) {
-      await convertProject(manifestPath, backupPath, projectPath);
+      await convertProject(manifestPath, backupPath, projectPath, devPreview);
       usageDataObject.reportSuccess("convert", { result: "Project converted" });
     } else {
       usageDataObject.reportSuccess("convert", {

--- a/packages/office-addin-project/src/convert.ts
+++ b/packages/office-addin-project/src/convert.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import * as fsExtra from "fs-extra";
 import * as path from "path";
 import * as util from "util";
-import { exec, execSync } from "child_process";
+import { exec } from "child_process";
 import { convert } from "office-addin-manifest-converter";
 import { ExpectedError } from "office-addin-usage-data";
 
@@ -18,7 +18,8 @@ const skipBackup: string[] = ["node_modules"];
 export async function convertProject(
   manifestPath: string = "./manifest.xml",
   backupPath: string = "./backup.zip",
-  projectDir: string = ""
+  projectDir: string = "",
+  devPreview: boolean = false
 ) {
   if (manifestPath.endsWith(".json")) {
     throw new ExpectedError(
@@ -41,7 +42,12 @@ export async function convertProject(
     projectDir = projectDir === "" ? outputPath : projectDir; 
     process.chdir(projectDir);
   
-    await convert(manifestPath, outputPath, false /* imageDownload */, true /* imageUrls */);
+    if(!devPreview) {
+      await convert(manifestPath, outputPath, false /* imageDownload */);
+    } else {
+      // override the schema used in the json manifest to use the devPreview schema
+      await convert(manifestPath, outputPath, false /* imageDownload */, "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json", "devPreview");
+    }
     await updatePackages();
     await updateManifestXmlReferences();
     fs.unlinkSync(manifestPath);


### PR DESCRIPTION
Thank you for your pull request!  

Please add '[major]', '[minor]', or [patch] to the title to indicate the impact the change has on the code.  Please also provide the following information.

---

**Change Description**:
Update the version of the package of office-addin-manifest-converter in office-addin-package and then add a "--preview-manifest-schema" option that uses a the devPreview json manifest schema

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
Yes . . . adds a parameter to office-addin-project that allows the use of the devPreview json manifest schema

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
Yes.  Will need to update the use of office-addin-project for projects that need to use the devPreview schema in the resulting json manifest

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Manually used cli to convert a test project.