### PR TITLE
[patch] getHttpsServerOptions add params

### DIFF
--- a/packages/office-addin-dev-certs/src/httpsServerOptions.ts
+++ b/packages/office-addin-dev-certs/src/httpsServerOptions.ts
@@ -13,8 +13,12 @@ interface IHttpsServerOptions {
   key: Buffer;
 }
 
-export async function getHttpsServerOptions(): Promise<IHttpsServerOptions> {
-  await ensureCertificatesAreInstalled();
+export async function getHttpsServerOptions(
+  daysUntilCertificateExpires?: number,
+  domains?: string[],
+  machine?: boolean
+): Promise<IHttpsServerOptions> {
+  await ensureCertificatesAreInstalled(daysUntilCertificateExpires, domains, machine);
 
   const httpsServerOptions = {} as IHttpsServerOptions;
   try {


### PR DESCRIPTION
**Change Description**:
I want sign a cert for local ip, e.g. 127.1.1.1 \ 192.0.0.0, but getHttpsServerOptions can't pass the domains.

the function `getHttpsServerOptions` add three optional params, they are same as the function `ensureCertificatesAreInstalled` 's params.




1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    If Yes, briefly describe what is impacted.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Describe manual testing done. 
