### PR TITLE
[patch] Upgrade path-to-regexp to 0.1.12

### DIFF
--- a/packages/office-addin-sso/package-lock.json
+++ b/packages/office-addin-sso/package-lock.json
@@ -14,7 +14,7 @@
         "cookie-parser": "^1.4.7",
         "cors": "2.8.5",
         "dotenv": "^8.2.0",
-        "express": "4.21.1",
+        "express": "^4.21.2",
         "form-urlencoded": "3.0.0",
         "http-errors": "~1.6.3",
         "jquery": "^3.5.1",
@@ -23,6 +23,7 @@
         "morgan": "1.9.1",
         "node-fetch": "^2.6.1",
         "office-addin-usage-data": "^1.6.14",
+        "path-to-regexp": "^0.1.12",
         "pug": "^3.0.2"
       },
       "bin": {
@@ -3594,9 +3595,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3617,7 +3618,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -3632,6 +3633,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -6349,9 +6354,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/packages/office-addin-sso/package.json
+++ b/packages/office-addin-sso/package.json
@@ -27,7 +27,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "2.8.5",
     "dotenv": "^8.2.0",
-    "express": "4.21.1",
+    "express": "^4.21.2",
     "form-urlencoded": "3.0.0",
     "http-errors": "~1.6.3",
     "jquery": "^3.5.1",
@@ -36,6 +36,7 @@
     "morgan": "1.9.1",
     "node-fetch": "^2.6.1",
     "office-addin-usage-data": "^1.6.14",
+    "path-to-regexp": "^0.1.12",
     "pug": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
**Change Description**:

This change upgrades the path-to-regexp package to version 0.1.12 (to address vulnerabilities).

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
    No


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
    No

**Validation/testing performed**:
Validated with `npm run test`.
