### PR TITLE
[major] Add a cache clearing tool

### DIFF
--- a/.azure-devops/steps/build-individually.yaml
+++ b/.azure-devops/steps/build-individually.yaml
@@ -8,7 +8,7 @@ steps:
     
     Write-Host "==== Level 0: No internal dependencies ===="
     Write-Host "Building office-addin-prettier-config..."
-    Set-Location "$root/packages/eslint-plugin-office-addins"
+    Set-Location "$root/packages/office-addin-prettier-config"
     npm run build
     
     Write-Host "==== Level 1: Depends only on Level 0 ===="
@@ -42,6 +42,10 @@ steps:
     Set-Location "$root/packages/office-addin-manifest"
     npm run build
     
+    Write-Host "Building office-addin-cache..."
+    Set-Location "$root/packages/office-addin-cache"
+    npm run build
+
     Write-Host "Building custom-functions-metadata..."
     Set-Location "$root/packages/custom-functions-metadata"
     npm run build

--- a/.azure-devops/steps/test-individually.yaml
+++ b/.azure-devops/steps/test-individually.yaml
@@ -42,6 +42,10 @@ steps:
     Set-Location "$root/packages/office-addin-manifest"
     npm run test
     
+    Write-Host "Building office-addin-cache..."
+    Set-Location "$root/packages/office-addin-cache"
+    npm run test
+
     Write-Host "Testing custom-functions-metadata..."
     Set-Location "$root/packages/custom-functions-metadata"
     npm run test

--- a/.azure-devops/steps/test-individually.yaml
+++ b/.azure-devops/steps/test-individually.yaml
@@ -42,7 +42,7 @@ steps:
     Set-Location "$root/packages/office-addin-manifest"
     npm run test
     
-    Write-Host "Building office-addin-cache..."
+    Write-Host "Testing office-addin-cache..."
     Set-Location "$root/packages/office-addin-cache"
     npm run test
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The [Excel Custom Functions](https://github.com/OfficeDev/Excel-Custom-Functions
 
   A WebPack plugin which generates the metadata for custom functions.
 
+* [office-addin-cache](packages/office-addin-cache/README.md)
+
+  This package can be used to clear the Office add-ins cache.
+
 * [office-addin-cli](packages/office-addin-cli/README.md)
 
   A command-line interface for Office Add-ins.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17305,6 +17305,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/office-addin-cache": {
+      "resolved": "packages/office-addin-cache",
+      "link": true
+    },
     "node_modules/office-addin-cli": {
       "resolved": "packages/office-addin-cli",
       "link": true
@@ -22792,6 +22796,41 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "packages/office-addin-cache": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^13.0.0",
+        "office-addin-usage-data": "^2.0.8"
+      },
+      "bin": {
+        "office-addin-cache": "cli.js"
+      },
+      "devDependencies": {
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^22.10.10",
+        "concurrently": "^9.0.0",
+        "mocha": "^11.0.1",
+        "office-addin-lint": "^3.0.8",
+        "rimraf": "^6.0.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.3"
+      }
+    },
+    "packages/office-addin-cache/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/office-addin-cli": {

--- a/packages/office-addin-cache/.gitattributes
+++ b/packages/office-addin-cache/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+cli.js text eol=lf

--- a/packages/office-addin-cache/.npmignore
+++ b/packages/office-addin-cache/.npmignore
@@ -1,0 +1,7 @@
+.vscode
+node_modules
+package-lock.json
+src
+test
+testExecution
+tsconfig.json

--- a/packages/office-addin-cache/.vscode/launch.json
+++ b/packages/office-addin-cache/.vscode/launch.json
@@ -1,0 +1,56 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Command Line: clear",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/lib/cli.js",
+      "args": [
+        "clear"
+      ]
+    },
+    {
+      "name": "Command Line: clear --verbose",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/lib/cli.js",
+      "args": [
+        "clear",
+        "--verbose"
+      ]
+    },
+    {
+      "name": "Command Line: clear --force-close --verbose",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/lib/cli.js",
+      "args": [
+        "clear",
+        "--force-close",
+        "--verbose"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-u",
+        "tdd",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/test",
+        "-r",
+        "ts-node/register",
+        "${workspaceFolder}/test/**/*.ts"
+      ],
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/packages/office-addin-cache/.vscode/tasks.json
+++ b/packages/office-addin-cache/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "npm",
+      "script": "build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Watch",
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Tests",
+      "type": "npm",
+      "script": "test",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/packages/office-addin-cache/README.md
+++ b/packages/office-addin-cache/README.md
@@ -1,0 +1,36 @@
+# office-addin-cache
+
+This package clears the Office Add-in cache folders on the user's computer. It supports Windows and macOS. It doesn't clear the browser cache.
+
+## Usage
+
+```
+office-addin-cache clear [options]
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--force-close` | Close all running Microsoft Office applications without prompting. |
+| `--verbose` | Report the path of each folder being emptied. |
+
+## Cache folders cleared
+
+### Windows
+
+| Label | Path |
+|---|---|
+| WEF | `%LOCALAPPDATA%\Microsoft\Office\16.0\Wef` |
+| WebView Cache | `%USERPROFILE%\AppData\Local\Packages\Microsoft.Win32WebViewHost_cw5n1h2txyewy` |
+| Outlook Hub App Cache | `%USERPROFILE%\AppData\Local\Microsoft\Outlook\HubAppFileCache` |
+
+### macOS
+
+| Label | Path |
+|---|---|
+| OsfWebHost | `~/Library/Containers/com.Microsoft.OsfWebHost/Data` |
+
+## Office application behavior
+
+If Office applications are running when the command is invoked, the tool will list them and offer to force-close them. If `--force-close` is specified, they will be closed automatically without a prompt. If the applications cannot be closed, the tool will exit without clearing the cache.

--- a/packages/office-addin-cache/cli.js
+++ b/packages/office-addin-cache/cli.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+//
+// If the package.json bin config specifies a file in the lib folder, it will cause an
+// error during "npm install" if the lib folder doesn't exist (because the package hasn't been built yet).
+// It specifies this file instead which then calls into the file in the lib folder.
+require("./lib/cli.js");

--- a/packages/office-addin-cache/eslint.config.mjs
+++ b/packages/office-addin-cache/eslint.config.mjs
@@ -1,0 +1,14 @@
+import officeAddins from "eslint-plugin-office-addins";
+import tsParser from "@typescript-eslint/parser";
+
+export default [
+  ...officeAddins.configs.recommended,
+  {
+    plugins: {
+      "office-addins": officeAddins,
+    },
+    languageOptions: {
+      parser: tsParser
+    },
+  },
+];

--- a/packages/office-addin-cache/package.json
+++ b/packages/office-addin-cache/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "office-addin-cache",
+  "version": "1.0.0",
+  "description": "Clear the Office Add-in cache folders.",
+  "main": "./lib/main.js",
+  "scripts": {
+    "build": "rimraf lib && concurrently \"tsc -p tsconfig.json\"",
+    "cli": "node lib/cli.js",
+    "lint": "office-addin-lint check",
+    "lint:fix": "office-addin-lint fix",
+    "prettier": "office-addin-lint prettier",
+    "test": "mocha -r ts-node/register test/**/*.ts",
+    "watch": "rimraf lib && concurrently \"tsc -p tsconfig.json -w\"",
+    "clear": "office-addin-cache clear",
+    "clear:verbose": "office-addin-cache clear --verbose",
+    "clear:force": "office-addin-cache clear --force-close",
+    "clear:force:verbose": "office-addin-cache clear --force-close --verbose"
+  },
+  "author": "Office Dev",
+  "license": "MIT",
+  "bin": {
+    "office-addin-cache": "./cli.js"
+  },
+  "keywords": [
+    "Office",
+    "Office Add-in"
+  ],
+  "dependencies": {
+    "commander": "^13.0.0",
+    "office-addin-usage-data": "^2.0.8"
+  },
+  "devDependencies": {
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^22.10.10",
+    "concurrently": "^9.0.0",
+    "mocha": "^11.0.1",
+    "office-addin-lint": "^3.0.8",
+    "rimraf": "^6.0.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OfficeDev/Office-Addin-Scripts"
+  },
+  "bugs": {
+    "url": "https://github.com/OfficeDev/Office-Addin-Scripts/issues"
+  },
+  "prettier": "office-addin-prettier-config"
+}

--- a/packages/office-addin-cache/src/cache.ts
+++ b/packages/office-addin-cache/src/cache.ts
@@ -1,0 +1,376 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import readline from "readline";
+
+/* global process console setTimeout setInterval clearInterval */
+
+const execFileAsync = promisify(execFile);
+
+/* -------------------- Types -------------------- */
+
+type Platform = string;
+
+type RunningProcess = { kind: "process"; name: string } | { kind: "app"; name: string };
+
+type CacheTarget = {
+  label: string;
+  dir: string;
+};
+
+export type Options = {
+  verbose: boolean;
+  forceClose: boolean;
+};
+
+type InlineSpinner = {
+  enabled: boolean;
+  start: () => void;
+  stop: () => void;
+};
+
+/* -------------------- Utils -------------------- */
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/* -------------------- Spinner -------------------- */
+
+function createInlineSpinner(): InlineSpinner {
+  const enabled: boolean = process.stdout.isTTY ?? false;
+  const frames: string[] = ["|", "/", "-", "|", "\\", "-"];
+  const intervalMs = 80;
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let idx = 0;
+  let active = false;
+  let showing = false;
+
+  function hideCursor(): void {
+    process.stdout.write("\x1B[?25l");
+  }
+
+  function showCursor(): void {
+    process.stdout.write("\x1B[?25h");
+  }
+
+  function tick(): void {
+    if (!active) return;
+    const ch = frames[idx];
+    idx = (idx + 1) % frames.length;
+    if (showing) process.stdout.write("\b");
+    process.stdout.write(ch);
+    showing = true;
+  }
+
+  function start(): void {
+    if (!enabled || active) return;
+    active = true;
+    showing = false;
+    idx = 0;
+    hideCursor();
+    timer = setInterval(tick, intervalMs);
+  }
+
+  function stop(): void {
+    if (!enabled || !active) return;
+    if (timer) clearInterval(timer);
+    timer = null;
+    if (showing) process.stdout.write("\b \b");
+    showing = false;
+    active = false;
+    showCursor();
+  }
+
+  return { enabled, start, stop };
+}
+
+/* -------------------- Office Application Processes -------------------- */
+
+const WIN_PROCS: string[] = [
+  "WINWORD.EXE",
+  "EXCEL.EXE",
+  "POWERPNT.EXE",
+  // Outlook classic
+  "OUTLOOK.EXE",
+  "ONENOTE.EXE",
+  // New Outlook
+  "OLK.EXE",
+  "WINPROJ.EXE",
+];
+
+const MAC_APPS: string[] = [
+  "Microsoft Word",
+  "Microsoft Excel",
+  "Microsoft PowerPoint",
+  "Microsoft Outlook",
+  "Microsoft OneNote",
+  "Microsoft Project",
+];
+
+function allOfficeCandidatesForPlatform(): string[] {
+  return process.platform === "win32" ? WIN_PROCS : MAC_APPS;
+}
+
+async function detectOfficeRunning(candidates?: string[]): Promise<RunningProcess[]> {
+  const platform: Platform = process.platform;
+  const officeAppProcNames: string[] =
+    candidates && candidates.length ? candidates : allOfficeCandidatesForPlatform();
+
+  if (platform === "win32") {
+    const { stdout } = await execFileAsync("tasklist", ["/FO", "CSV", "/NH"]);
+    const lines = stdout.split("\n");
+    const wanted = new Set<string>(officeAppProcNames.map((n) => n.toUpperCase()));
+    const running: RunningProcess[] = [];
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const cols = line.split('","').map((s: string) => s.replace(/^"|"$/g, ""));
+      const imageName = cols[0]?.toUpperCase();
+      if (imageName && wanted.has(imageName)) {
+        running.push({ kind: "process", name: imageName });
+      }
+    }
+
+    return running;
+  }
+
+  if (platform === "darwin") {
+    const { stdout } = await execFileAsync("ps", ["-ax"]);
+    const lines = stdout.split("\n");
+    const running: RunningProcess[] = [];
+    const wanted = new Set<string>(officeAppProcNames);
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const parts = line.trim().split(/\s+/);
+      const command = parts.slice(4).join(" ");
+      const base = path.basename(command);
+      if (wanted.has(base)) {
+        running.push({ kind: "app", name: base });
+      }
+    }
+
+    return running;
+  }
+
+  return [];
+}
+
+async function forceCloseOfficeApps(
+  runningList: RunningProcess[],
+  verbose: boolean
+): Promise<void> {
+  const platform: Platform = process.platform;
+
+  if (platform === "win32") {
+    for (const proc of runningList) {
+      try {
+        if (verbose) console.log(`Force-closing: ${proc.name}`);
+        await execFileAsync("taskkill", ["/F", "/IM", proc.name, "/T"]);
+      } catch {
+        /* ignore */
+      }
+    }
+    return;
+  }
+
+  if (platform === "darwin") {
+    for (const proc of runningList) {
+      try {
+        if (verbose) console.log(`Force-killing: ${proc.name}`);
+        await execFileAsync("pkill", ["-9", "-f", proc.name]);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+function formatRunningList(running: RunningProcess[]): string[] {
+  const processDisplayNames = new Map<string, string>([
+    ["WINWORD.EXE", "Word"],
+    ["EXCEL.EXE", "Excel"],
+    ["POWERPNT.EXE", "PowerPoint"],
+    ["OUTLOOK.EXE", "Outlook"],
+    ["ONENOTE.EXE", "OneNote"],
+    ["OLK.EXE", "New Outlook"],
+    ["WINPROJ.EXE", "Project"],
+  ]);
+
+  return running.map((p) => processDisplayNames.get(p.name) ?? p.name);
+}
+
+async function scanWithSpinner(
+  message: string,
+  spinner: InlineSpinner,
+  candidates?: string[]
+): Promise<RunningProcess[]> {
+  process.stdout.write(`${message} `);
+  spinner.start();
+  try {
+    return await detectOfficeRunning(candidates);
+  } finally {
+    spinner.stop();
+    process.stdout.write("\n");
+  }
+}
+
+async function verifyClosed(previousNames: string[], spinner: InlineSpinner): Promise<boolean> {
+  process.stdout.write("Verifying that Office applications have been closed ... ");
+  spinner.start();
+
+  const start = Date.now();
+  const timeoutMs = 20000;
+
+  try {
+    while (true) {
+      const still = await detectOfficeRunning(previousNames);
+      if (still.length === 0) return true;
+      if (Date.now() - start > timeoutMs) return false;
+      await sleep(250);
+    }
+  } finally {
+    spinner.stop();
+    process.stdout.write("\n");
+  }
+}
+
+async function promptYesNo(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const answer: string = await new Promise((resolve) => rl.question(question, resolve));
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+/* -------------------- Cache -------------------- */
+
+export async function getCacheTargets(): Promise<CacheTarget[]> {
+  const platform: Platform = process.platform;
+  const targets: CacheTarget[] = [];
+
+  if (platform === "win32") {
+    const base: string = process.env.USERPROFILE ?? "";
+
+    targets.push({
+      label: "WEF",
+      dir: path.join(process.env.LOCALAPPDATA ?? "", "Microsoft", "Office", "16.0", "Wef"),
+    });
+
+    targets.push({
+      label: "WebView Cache",
+      dir: path.join(
+        base,
+        "AppData",
+        "Local",
+        "Packages",
+        "Microsoft.Win32WebViewHost_cw5n1h2txyewy"
+      ),
+    });
+
+    targets.push({
+      label: "Outlook Hub App Cache",
+      dir: path.join(base, "AppData", "Local", "Microsoft", "Outlook", "HubAppFileCache"),
+    });
+
+    return targets;
+  }
+
+  if (platform === "darwin") {
+    const home = os.homedir();
+    return [
+      {
+        label: "OsfWebHost",
+        dir: path.join(home, "Library/Containers/com.Microsoft.OsfWebHost/Data"),
+      },
+    ];
+  }
+
+  return targets;
+}
+
+async function clearTargets(targets: CacheTarget[], verbose: boolean): Promise<void> {
+  for (const target of targets) {
+    if (verbose) console.log(`Clearing: ${target.label} (${target.dir})`);
+    try {
+      await fs.rm(target.dir, { recursive: true, force: true });
+      console.log(`Cleared: ${target.label}`);
+    } catch {
+      console.log(`Skipped: ${target.label}`);
+      console.log(`Please clear this folder manually: ${target.dir}`);
+    }
+  }
+}
+
+/* -------------------- Primary Export -------------------- */
+
+export async function clearCache(options: Options): Promise<void> {
+  const spinner: InlineSpinner = createInlineSpinner();
+
+  const running: RunningProcess[] = await scanWithSpinner(
+    "Looking for running Office applications ...",
+    spinner,
+    allOfficeCandidatesForPlatform()
+  );
+
+  if (running.length > 0) {
+    const friendlyAppNames: string[] = formatRunningList(running);
+
+    console.log("Office applications are currently running:");
+    friendlyAppNames.forEach((name) => console.log(`  - ${name}`));
+
+    if (options.forceClose) {
+      console.log("\nForce-close option specified. Closing Office applications automatically...");
+    } else {
+      console.log(
+        "\nIf you choose to force-close them, the tool will continue and clear the cache automatically."
+      );
+      console.log(
+        "If you choose not to, close all Office applications manually before rerunning this tool."
+      );
+    }
+
+    const doForce = options.forceClose || (await promptYesNo("\nForce-close? (y/N): "));
+
+    if (!doForce) {
+      console.log("\nNo changes made.");
+      console.log("Please close all Office apps and rerun the command.");
+      process.exitCode = 1;
+      return;
+    }
+
+    await forceCloseOfficeApps(running, options.verbose);
+
+    const closed = await verifyClosed(
+      running.map((process) => process.name),
+      spinner
+    );
+
+    if (!closed) {
+      console.log("\nUnable to close all Office applications.");
+      console.log("\nPlease close them manually and then rerun this tool.");
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log("All previously detected Office apps are no longer running.");
+    console.log("Proceeding to clear the Office Add-ins cache...");
+  }
+
+  const targets: CacheTarget[] = await getCacheTargets();
+  await clearTargets(targets, options.verbose);
+
+  console.log("\nDone.");
+}

--- a/packages/office-addin-cache/src/cache.ts
+++ b/packages/office-addin-cache/src/cache.ts
@@ -175,7 +175,7 @@ async function forceCloseOfficeApps(
         if (verbose) console.log(`Force-closing: ${proc.name}`);
         await execFileAsync("taskkill", ["/F", "/IM", proc.name, "/T"]);
       } catch {
-        /* ignore */
+        if (verbose) console.log(`Failed to force-close: ${proc.name}`);
       }
     }
     return;
@@ -187,7 +187,7 @@ async function forceCloseOfficeApps(
         if (verbose) console.log(`Force-killing: ${proc.name}`);
         await execFileAsync("pkill", ["-9", "-f", proc.name]);
       } catch {
-        /* ignore */
+        if (verbose) console.log(`Failed to force-kill: ${proc.name}`);
       }
     }
   }

--- a/packages/office-addin-cache/src/cli.ts
+++ b/packages/office-addin-cache/src/cli.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { Command } from "commander";
+import { logErrorMessage } from "office-addin-usage-data";
+import * as commands from "./commands";
+
+/* global process */
+
+const commander = new Command();
+
+commander.name("office-addin-cache");
+commander.version(process.env.npm_package_version || "(version not available)");
+
+commander
+  .command("clear")
+  .description("Empty the Office Add-in cache folders.")
+  .option("--force-close", "Close all running Microsoft Office applications without prompting.")
+  .option("--verbose", "Report the path of each folder being emptied.")
+  .action(commands.clear);
+
+// if the command is not known, display an error
+commander.on("command:*", function () {
+  logErrorMessage(`The command syntax is not valid.\n`);
+  process.exitCode = 1;
+  commander.help();
+});
+
+if (process.argv.length > 2) {
+  commander.parse(process.argv);
+} else {
+  commander.help();
+}

--- a/packages/office-addin-cache/src/commands.ts
+++ b/packages/office-addin-cache/src/commands.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { OptionValues } from "commander";
+import { logErrorMessage } from "office-addin-usage-data";
+import { clearCache } from "./cache";
+import { usageDataObject } from "./defaults";
+
+/* global process */
+
+export async function clear(options: OptionValues): Promise<void> {
+  try {
+    await clearCache({
+      forceClose: options.forceClose ?? false,
+      verbose: options.verbose ?? false,
+    });
+    usageDataObject.reportSuccess("clear");
+  } catch (err: any) {
+    process.exitCode = 1;
+    usageDataObject.reportException("clear", err);
+    logErrorMessage(err);
+  }
+}

--- a/packages/office-addin-cache/src/defaults.ts
+++ b/packages/office-addin-cache/src/defaults.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import {
+  connectionStringForOfficeAddinCLITools,
+  OfficeAddinUsageData,
+} from "office-addin-usage-data";
+
+// Usage data defaults
+export const usageDataObject: OfficeAddinUsageData = new OfficeAddinUsageData({
+  projectName: "office-addin-cache",
+  connectionString: connectionStringForOfficeAddinCLITools,
+  raisePrompt: false,
+});

--- a/packages/office-addin-cache/src/main.ts
+++ b/packages/office-addin-cache/src/main.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+export * from "./cache";

--- a/packages/office-addin-cache/test/test.ts
+++ b/packages/office-addin-cache/test/test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import assert from "assert";
+import { describe, it } from "mocha";
+import { getCacheTargets } from "../src/cache";
+
+/* global process */
+
+describe("getCacheTargets()", function () {
+  it("returns an array", async function () {
+    const targets = await getCacheTargets();
+    assert.ok(Array.isArray(targets));
+  });
+
+  it("returns targets for the current platform", async function () {
+    const targets = await getCacheTargets();
+    if (process.platform === "win32" || process.platform === "darwin") {
+      assert.ok(targets.length > 0, "expected at least one cache target on a supported platform");
+      for (const target of targets) {
+        assert.ok(typeof target.label === "string" && target.label.length > 0, "target label should be a non-empty string");
+        assert.ok(typeof target.dir === "string" && target.dir.length > 0, "target dir should be a non-empty string");
+      }
+    } else {
+      assert.strictEqual(targets.length, 0, "expected no targets on an unsupported platform");
+    }
+  });
+});

--- a/packages/office-addin-cache/tsconfig.json
+++ b/packages/office-addin-cache/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "lib",
+    "skipLibCheck": true,
+    "types": ["node"],
+  },
+  "include": ["src/**/*"],
+  "exclude": ["lib", "node_modules"],
+}


### PR DESCRIPTION
I called this "major" but the only files changed outside of the new folder are the readme and package-lock.json. 

---

**Change Description**:

Adds a tool that will clear the Office add-in cache on Windows and macOS. There is an internal spec. 
Many of these files are identical to the corresponding files in the other packages or differ only as needed because of the different names of the package and functions. 

1. **Do these changes impact *command syntax* of any of the packages?** (e.g., add/remove command, add/remove a command parameter, or update required parameters)
No. existing packages are not affected.


2. **Do these changes impact *documentation*?** (e.g., a tutorial on https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
Yes. When this is published, we'll need to update the article on cache-clearing to tell readers about this tool.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

Ran the 4 `clear*` scripts in the package.json. All worked as expected. 
Ran the debug launch configurations in the launch.json. All of them attached debugger and break points worked.
Ran the tests in the new tool's test folder. Both passed.
Ran eslint till there were no errors.