### PR TITLE
fix: resolve Invalid id in Terminal add in still installed error

### DIFF
--- a/packages/office-addin-dev-settings/src/publish.ts
+++ b/packages/office-addin-dev-settings/src/publish.ts
@@ -57,10 +57,15 @@ export async function uninstallWithTeams(id: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const guidRegex = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
     const manifestIdRegex = new RegExp(`^${guidRegex.source}$`);
-    const titleIdRegex = new RegExp(`^U_${guidRegex.source}$`);
+    const titleIdRegexU = new RegExp(`^U_${guidRegex.source}$`);
+    const titleIdRegexT = new RegExp(`^T_${guidRegex.source}$`);
     let mode: string = "";
 
-    if (titleIdRegex.test(id)) {
+    if (titleIdRegexT.test(id)) {
+      // T_ IDs must be converted to manifest-id format (strip the T_ prefix)
+      const manifestId = id.substring(2);
+      mode = `--mode manifest-id --manifest-id ${manifestId}`;
+    } else if (titleIdRegexU.test(id)) {
       mode = `--mode title-id --title-id ${id}`;
     } else if (manifestIdRegex.test(id)) {
       mode = `--mode manifest-id --manifest-id ${id}`;


### PR DESCRIPTION
**Root Cause**
- DA projects return title IDs with `T_` prefix (vs. `U_` for traditional Office add-ins)
- Validation regex didn't recognize `T_` prefix
- ATK CLI's `atk uninstall --mode title-id` doesn't support `T_` IDs (30s timeout)

**Solution**
- Detect `T_` prefix title IDs
- Strip the `T_` prefix to extract the manifest GUID
- Use `--mode manifest-id` instead of `--mode title-id` for uninstall
- `U_` IDs continue using `--mode title-id` (existing behavior)

**Changes**
- Modified `uninstallWithTeams()` in `packages/office-addin-dev-settings/src/publish.ts`
- Added separate regex patterns for `T_` and `U_` prefixes
- Auto-convert `T_<guid>` → `--mode manifest-id --manifest-id <guid>`

**Validation/testing performed**:

Local Testing done via `npm link`.
Stop command now works for DA projects without errors or timeouts. Clean add-in un-installation when office app is closed and debug is stopped.

<img width="1232" height="305" alt="image (2)" src="https://github.com/user-attachments/assets/9b11ce24-32f7-4985-8f72-2116869f0935" />


