### PR TITLE
[patch] Stop application insights from autocollecting everything

### DIFF
--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -150,7 +150,7 @@ export class OfficeAddinUsageData {
             .setAutoCollectExceptions(false)
             .setAutoCollectHeartbeat(false)
             .setAutoCollectIncomingRequestAzureFunctions(false)
-            .setAutoCollectPerformance(false, null)
+            .setAutoCollectPerformance(false, false)
             .setAutoCollectPreAggregatedMetrics(false)
             .setAutoCollectRequests(false)
             .start();

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -142,7 +142,12 @@ export class OfficeAddinUsageData {
         // Only call setup if Application Insights hasn't been initialized yet
         // This prevents warnings about duplicate API registrations in tests
         if (!appInsights.defaultClient) {
-          appInsights.setup(connectionString).setAutoCollectExceptions(false).start();
+          appInsights
+            .setup(connectionString)
+            .setAutoCollectExceptions(false)
+            .setAutoCollectDependencies(false)
+            .setAutoCollectRequests(false)
+            .start();
         }
         this.usageDataClient = appInsights.defaultClient;
         this.removeApplicationInsightsSensitiveInformation();

--- a/packages/office-addin-usage-data/src/usageData.ts
+++ b/packages/office-addin-usage-data/src/usageData.ts
@@ -144,8 +144,14 @@ export class OfficeAddinUsageData {
         if (!appInsights.defaultClient) {
           appInsights
             .setup(connectionString)
-            .setAutoCollectExceptions(false)
+            .setAutoDependencyCorrelation(false)
+            .setAutoCollectConsole(false)
             .setAutoCollectDependencies(false)
+            .setAutoCollectExceptions(false)
+            .setAutoCollectHeartbeat(false)
+            .setAutoCollectIncomingRequestAzureFunctions(false)
+            .setAutoCollectPerformance(false, null)
+            .setAutoCollectPreAggregatedMetrics(false)
             .setAutoCollectRequests(false)
             .start();
         }


### PR DESCRIPTION
**Change Description**:
The updated to application insights package previously done started automatically collecting extra information that was un-needed.  The reduces that set.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran automated tests.