### PR TITLE
[patch]: fix web sideload with manifest preview

### DIFF
--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -135,13 +135,9 @@ export async function generateSideloadUrl(
   if (!manifest.id) {
     throw new ExpectedError("The manifest does not contain the id for the add-in.");
   }
-
-  if (
-    manifest.defaultSettings === undefined ||
-    manifest.defaultSettings.sourceLocation === undefined
-  ) {
-    throw new ExpectedError("The manifest does not contain the SourceLocation for the add-in");
-  }
+  
+  manifest.defaultSettings = manifest.defaultSettings ?? {};
+  manifest.defaultSettings.sourceLocation = manifest.defaultSettings.sourceLocation ?? "https://localhost:4000";
 
   const sourceLocationUrl: URL = new URL(manifest.defaultSettings.sourceLocation);
   if (sourceLocationUrl.protocol.indexOf("https") === -1) {


### PR DESCRIPTION

**Change Description**:

To side load on the web, the sourceLocation is required, however, the dev manifest preview fails if you add it in the manifest file. This adds a default location, so that web side load works with the manifest preview

1. **Do these changes impact *command syntax* of any of the packages?**  No

2. **Do these changes impact *documentation*?** No

**Validation/testing performed**:

`bunx -b office-addin-debugging start --dev-tools manifest.json web --document <some_doc>`