### PR TITLE
[patch] Add custom function metadata auto-gen support for @linkedEntityLoadService

### DIFF
--- a/packages/custom-functions-metadata/Specification.md
+++ b/packages/custom-functions-metadata/Specification.md
@@ -14,7 +14,7 @@ The function parameter types may be provided using the [@param](#param) tag in J
 * [@customfunction](#customfunction) id name
 * [@excludeFromAutoComplete](#excludeFromAutoComplete)
 * [@helpurl](#helpurl) url
-* [@linkedEntityDataProvider](#linkedEntityDataProvider)
+* [@linkedEntityLoadService](#linkedEntityLoadService)
 * [@param](#param) _{type}_ name description
 * [@requiresAddress](#requiresAddress)
 * [@requiresParameterAddresses](#requiresParameterAddresses)
@@ -74,7 +74,7 @@ Indicates that the function will be excluded from the autocomplete drop-down lis
 
 If the function is manually spelled correctly in the grid, the function will still execute.
 
-A function cannot have both `@excludeFromAutoComplete` and `@linkedEntityDataProvider` tags.
+A function cannot have both `@excludeFromAutoComplete` and `@linkedEntityLoadService` tags.
 
 ---
 ### @helpurl
@@ -84,7 +84,7 @@ Syntax: @helpurl _url_
 The provided _url_ is displayed in Excel.
 
 ---
-### @linkedEntityDataProvider
+### @linkedEntityLoadService
 
 Indicates that the function is a "special" custom function that is meant to act as the "loadFunction" for user defined `LinkedEntityDataDomain`s. 
 
@@ -93,7 +93,7 @@ The function will be excluded from the autocomplete drop-down list and Formula B
 * Must accept and return a single non-repeating, non-optional, scalar parameter of type `unknown`.
 * Must not be a XLL-compatible custom function.
 * Must allow rich data as input.
-* A `@linkedEntityDataProvider` function cannot be combined with `@streaming`, `@volatile`, `@requiresAddress`, `@requiresParameterAddresses`, `@excludeFromAutoComplete`, or `@capturesCallingObject` tags.
+* A `@linkedEntityLoadService` function cannot be combined with `@streaming`, `@volatile`, `@requiresAddress`, `@requiresParameterAddresses`, `@excludeFromAutoComplete`, or `@capturesCallingObject` tags.
 
 ---
 ### @param 

--- a/packages/custom-functions-metadata/package-lock.json
+++ b/packages/custom-functions-metadata/package-lock.json
@@ -12,7 +12,7 @@
         "assert": "^1.5.0",
         "commander": "^10.0.0",
         "nconf": "^0.12.0",
-        "office-addin-usage-data": "^1.6.14",
+        "office-addin-usage-data": "^2.0.0",
         "xregexp": "^4.3.0"
       },
       "bin": {
@@ -26,8 +26,8 @@
         "@types/xregexp": "^3.0.30",
         "concurrently": "^6.2.2",
         "mocha": "^9.1.1",
-        "office-addin-lint": "^2.3.5",
-        "office-addin-prettier-config": "^1.2.1",
+        "office-addin-lint": "^3.0.0",
+        "office-addin-prettier-config": "^2.0.0",
         "rimraf": "^3.0.2",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4"
@@ -627,31 +627,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/rule-tester": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-7.18.0.tgz",
-      "integrity": "sha512-ClrFQlwen9pJcYPIBLuarzBpONQAwjmJ0+YUjAo1TGzoZFJPyUK/A7bb4Mps0u+SMJJnFXbfMN8I9feQDf0O5A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
-        "ajv": "^6.12.6",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "4.6.2",
-        "semver": "^7.6.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@eslint/eslintrc": ">=2",
-        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -1781,9 +1756,9 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/es-abstract": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "version": "1.23.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -1801,7 +1776,7 @@
         "function.prototype.name": "^1.1.6",
         "get-intrinsic": "^1.2.4",
         "get-symbol-description": "^1.0.2",
-        "globalthis": "^1.0.3",
+        "globalthis": "^1.0.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.0.3",
@@ -1817,10 +1792,10 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
+        "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.5",
-        "regexp.prototype.flags": "^1.5.2",
+        "regexp.prototype.flags": "^1.5.3",
         "safe-array-concat": "^1.1.2",
         "safe-regex-test": "^1.0.3",
         "string.prototype.trim": "^1.2.9",
@@ -1860,9 +1835,9 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.19.tgz",
-      "integrity": "sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.0.tgz",
+      "integrity": "sha512-tpxqxncxnpw3c93u8n3VOzACmRFoVmWJqbWXvX/JfKbkhBw1oslgPrUfeSt2psuqyEJFD6N/9lg5i7bsKpoq+Q==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -1872,12 +1847,13 @@
         "es-set-tostringtag": "^2.0.3",
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "globalthis": "^1.0.3",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.0.3",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.7",
-        "iterator.prototype": "^1.1.2",
+        "iterator.prototype": "^1.1.3",
         "safe-array-concat": "^1.1.2"
       },
       "engines": {
@@ -2025,18 +2001,17 @@
       }
     },
     "node_modules/eslint-plugin-office-addins": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-3.0.3.tgz",
-      "integrity": "sha512-HqDqE5j1K/EnanKaSI3B3r3XHDS6jkWXvGQOIuk5GwyYre7Tkbczh+2BzorPqzMzTuH4VVCO7NI72/M/iNu2PA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-office-addins/-/eslint-plugin-office-addins-4.0.0.tgz",
+      "integrity": "sha512-5u+xBRGYmjjinG6Vq4Cczz/3eRYqirISV50ji/YyrB5Vb328JYgDnBN/Xoy+t7EXXJsvx6Rx5gVH61Tl3yJlsA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/rule-tester": "^7.5.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-native": "^4.1.0",
-        "office-addin-prettier-config": "^1.2.1",
+        "office-addin-prettier-config": "^2.0.0",
         "prettier": "^3.2.5",
         "requireindex": "~1.2.0",
         "typescript": "^5.4.3",
@@ -2152,9 +2127,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins/node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2221,9 +2196,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.37.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
-      "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
+      "version": "7.37.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz",
+      "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.8",
@@ -2231,7 +2206,7 @@
         "array.prototype.flatmap": "^1.3.2",
         "array.prototype.tosorted": "^1.1.4",
         "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.0.19",
+        "es-iterator-helpers": "^1.1.0",
         "estraverse": "^5.3.0",
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
@@ -3337,9 +3312,9 @@
       "dev": true
     },
     "node_modules/iterator.prototype": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
-      "integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.3.tgz",
+      "integrity": "sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==",
       "dev": true,
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -3347,6 +3322,9 @@
         "has-symbols": "^1.0.3",
         "reflect.getprototypeof": "^1.0.4",
         "set-function-name": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/js-tokens": {
@@ -3638,9 +3616,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -3724,18 +3702,18 @@
       }
     },
     "node_modules/office-addin-lint": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-2.3.5.tgz",
-      "integrity": "sha512-Un75ZXv5XQ0bwE7Qf93E9YlbRd2B4qCPcZ3vqSVzNK8xJIOjc9fsJz9Dcsz8uza5gnEX7jEmTQq3aWZERJDK7w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/office-addin-lint/-/office-addin-lint-3.0.0.tgz",
+      "integrity": "sha512-sSgi3aWX6kAnjUTZLsZFpoBViH2JRKuoFGbXrOtKnbIX56HMH0C+a6/nMYPjvqRwBJzOpPNtS9aVLxj9KIr6+g==",
       "dev": true,
       "dependencies": {
         "commander": "^6.2.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-office-addins": "^3.0.3",
+        "eslint-plugin-office-addins": "^4.0.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "office-addin-prettier-config": "^1.2.1",
-        "office-addin-usage-data": "^1.6.14",
+        "office-addin-prettier-config": "^2.0.0",
+        "office-addin-usage-data": "^2.0.0",
         "prettier": "^3.2.5",
         "typescript-eslint": "^8.4.0"
       },
@@ -3753,15 +3731,15 @@
       }
     },
     "node_modules/office-addin-prettier-config": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-1.2.1.tgz",
-      "integrity": "sha512-FlBMKuZostX7/g2M5Y8qUtkdy83STzm7zDonx3ZRr9NnrFyhdUVANqnDCy4NwCOpcALxMVnpNOYMmTFIQBXaAw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/office-addin-prettier-config/-/office-addin-prettier-config-2.0.0.tgz",
+      "integrity": "sha512-jnB+jm56cEb58Z1FPpvaSbK7Rc4khK2f5S0A0YNyi4vy/LNsar2Hwb/tYHknB7ssKyFMPKxjinUXMBw6xn7tCw==",
       "dev": true
     },
     "node_modules/office-addin-usage-data": {
-      "version": "1.6.14",
-      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-1.6.14.tgz",
-      "integrity": "sha512-V3TQoMR7McjJ62TWQeRnZqVp1mpjk1bbazvea/pqCJod5zggjlgDspjL5NJzTZc4+MwwJPR8k5Yr5Me+OcRLQw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-2.0.0.tgz",
+      "integrity": "sha512-cwtDLII2S6raE0OucU+MZOhWdiNLmARDaFxus/6so0KQawQiMEVo2lPhacPOTYypeBKZAK7o5AIcE2NWT6VFfQ==",
       "dependencies": {
         "applicationinsights": "^1.7.3",
         "commander": "^6.2.0",
@@ -4511,9 +4489,9 @@
       }
     },
     "node_modules/synckit/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
     "node_modules/text-table": {

--- a/packages/custom-functions-metadata/src/parseTree.ts
+++ b/packages/custom-functions-metadata/src/parseTree.ts
@@ -25,7 +25,7 @@ export interface IFunctionOptions {
   volatile?: boolean;
   requiresParameterAddresses?: boolean;
   excludeFromAutoComplete?: boolean;
-  linkedEntityDataProvider?: boolean;
+  linkedEntityLoadService?: boolean;
   capturesCallingObject?: boolean;
 }
 
@@ -104,7 +104,7 @@ const CANCELABLE = "cancelable";
 const REQUIRESADDRESS = "requiresaddress";
 const REQUIRESPARAMETERADDRESSES = "requiresparameteraddresses";
 const EXCLUDEFROMAUTOCOMPLETE = "excludefromautocomplete";
-const LINKEDENTITYDATAPROVIDER = "linkedentitydataprovider";
+const LINKEDENTITYLOADSERVICE = "linkedentityloadservice";
 const CAPTURESCALLINGOBJECT = "capturescallingobject";
 
 const TYPE_MAPPINGS = {
@@ -311,7 +311,7 @@ export function parseTree(sourceCode: string, sourceFileName: string): IParseTre
             !options.volatile &&
             !options.requiresParameterAddresses &&
             !options.excludeFromAutoComplete &&
-            !options.linkedEntityDataProvider &&
+            !options.linkedEntityLoadService &&
             !options.capturesCallingObject
           ) {
             delete functionMetadata.options;
@@ -340,8 +340,8 @@ export function parseTree(sourceCode: string, sourceFileName: string): IParseTre
               delete options.excludeFromAutoComplete;
             }
 
-            if (!options.linkedEntityDataProvider) {
-              delete options.linkedEntityDataProvider;
+            if (!options.linkedEntityLoadService) {
+              delete options.linkedEntityLoadService;
             }
 
             if (!options.capturesCallingObject) {
@@ -498,7 +498,7 @@ function getOptions(
     volatile: isVolatile(func),
     requiresParameterAddresses: isRequiresParameterAddresses(func),
     excludeFromAutoComplete: isExcludedFromAutoComplete(func),
-    linkedEntityDataProvider: isLinkedEntityDataProvider(func),
+    linkedEntityLoadService: isLinkedEntityLoadService(func),
     capturesCallingObject: capturesCallingObject(func),
   };
 
@@ -521,7 +521,7 @@ function getOptions(
   }
 
   if (
-    optionsItem.linkedEntityDataProvider &&
+    optionsItem.linkedEntityLoadService &&
     (optionsItem.excludeFromAutoComplete ||
       optionsItem.volatile ||
       optionsItem.stream ||
@@ -546,7 +546,7 @@ function getOptions(
       errorParam = "@capturesCallingObject";
     }
 
-    const errorString = `${errorParam} cannot be used with @linkedEntityDataProvider.`;
+    const errorString = `${errorParam} cannot be used with @linkedEntityLoadService.`;
     extra.errors.push(logError(errorString, functionPosition));
   }
 
@@ -869,11 +869,11 @@ function isExcludedFromAutoComplete(node: ts.Node): boolean {
 }
 
 /**
- * Returns true if linkedEntityDataProvider tag found in comments
+ * Returns true if linkedEntityLoadService tag found in comments
  * @param node jsDocs node
  */
-function isLinkedEntityDataProvider(node: ts.Node): boolean {
-  return hasTag(node, LINKEDENTITYDATAPROVIDER);
+function isLinkedEntityLoadService(node: ts.Node): boolean {
+  return hasTag(node, LINKEDENTITYLOADSERVICE);
 }
 
 /**

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/expected.js.errors.txt
@@ -1,1 +1,1 @@
-@capturesCallingObject cannot be used with @linkedEntityDataProvider. (1,1)
+@capturesCallingObject cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/expected.ts.errors.txt
@@ -1,1 +1,1 @@
-@capturesCallingObject cannot be used with @linkedEntityDataProvider. (1,1)
+@capturesCallingObject cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/functions.js
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the capturesCallingObject tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
  * @capturesCallingObject
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-function linkedEntityLoadServiceTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(request) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/functions.js
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the capturesCallingObject tag
+ * Test the linkedEntityLoadService tag in combination with the capturesCallingObject tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @capturesCallingObject
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-function linkedEntityDataProviderTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(linkedEntityId) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/functions.ts
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the capturesCallingObject tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
  * @capturesCallingObject
- * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(request: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-capturesCallingObject/functions.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the capturesCallingObject tag
+ * Test the linkedEntityLoadService tag in combination with the capturesCallingObject tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @capturesCallingObject
  * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/expected.js.errors.txt
@@ -1,1 +1,1 @@
-@excludeFromAutoComplete cannot be used with @linkedEntityDataProvider. (1,1)
+@excludeFromAutoComplete cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/expected.ts.errors.txt
@@ -1,1 +1,1 @@
-@excludeFromAutoComplete cannot be used with @linkedEntityDataProvider. (1,1)
+@excludeFromAutoComplete cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.js
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the excludeFromAutoComplete tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
  * @excludeFromAutoComplete
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-function linkedEntityLoadServiceTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(request) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.js
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the excludeFromAutoComplete tag
+ * Test the linkedEntityLoadService tag in combination with the excludeFromAutoComplete tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @excludeFromAutoComplete
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-function linkedEntityDataProviderTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(linkedEntityId) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the excludeFromAutoComplete tag
+ * Test the linkedEntityLoadService tag in combination with the excludeFromAutoComplete tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @excludeFromAutoComplete
  * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-excludefromautocomplete/functions.ts
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the excludeFromAutoComplete tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
  * @excludeFromAutoComplete
- * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(request: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/expected.js.errors.txt
@@ -1,1 +1,1 @@
-@requiresAddress cannot be used with @linkedEntityDataProvider. (1,1)
+@requiresAddress cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/expected.ts.errors.txt
@@ -1,1 +1,1 @@
-@requiresAddress cannot be used with @linkedEntityDataProvider. (1,1)
+@requiresAddress cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/functions.js
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the requiresAddress tag
+ * Test the linkedEntityLoadService tag in combination with the requiresAddress tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @param handler {CustomFunctions.Invocation} my handler
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @requiresAddress
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-function linkedEntityDataProviderTest(linkedEntityId, handler) {
+function linkedEntityLoadServiceTest(linkedEntityId, handler) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/functions.js
@@ -3,13 +3,13 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the requiresAddress tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @param handler {CustomFunctions.Invocation} my handler
  * @customfunction
  * @linkedEntityLoadService
  * @requiresAddress
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-function linkedEntityLoadServiceTest(linkedEntityId, handler) {
+function linkedEntityLoadServiceTest(request, handler) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/functions.ts
@@ -3,13 +3,13 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the requiresAddress tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @param handler my handler
  * @customfunction
  * @linkedEntityLoadService
  * @requiresAddress
- * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-async function linkedEntityLoadServiceTest(linkedEntityId: unknown, handler: CustomFunctions.Invocation): Promise<any> {
+async function linkedEntityLoadServiceTest(request: unknown, handler: CustomFunctions.Invocation): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresaddress/functions.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the requiresAddress tag
+ * Test the linkedEntityLoadService tag in combination with the requiresAddress tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @param handler my handler
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @requiresAddress
  * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: unknown, handler: CustomFunctions.Invocation): Promise<any> {
+async function linkedEntityLoadServiceTest(linkedEntityId: unknown, handler: CustomFunctions.Invocation): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/expected.js.errors.txt
@@ -1,1 +1,1 @@
-@requiresParameterAddresses cannot be used with @linkedEntityDataProvider. (1,1)
+@requiresParameterAddresses cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/expected.ts.errors.txt
@@ -1,1 +1,1 @@
-@requiresParameterAddresses cannot be used with @linkedEntityDataProvider. (1,1)
+@requiresParameterAddresses cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/functions.js
@@ -3,13 +3,13 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the requiresParameterAddresses tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @param handler {CustomFunctions.Invocation} my handler
  * @customfunction
  * @linkedEntityLoadService
  * @requiresParameterAddresses
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-function linkedEntityLoadServiceTest(linkedEntityId, handler) {
+function linkedEntityLoadServiceTest(request, handler) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/functions.js
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the requiresParameterAddresses tag
+ * Test the linkedEntityLoadService tag in combination with the requiresParameterAddresses tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @param handler {CustomFunctions.Invocation} my handler
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @requiresParameterAddresses
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-function linkedEntityDataProviderTest(linkedEntityId, handler) {
+function linkedEntityLoadServiceTest(linkedEntityId, handler) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/functions.ts
@@ -3,13 +3,13 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the requiresParameterAddresses tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @param handler my handler
  * @customfunction
  * @linkedEntityLoadService
  * @requiresParameterAddresses
- * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-async function linkedEntityLoadServiceTest(linkedEntityId: unknown, handler: CustomFunctions.Invocation): Promise<any> {
+async function linkedEntityLoadServiceTest(request: unknown, handler: CustomFunctions.Invocation): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-requiresparameteraddresses/functions.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the requiresParameterAddresses tag
+ * Test the linkedEntityLoadService tag in combination with the requiresParameterAddresses tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @param handler my handler
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @requiresParameterAddresses
  * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: unknown, handler: CustomFunctions.Invocation): Promise<any> {
+async function linkedEntityLoadServiceTest(linkedEntityId: unknown, handler: CustomFunctions.Invocation): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/expected.js.errors.txt
@@ -1,1 +1,1 @@
-@streaming cannot be used with @linkedEntityDataProvider. (1,1)
+@streaming cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/expected.ts.errors.txt
@@ -1,1 +1,1 @@
-@streaming cannot be used with @linkedEntityDataProvider. (1,1)
+@streaming cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.js
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the streaming tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
  * @streaming
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-function linkedEntityLoadServiceTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(request) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.js
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the streaming tag
+ * Test the linkedEntityLoadService tag in combination with the streaming tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @streaming
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-function linkedEntityDataProviderTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(linkedEntityId) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the streaming tag
+ * Test the linkedEntityLoadService tag in combination with the streaming tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @streaming
  * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-streaming/functions.ts
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the streaming tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
  * @streaming
- * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(request: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/expected.js.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/expected.js.errors.txt
@@ -1,1 +1,1 @@
-@volatile cannot be used with @linkedEntityDataProvider. (1,1)
+@volatile cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/expected.ts.errors.txt
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/expected.ts.errors.txt
@@ -1,1 +1,1 @@
-@volatile cannot be used with @linkedEntityDataProvider. (1,1)
+@volatile cannot be used with @linkedEntityLoadService. (1,1)

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.js
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the volatile tag
+ * Test the linkedEntityLoadService tag in combination with the volatile tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @volatile
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-function linkedEntityDataProviderTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(linkedEntityId) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.js
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.js
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the volatile tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
  * @volatile
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-function linkedEntityLoadServiceTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(request) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
@@ -3,12 +3,12 @@
 
 /**
  * Test the linkedEntityLoadService tag in combination with the volatile tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
  * @volatile
- * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(request: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/error-linkedentitydataprovider-volatile/functions.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag in combination with the volatile tag
+ * Test the linkedEntityLoadService tag in combination with the volatile tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @volatile
  * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/expected.json
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/expected.json
@@ -2,11 +2,11 @@
     "allowCustomDataForDataTypeAny": true,
     "functions": [
         {
-            "description": "Test the linkedEntityDataProvider tag",
-            "id": "LINKEDENTITYDATAPROVIDERTEST",
-            "name": "LINKEDENTITYDATAPROVIDERTEST",
+            "description": "Test the linkedEntityLoadService tag",
+            "id": "LINKEDENTITYLOADSERVICETEST",
+            "name": "LINKEDENTITYLOADSERVICETEST",
             "options": {
-                "linkedEntityDataProvider": true
+                "linkedEntityLoadService": true
             },
             "parameters": [
                 {

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/expected.json
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/expected.json
@@ -10,8 +10,8 @@
             },
             "parameters": [
                 {
-                    "description": "Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.",
-                    "name": "linkedEntityId",
+                    "description": "Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.",
+                    "name": "request",
                     "type": "any"
                 }
             ],

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.js
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.js
@@ -3,11 +3,11 @@
 
 /**
  * Test the linkedEntityLoadService tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
- * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-function linkedEntityLoadServiceTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(request) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.js
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.js
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag
+ * Test the linkedEntityLoadService tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @returns {Promise<any>} Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-function linkedEntityDataProviderTest(linkedEntityId) {
+function linkedEntityLoadServiceTest(linkedEntityId) {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
@@ -3,11 +3,11 @@
 
 /**
  * Test the linkedEntityLoadService tag
- * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
+ * @param request Represents a request to the `@linkedEntityLoadService` custom function to load `LinkedEntityCellValue` objects.
  * @customfunction
  * @linkedEntityLoadService
- * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
+ * @returns Resolved/Updated `LinkedEntityCellValue` objects that were requested by the passed-in request.
  */
-async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(request: unknown): Promise<any> {
     // Empty
 }

--- a/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
+++ b/packages/custom-functions-metadata/test/cases/linkedentitydataprovider/functions.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 /**
- * Test the linkedEntityDataProvider tag
+ * Test the linkedEntityLoadService tag
  * @param linkedEntityId Unique `LinkedEntityId` of the `LinkedEntityCellValue`s which is being requested for resolution/refresh.
  * @customfunction
- * @linkedEntityDataProvider
+ * @linkedEntityLoadService
  * @returns Resolved/Updated `LinkedEntityCellValue` that was requested by the passed-in id.
  */
-async function linkedEntityDataProviderTest(linkedEntityId: unknown): Promise<any> {
+async function linkedEntityLoadServiceTest(linkedEntityId: unknown): Promise<any> {
     // Empty
 }


### PR DESCRIPTION
**Change Description**:

    Updating naming of @linkedEntityDataProvider to @linkedEntityLoadService

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    No


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
   No


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct
