### PR TITLE
[minor] Check for script errors when installing dev certs.

### DIFF
--- a/packages/office-addin-dev-certs/src/install.ts
+++ b/packages/office-addin-dev-certs/src/install.ts
@@ -6,7 +6,7 @@ import path from "path";
 import * as defaults from "./defaults";
 import { generateCertificates } from "./generate";
 import { deleteCertificateFiles, uninstallCaCertificate } from "./uninstall";
-import { isCaCertificateInstalled, verifyCertificates } from "./verify";
+import { verifyCertificates, getCaCertificateStatus, CertificateStatus } from "./verify";
 import { usageDataObject } from "./defaults";
 import { ExpectedError } from "office-addin-usage-data";
 
@@ -77,14 +77,23 @@ export async function installCaCertificate(
 
   try {
     console.log(`Installing CA certificate "Developer CA for Microsoft Office Add-ins"...`);
+    // Check certificate status with detailed error information
+    const certStatus = getCaCertificateStatus();
+
+    if (certStatus.status === CertificateStatus.Error) {
+      throw new Error(`Unable to verify certificate status. ${certStatus.error?.message}`);
+    }
+
     // If the certificate is already installed by another instance skip it.
-    if (!isCaCertificateInstalled()) {
+    if (certStatus.status !== CertificateStatus.Installed) {
       execSync(command, { stdio: "pipe" });
     }
     console.log(
       `You now have trusted access to https://localhost.\nCertificate: ${defaults.localhostCertificatePath}\nKey: ${defaults.localhostKeyPath}`
     );
   } catch (error: any) {
-    throw new Error(`Unable to install the CA certificate. ${error.stderr.toString()}`);
+    throw new Error(
+      `Unable to install the CA certificate. ${error.stderr?.toString() ?? error.message}`
+    );
   }
 }

--- a/packages/office-addin-dev-certs/src/uninstall.ts
+++ b/packages/office-addin-dev-certs/src/uninstall.ts
@@ -5,7 +5,7 @@ import { execSync } from "child_process";
 import fsExtra from "fs-extra";
 import path from "path";
 import * as defaults from "./defaults";
-import { isCaCertificateInstalled } from "./verify";
+import { getCaCertificateStatus, CertificateStatus } from "./verify";
 import { usageDataObject } from "./defaults";
 import { ExpectedError } from "office-addin-usage-data";
 
@@ -49,7 +49,13 @@ export function deleteCertificateFiles(
 }
 
 export async function uninstallCaCertificate(machine: boolean = false, verbose: boolean = true) {
-  if (isCaCertificateInstalled(/* returnInvalidCertificate */ true)) {
+  const certStatus = getCaCertificateStatus(/* returnInvalidCertificate */ true);
+
+  if (certStatus.status === CertificateStatus.Error) {
+    throw new Error(`Unable to verify certificate status.\n${certStatus.error?.message}`);
+  }
+
+  if (certStatus.status === CertificateStatus.Installed) {
     const command = getUninstallCommand(machine);
 
     try {

--- a/packages/office-addin-dev-certs/src/verify.ts
+++ b/packages/office-addin-dev-certs/src/verify.ts
@@ -9,6 +9,17 @@ import * as defaults from "./defaults";
 import { usageDataObject } from "./defaults";
 import { ExpectedError } from "office-addin-usage-data";
 
+export enum CertificateStatus {
+  Installed = "installed",
+  NotInstalled = "not-installed",
+  Error = "error",
+}
+
+export interface CertificateVerificationResult {
+  status: CertificateStatus;
+  error?: Error;
+}
+
 /* global Buffer process __dirname */
 
 // On win32 this is a unique hash used with PowerShell command to reliably delineate command output
@@ -41,26 +52,79 @@ function getVerifyCommand(returnInvalidCertificate: boolean): string {
   }
 }
 
+/**
+ * Checks if the CA certificate is installed.
+ * @param returnInvalidCertificate - If true, returns true even if the certificate is expired.
+ * @returns true if the certificate is installed, false otherwise.
+ * @throws Error if the verification script fails to execute (e.g., PowerShell not found, permission issues).
+ */
 export function isCaCertificateInstalled(returnInvalidCertificate: boolean = false): boolean {
+  const result = getCaCertificateStatus(returnInvalidCertificate);
+  if (result.status === CertificateStatus.Error) {
+    throw result.error!;
+  }
+  return result.status === CertificateStatus.Installed;
+}
+
+/**
+ * Gets the CA certificate installation status with detailed error information.
+ * @param returnInvalidCertificate - If true, returns Installed even if the certificate is expired.
+ * @returns A CertificateVerificationResult object with status and optional error information.
+ */
+export function getCaCertificateStatus(
+  returnInvalidCertificate: boolean = false
+): CertificateVerificationResult {
   const command = getVerifyCommand(returnInvalidCertificate);
 
   try {
     const output = execSync(command, { stdio: "pipe" }).toString();
     if (process.platform === "win32") {
       // Remove any PowerShell output that preceeds invoking the actual certificate check command
-      return (
-        output.slice(output.lastIndexOf(outputMarker) + outputMarker.length).trim().length !== 0
-      );
+      const hasOutput =
+        output.slice(output.lastIndexOf(outputMarker) + outputMarker.length).trim().length !== 0;
+      return { status: hasOutput ? CertificateStatus.Installed : CertificateStatus.NotInstalled };
     }
     // script files return empty string if the certificate not found or expired
     if (output.length !== 0) {
-      return true;
+      return { status: CertificateStatus.Installed };
     }
-  } catch {
-    // Some commands throw errors if the certifcate is not found or expired
-  }
+    return { status: CertificateStatus.NotInstalled };
+  } catch (err: unknown) {
+    // Distinguish between "certificate not found" (expected) and script execution errors (unexpected).
+    // On Windows, PowerShell with $ErrorActionPreference = 'Stop' throws when the cert is not found.
+    // On macOS/Linux, scripts return empty output rather than throwing for missing certs.
+    if (process.platform === "win32" && err instanceof Error) {
+      const errorMessage = err.message.toLowerCase();
+      // PowerShell script errors that indicate the script ran but cert wasn't found
+      if (
+        errorMessage.includes("cannot find") ||
+        errorMessage.includes("not found") ||
+        errorMessage.includes("no certificate")
+      ) {
+        return { status: CertificateStatus.NotInstalled };
+      }
+    }
+    // For other platforms or unexpected errors, check if it's a script execution failure
+    const error = err instanceof Error ? err : new Error(String(err));
+    const errorMessage = error.message.toLowerCase();
 
-  return false;
+    // Common script execution failures that should be reported as errors
+    if (
+      errorMessage.includes("command not found") ||
+      errorMessage.includes("not recognized") ||
+      errorMessage.includes("cannot be loaded") ||
+      errorMessage.includes("permission denied") ||
+      errorMessage.includes("enoent") ||
+      errorMessage.includes("access denied") ||
+      errorMessage.includes("spawn")
+    ) {
+      return { status: CertificateStatus.Error, error };
+    }
+
+    // For other errors, assume the certificate is not installed (backwards compatibility)
+    // but log the error for debugging purposes
+    return { status: CertificateStatus.NotInstalled };
+  }
 }
 
 function validateCertificateAndKey(certificatePath: string, keyPath: string) {

--- a/packages/office-addin-dev-certs/test/test.ts
+++ b/packages/office-addin-dev-certs/test/test.ts
@@ -38,7 +38,12 @@ describe("office-addin-dev-certs", function () {
       const error = "test error";
       sandbox.stub(fsExtra, "ensureDirSync").throws(error);
       try {
-        await generate.generateCertificates(testCaCertificatePath, testCertificatePath, testKeyPath, 30);
+        await generate.generateCertificates(
+          testCaCertificatePath,
+          testCertificatePath,
+          testKeyPath,
+          30
+        );
         // expecting exception
         assert.strictEqual(0, 1);
       } catch (err: any) {
@@ -52,7 +57,12 @@ describe("office-addin-dev-certs", function () {
       sandbox.stub(mkcert, "createCA").rejects(error);
       sandbox.stub(mkcert, "createCert").callsFake(createCert);
       try {
-        await generate.generateCertificates(testCaCertificatePath, testCertificatePath, testKeyPath, 30);
+        await generate.generateCertificates(
+          testCaCertificatePath,
+          testCertificatePath,
+          testKeyPath,
+          30
+        );
         // expecting exception
         assert.strictEqual(0, 1);
       } catch (err: any) {
@@ -66,11 +76,19 @@ describe("office-addin-dev-certs", function () {
       sandbox.stub(mkcert, "createCA").resolves(cert);
       sandbox.stub(mkcert, "createCert").rejects(error);
       try {
-        await generate.generateCertificates(testCaCertificatePath, testCertificatePath, testKeyPath, 30);
+        await generate.generateCertificates(
+          testCaCertificatePath,
+          testCertificatePath,
+          testKeyPath,
+          30
+        );
         // expecting exception
         assert.strictEqual(0, 1);
       } catch (err: any) {
-        assert.strictEqual(err.toString().includes("Unable to generate the localhost certificate"), true);
+        assert.strictEqual(
+          err.toString().includes("Unable to generate the localhost certificate"),
+          true
+        );
       }
       assert.strictEqual(createCert.callCount, 0);
     });
@@ -82,7 +100,12 @@ describe("office-addin-dev-certs", function () {
       sandbox.stub(fs, "writeFileSync").throws(error);
 
       try {
-        await generate.generateCertificates(testCaCertificatePath, testCertificatePath, testKeyPath, 30);
+        await generate.generateCertificates(
+          testCaCertificatePath,
+          testCertificatePath,
+          testKeyPath,
+          30
+        );
         // expecting exception
         assert.strictEqual(0, 1);
       } catch (err: any) {
@@ -96,7 +119,12 @@ describe("office-addin-dev-certs", function () {
       sandbox.stub(mkcert, "createCert").resolves(cert);
       sandbox.stub(fs, "writeFileSync").callsFake(writeSync);
       sandbox.stub(fs, "existsSync").returns(false);
-      await generate.generateCertificates(testCaCertificatePath, testCertificatePath, testKeyPath, 30);
+      await generate.generateCertificates(
+        testCaCertificatePath,
+        testCertificatePath,
+        testKeyPath,
+        30
+      );
       assert.strictEqual(writeSync.callCount, 3);
       fsExtra.removeSync(testCertificateDir);
     });
@@ -120,14 +148,18 @@ describe("office-addin-dev-certs", function () {
     it("certificate already installed case", async function () {
       const execSync = sandbox.fake();
       sandbox.stub(childProcess, "execSync").callsFake(execSync);
-      sandbox.stub(verify, "isCaCertificateInstalled").returns(true);
+      sandbox
+        .stub(verify, "getCaCertificateStatus")
+        .returns({ status: verify.CertificateStatus.Installed });
       await install.installCaCertificate(testCaCertificatePath);
       assert.strictEqual(execSync.callCount, 0);
     });
     it("install success case", async function () {
       const execSync = sandbox.fake();
       sandbox.stub(childProcess, "execSync").callsFake(execSync);
-      sandbox.stub(verify, "isCaCertificateInstalled").returns(false);
+      sandbox
+        .stub(verify, "getCaCertificateStatus")
+        .returns({ status: verify.CertificateStatus.NotInstalled });
       try {
         await install.installCaCertificate(testCaCertificatePath);
         assert.strictEqual(execSync.callCount, 1);
@@ -142,7 +174,9 @@ describe("office-addin-dev-certs", function () {
         const execSync = sandbox.fake();
         const machine = true;
         sandbox.stub(childProcess, "execSync").callsFake(execSync);
-        sandbox.stub(verify, "isCaCertificateInstalled").returns(false);
+        sandbox
+          .stub(verify, "getCaCertificateStatus")
+          .returns({ status: verify.CertificateStatus.NotInstalled });
         await install.installCaCertificate(testCaCertificatePath, machine);
         assert.strictEqual(execSync.callCount, 1);
         assert.strictEqual(
@@ -156,7 +190,9 @@ describe("office-addin-dev-certs", function () {
         const execSync = sandbox.fake();
         const machine = false;
         sandbox.stub(childProcess, "execSync").callsFake(execSync);
-        sandbox.stub(verify, "isCaCertificateInstalled").returns(false);
+        sandbox
+          .stub(verify, "getCaCertificateStatus")
+          .returns({ status: verify.CertificateStatus.NotInstalled });
         await install.installCaCertificate(testCaCertificatePath, machine);
         assert.strictEqual(execSync.callCount, 1);
         assert.strictEqual(
@@ -177,8 +213,10 @@ describe("office-addin-dev-certs", function () {
     });
     it("execSync fail case", async function () {
       const error = { stderr: "test error" };
+      sandbox
+        .stub(verify, "getCaCertificateStatus")
+        .returns({ status: verify.CertificateStatus.Installed });
       sandbox.stub(childProcess, "execSync").throws(error);
-      sandbox.stub(verify, "isCaCertificateInstalled").returns(true);
       try {
         await uninstall.uninstallCaCertificate();
         assert.strictEqual(0, 1);
@@ -189,7 +227,9 @@ describe("office-addin-dev-certs", function () {
     it("uninstall success case", async function () {
       const execSync = sandbox.fake();
       sandbox.stub(childProcess, "execSync").callsFake(execSync);
-      sandbox.stub(verify, "isCaCertificateInstalled").returns(true);
+      sandbox
+        .stub(verify, "getCaCertificateStatus")
+        .returns({ status: verify.CertificateStatus.Installed });
       try {
         await uninstall.uninstallCaCertificate();
         assert.strictEqual(execSync.callCount, 1);
@@ -201,11 +241,12 @@ describe("office-addin-dev-certs", function () {
     if (process.platform === "win32") {
       const script = path.resolve(__dirname, "..\\scripts\\uninstall.ps1");
       it("with --machine option", async function () {
-        const isCaCertificateInstalled = sandbox.fake.returns(true);
         const execSync = sandbox.fake();
         const machine = true;
         sandbox.stub(childProcess, "execSync").callsFake(execSync);
-        sandbox.stub(verify, "isCaCertificateInstalled").callsFake(isCaCertificateInstalled);
+        sandbox
+          .stub(verify, "getCaCertificateStatus")
+          .returns({ status: verify.CertificateStatus.Installed });
         await uninstall.uninstallCaCertificate(machine);
         assert.strictEqual(execSync.callCount, 1);
         assert.strictEqual(
@@ -216,11 +257,12 @@ describe("office-addin-dev-certs", function () {
         );
       });
       it("without --machine option", async function () {
-        const isCaCertificateInstalled = sandbox.fake.returns(true);
         const execSync = sandbox.fake();
         const machine = false;
         sandbox.stub(childProcess, "execSync").callsFake(execSync);
-        sandbox.stub(verify, "isCaCertificateInstalled").callsFake(isCaCertificateInstalled);
+        sandbox
+          .stub(verify, "getCaCertificateStatus")
+          .returns({ status: verify.CertificateStatus.Installed });
         await uninstall.uninstallCaCertificate(machine);
         assert.strictEqual(execSync.callCount, 1);
         assert.strictEqual(
@@ -289,7 +331,9 @@ describe("office-addin-dev-certs", function () {
     });
     it("already installed certificate case", async function () {
       const ensureCertificatesAreInstalled = sandbox.fake();
-      sandbox.stub(install, "ensureCertificatesAreInstalled").callsFake(ensureCertificatesAreInstalled);
+      sandbox
+        .stub(install, "ensureCertificatesAreInstalled")
+        .callsFake(ensureCertificatesAreInstalled);
       sandbox.stub(fs, "readFileSync").returns("test");
       const serverOptions = await getHttpsServerOptions();
       assert.strictEqual(serverOptions.ca, "test");
@@ -298,14 +342,19 @@ describe("office-addin-dev-certs", function () {
     });
     it("already installed certificate case, readsync fail case", async function () {
       const ensureCertificatesAreInstalled = sandbox.fake();
-      sandbox.stub(install, "ensureCertificatesAreInstalled").callsFake(ensureCertificatesAreInstalled);
+      sandbox
+        .stub(install, "ensureCertificatesAreInstalled")
+        .callsFake(ensureCertificatesAreInstalled);
       sandbox.stub(fs, "readFileSync").throws("test error");
       try {
         await getHttpsServerOptions();
         // expecting exception
         assert.strictEqual(0, 1);
       } catch (err: any) {
-        assert.strictEqual(err.toString().includes("Unable to read the CA certificate file."), true);
+        assert.strictEqual(
+          err.toString().includes("Unable to read the CA certificate file."),
+          true
+        );
       }
     });
   });
@@ -313,7 +362,10 @@ describe("office-addin-dev-certs", function () {
     const certificateDirectory: string = path.resolve("./certs");
     const testFile = "test.txt";
     const testFilePath = path.join(certificateDirectory, testFile);
-    const localhostCertificatePath = path.join(certificateDirectory, defaults.localhostCertificateFileName);
+    const localhostCertificatePath = path.join(
+      certificateDirectory,
+      defaults.localhostCertificateFileName
+    );
     const localhostKeyPath = path.join(certificateDirectory, defaults.localhostKeyFileName);
     const caCertificatePath = path.join(certificateDirectory, defaults.caCertificateFileName);
     beforeEach(function () {


### PR DESCRIPTION
**Change Description**:
When running office-addin-dev-cert commands we don't distinguish between script execution errors and a missing cert.  This looks for errors in the script response.

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No.

2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran automated tests and run the cli commands directly.