### PR TITLE
Add support for disk manifests and source bundle override

### DIFF
--- a/packages/office-addin-debugging/src/cli.ts
+++ b/packages/office-addin-debugging/src/cli.ts
@@ -33,6 +33,8 @@ commander
   .option("--source-bundle-url-port <port>")
   .option("--source-bundle-url-path <path>")
   .option("--source-bundle-url-extension <extension>")
+  .option("--local")
+  .option("--source-bundle-override-file <path>")
   .action(commands.start);
 
 commander

--- a/packages/office-addin-debugging/src/commands.ts
+++ b/packages/office-addin-debugging/src/commands.ts
@@ -3,6 +3,7 @@
 
 import { OptionValues } from "commander";
 import fs from "fs";
+import fspath from "path";
 import { parseNumber, getPackageJsonScript } from "office-addin-cli";
 import { logErrorMessage } from "office-addin-usage-data";
 import * as devSettings from "office-addin-dev-settings";
@@ -50,6 +51,7 @@ export async function start(
   platform: string | undefined,
   options: OptionValues
 ) {
+  console.log(JSON.stringify(options));
   try {
     const appPlatformToDebug: Platform | undefined = parsePlatform(
       platform || process.env.npm_package_config_app_platform_to_debug || Platform.Win32
@@ -85,6 +87,9 @@ export async function start(
       options.sourceBundleUrlPath,
       options.sourceBundleUrlExtension
     );
+    const local: boolean = options.local === true;
+    const sourceBundleOverrideFile: string | undefined =
+      options.sourceBundleOverrideFile || process.env.npm_package_config_source_bundle_override_file;
 
     if (appPlatformToDebug === undefined) {
       throw new ExpectedError("Please specify the platform to debug.");
@@ -119,6 +124,8 @@ export async function start(
       enableSideload,
       openDevTools,
       document,
+      local,
+      sourceBundleOverrideFile
     });
 
     usageDataObject.reportSuccess("start");

--- a/packages/office-addin-debugging/src/commands.ts
+++ b/packages/office-addin-debugging/src/commands.ts
@@ -51,7 +51,6 @@ export async function start(
   platform: string | undefined,
   options: OptionValues
 ) {
-  console.log(JSON.stringify(options));
   try {
     const appPlatformToDebug: Platform | undefined = parsePlatform(
       platform || process.env.npm_package_config_app_platform_to_debug || Platform.Win32

--- a/packages/office-addin-debugging/src/shared.ts
+++ b/packages/office-addin-debugging/src/shared.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import fs from "fs";
+import fspath from "path";
+
+export function getDiskManifestDir(create: boolean): string {
+  const tempDir = process.env.TEMP;
+  const targetDirName = "OfficeAddinDebugging";
+  const targetManifestDir = fspath.normalize(`${tempDir}/${targetDirName}`);
+
+  if (create && !fs.existsSync(targetManifestDir)) {
+    fs.mkdirSync(targetManifestDir);
+  }
+  return targetManifestDir;
+}

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -8,7 +8,7 @@ import fspath from "path";
 import * as devCerts from "office-addin-dev-certs";
 import * as devSettings from "office-addin-dev-settings";
 import os from "os";
-import { DebuggingMethod, sideloadAddIn, launchDesktopApp } from "office-addin-dev-settings";
+import { DebuggingMethod, sideloadAddIn } from "office-addin-dev-settings";
 import { OfficeApp, OfficeAddinManifest } from "office-addin-manifest";
 import * as nodeDebugger from "office-addin-node-debugger";
 import * as debugInfo from "./debugInfo";
@@ -422,13 +422,16 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
 
     if (enableSideload) {
       try {
-        console.log(`Sideloading the Office Add-in...`);
-        await sideloadAddIn(manifestPath, app, true, appType, document);
+        const launchOnly = local;
+        let msg = `Sideloading the Office Add-in...`;
+        if (launchOnly) {
+          msg = `Disk-loading the Office Add-in...`;
+        }
+        console.log(msg);
+        await sideloadAddIn(manifestPath, app, true, launchOnly, appType, document);
       } catch (err) {
         throw new Error(`Unable to sideload the Office Add-in. \n${err}`);
       }
-    } else if (app && isDesktopAppType && isWindowsPlatform) {
-      await launchDesktopApp(app, manifestInfo, undefined /* document */);
     }
 
     console.log(enableDebugging ? "Debugging started." : "Started.");

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -370,7 +370,7 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
     // setup to run manifest and source bundle locally
     if (isDesktopAppType && isWindowsPlatform) {
       if (local) {
-        const diskManifestDir = getDiskManifestDir(false /* create */);
+        const diskManifestDir = getDiskManifestDir(true /* create */);
         const diskManifestFile = fspath.join(diskManifestDir, fspath.basename(manifestPath));
         await fs.copyFileSync(manifestPath, diskManifestFile);
         const enableDiskManifests = await devSettings.enableDiskManifests(diskManifestDir);

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -8,7 +8,7 @@ import fspath from "path";
 import * as devCerts from "office-addin-dev-certs";
 import * as devSettings from "office-addin-dev-settings";
 import os from "os";
-import { DebuggingMethod, sideloadAddIn } from "office-addin-dev-settings";
+import { DebuggingMethod, sideloadAddIn, launchDesktopApp } from "office-addin-dev-settings";
 import { OfficeApp, OfficeAddinManifest } from "office-addin-manifest";
 import * as nodeDebugger from "office-addin-node-debugger";
 import * as debugInfo from "./debugInfo";
@@ -427,6 +427,8 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
       } catch (err) {
         throw new Error(`Unable to sideload the Office Add-in. \n${err}`);
       }
+    } else if (app && isDesktopAppType && isWindowsPlatform) {
+      await launchDesktopApp(app, manifestInfo, undefined /* document */);
     }
 
     console.log(enableDebugging ? "Debugging started." : "Started.");

--- a/packages/office-addin-debugging/src/start.ts
+++ b/packages/office-addin-debugging/src/start.ts
@@ -16,6 +16,7 @@ import { getProcessIdsForPort } from "./port";
 import { startDetachedProcess } from "./process";
 import { usageDataObject } from "./defaults";
 import { ExpectedError } from "office-addin-usage-data";
+import { getDiskManifestDir } from "./shared";
 
 /* global console process setTimeout */
 
@@ -246,6 +247,19 @@ export interface StartDebuggingOptions {
    * If provided, the document to open for sideloading to web.
    */
   document?: string;
+
+  /**
+   * This only works for classic Outlook on Windows.
+   * If provided, load manifest locally.
+   * Note: If enableSideLoad is true, the host will run the sideloaded manifest instead of the local one.
+   */
+  local?: boolean;
+
+  /**
+   * This only works for classic Outlook on Windows.
+   * If provided, this overrides the source bundle to a file on disk.
+   */
+  sourceBundleOverrideFile?: string;
 }
 
 /**
@@ -268,6 +282,8 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
     enableSideload,
     openDevTools,
     document,
+    local,
+    sourceBundleOverrideFile,
   } = {
     // Supplied Options
     ...options,
@@ -348,6 +364,23 @@ export async function startDebugging(manifestPath: string, options: StartDebuggi
     if (isDesktopAppType && isWindowsPlatform) {
       if (sourceBundleUrlComponents) {
         await devSettings.setSourceBundleUrl(manifestInfo.id, sourceBundleUrlComponents);
+      }
+    }
+
+    // setup to run manifest and source bundle locally
+    if (isDesktopAppType && isWindowsPlatform) {
+      if (local) {
+        const diskManifestDir = getDiskManifestDir(false /* create */);
+        const diskManifestFile = fspath.join(diskManifestDir, fspath.basename(manifestPath));
+        await fs.copyFileSync(manifestPath, diskManifestFile);
+        const enableDiskManifests = await devSettings.enableDiskManifests(diskManifestDir);
+        console.log("Using local disk manifest : " + enableDiskManifests);
+      }
+
+      if (sourceBundleOverrideFile) {
+        const sourceBundleOverrideFilePath = fspath.resolve(sourceBundleOverrideFile)
+        await devSettings.enableSourceBundleOverrideFile(manifestInfo.id, sourceBundleOverrideFilePath);
+        console.log("Source bundle overriden to " + sourceBundleOverrideFilePath);
       }
     }
 

--- a/packages/office-addin-debugging/src/stop.ts
+++ b/packages/office-addin-debugging/src/stop.ts
@@ -7,6 +7,8 @@ import * as debugInfo from "./debugInfo";
 import { stopProcess } from "./process";
 import { usageDataObject } from "./defaults";
 import { ExpectedError } from "office-addin-usage-data";
+import { getDiskManifestDir } from "./shared";
+import fs from "fs";
 
 /* global console process */
 
@@ -26,6 +28,11 @@ export async function stopDebugging(manifestPath: string) {
       await clearDevSettings(manifestInfo.id);
     }
 
+    const diskManifestDir = getDiskManifestDir(false /* create */);
+    if (fs.existsSync(diskManifestDir)) {
+      fs.rmSync(diskManifestDir, { recursive: true, force: true });
+    }
+
     // unregister
     try {
       await unregisterAddIn(manifestPath);
@@ -41,9 +48,9 @@ export async function stopDebugging(manifestPath: string) {
     }
 
     console.log("Debugging has been stopped.");
-    usageDataObject.reportSuccess("stopDebugging()");
+    usageDataObject.reportSuccess("stopDebugging");
   } catch (err: any) {
-    usageDataObject.reportException("stopDebugging()", err);
+    usageDataObject.reportException("stopDebugging", err);
     throw err;
   }
 }

--- a/packages/office-addin-dev-settings/src/commands.ts
+++ b/packages/office-addin-dev-settings/src/commands.ts
@@ -345,13 +345,14 @@ export async function sideload(
   try {
     const app: OfficeApp | undefined = options.app ? parseOfficeApp(options.app) : undefined;
     const canPrompt = true;
+    const launchOnly = false;
     const document: string | undefined = options.document ? options.document : undefined;
     const appType: AppType | undefined = parseAppType(
       type || process.env.npm_package_config_app_platform_to_debug
     );
     const registration: string = options.registration;
 
-    await sideloadAddIn(manifestPath, app, canPrompt, appType, document, registration);
+    await sideloadAddIn(manifestPath, app, canPrompt, launchOnly, appType, document, registration);
     usageDataObject.reportSuccess("sideload");
   } catch (err: any) {
     usageDataObject.reportException("sideload", err);

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -388,7 +388,7 @@ export async function sideloadAddIn(
   }
 }
 
-async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document?: string) {
+export async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document?: string) {
   if (!isSideloadingSupportedForDesktopHost(app)) {
     throw new ExpectedError(`Sideload to the ${getOfficeAppName(app)} app is not supported.`);
   }

--- a/packages/office-addin-dev-settings/src/sideload.ts
+++ b/packages/office-addin-dev-settings/src/sideload.ts
@@ -329,9 +329,10 @@ export async function sideloadAddIn(
   manifestPath: string,
   app?: OfficeApp,
   canPrompt: boolean = false,
+  launchOnly: boolean = false,
   appType?: AppType,
   document?: string,
-  registration?: string
+  registration?: string,
 ): Promise<void> {
   try {
     if (appType === undefined) {
@@ -368,7 +369,9 @@ export async function sideloadAddIn(
 
     switch (appType) {
       case AppType.Desktop:
-        await registerAddIn(manifestPath, registration);
+        if (!launchOnly) {
+          await registerAddIn(manifestPath, registration);
+        }
         await launchDesktopApp(app, manifest, document);
         break;
       case AppType.Web: {
@@ -388,7 +391,7 @@ export async function sideloadAddIn(
   }
 }
 
-export async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document?: string) {
+async function launchDesktopApp(app: OfficeApp, manifest: ManifestInfo, document?: string) {
   if (!isSideloadingSupportedForDesktopHost(app)) {
     throw new ExpectedError(`Sideload to the ${getOfficeAppName(app)} app is not supported.`);
   }

--- a/packages/office-addin-dev-settings/test/unit-tests/test.ts
+++ b/packages/office-addin-dev-settings/test/unit-tests/test.ts
@@ -553,6 +553,7 @@ describe("Sideload to Desktop", function () {
         manifestPath,
         OfficeApp.Project,
         true /* canPrompt */,
+        false /* launchOnly */,
         AppType.Desktop,
         undefined /* document */
       );
@@ -599,7 +600,7 @@ describe("Sideload to web", function () {
     let error;
     let manifestPath = fspath.resolve(manifestsFolder, "manifest.invalidsourcelocationforweb.xml");
     try {
-      await devSettingsSideload.sideloadAddIn(manifestPath, OfficeApp.Excel, true /* canPrompt */, AppType.Web, docurl);
+      await devSettingsSideload.sideloadAddIn(manifestPath, OfficeApp.Excel, true /* canPrompt */, false /* launchOnly */, AppType.Web, docurl);
     } catch (err: any) {
       error = err;
     }
@@ -613,7 +614,7 @@ describe("Sideload to web", function () {
     let error;
     let manifestPath = fspath.resolve(manifestsFolder, "manifest.xml");
     try {
-      await devSettingsSideload.sideloadAddIn(manifestPath, OfficeApp.Excel, true /* canPrompt */, AppType.Web);
+      await devSettingsSideload.sideloadAddIn(manifestPath, OfficeApp.Excel, true /* canPrompt */, false /* launchOnly */, AppType.Web);
     } catch (err: any) {
       error = err;
     }
@@ -628,6 +629,7 @@ describe("Sideload to web", function () {
         manifestPath,
         OfficeApp.Outlook,
         true /* canPrompt */,
+        false /* launchOnly */,
         AppType.Web,
         docurl
       );


### PR DESCRIPTION
1. **Do these changes impact *command syntax* of any of the packages?** 
    Yes. This change adds support for configuring disk manifests and overriding the source bundle JS file.


2. **Do these changes impact *documentation*?**
    Yes. This change adds support for configuring disk manifests and overriding the source bundle JS file.

No update is needed for the README.md file because the changes are meant for internal usage by our add-ins toolset.

All tests passed via `npm run test`
